### PR TITLE
Analysis: synchronized section zoom, capture fixes from real-console racing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,15 @@ Change who would use the tool.
   `GET /api/tracks/{name}/geometry`, ⊂out/⊃in buttons in the Sessions lap table)
   worked end-to-end and can be recovered from this description. Note: the two columns
   already exist in live DBs (migration ran before the revert) — harmless, reusable.
+  **Better source for real circuits (investigated 2026-07-26):** gt-telemetry.com's
+  bundle ships Mapbox GL / OSM / CARTO — their outlines for real tracks come from
+  geographic map data, not crowd traces. OpenStreetMap has real circuits mapped in
+  detail (`highway=raceway`, often both edges + named corners) under ODbL (usable with
+  attribution) via the Overpass API. Needs a lat/lon → GT7-world similarity transform
+  (rotate/translate/scale) least-squares-fitted between a driven lap and the OSM
+  centerline. Fictional GT7 tracks still need edge tracing. Their own backend
+  (api.gt-telemetry.com/tracks) is auth-gated and its data unlicensed — don't scrape it;
+  ask via GitHub issue if we ever want their fictional-track layouts.
 - [ ] **Auto-numbered corners on the track map** *(tabled 2026-07-26 — prototyped, then
   reverted; the naive version was wrong)*. Detect corners from racing-line curvature and
   number them from the start line, GT7-Data-Logger style. Lesson from the failed attempt:

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,24 @@ Change who would use the tool.
 - [x] **Track auto-identification + minimap library**.
   Detect the track from position bounds; store named tracks and reuse map orientation.
 - [x] **Weather / time-of-day tracking** via `day_progression_ms` for endurance stints.
+- [ ] **Track borders via edge tracing** *(tabled 2026-07-26 — prototyped, then reverted)*.
+  GT7 doesn't broadcast track geometry, but the gt-telemetry.com approach works with
+  data we already capture: drive one slow lap hugging the outer edge and one hugging
+  the inner edge, mark those laps as edge traces, store the two [x, z] polylines on the
+  named track, and render them under the racing lines. The reverted prototype
+  (schema columns `tracks.outer_json/inner_json`, `POST /api/tracks/{name}/border`,
+  `GET /api/tracks/{name}/geometry`, ⊂out/⊃in buttons in the Sessions lap table)
+  worked end-to-end and can be recovered from this description. Note: the two columns
+  already exist in live DBs (migration ran before the revert) — harmless, reusable.
+- [ ] **Auto-numbered corners on the track map** *(tabled 2026-07-26 — prototyped, then
+  reverted; the naive version was wrong)*. Detect corners from racing-line curvature and
+  number them from the start line, GT7-Data-Logger style. Lesson from the failed attempt:
+  UNSIGNED curvature is not enough — a long hairpin splits into two corners where curvature
+  dips mid-arc, and an S-section merges into one. A correct detector needs **signed**
+  curvature (split regions when turn direction flips, merge only same-direction arcs),
+  hysteresis on the threshold, and probably apex-at-minimum-speed rather than
+  apex-at-max-curvature. Display rule that worked: dots on the full map, numbered circles
+  only when the zoomed section shows ≤ ~30 corners.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -72,6 +72,24 @@ Change who would use the tool.
 
 ---
 
+## Done beyond this list
+
+Shipped along the way, not part of the original tiers:
+
+- [x] Admin view: runtime PS IP / source / log level (persisted), live log viewer,
+  diagnostics, car-DB updater, data management
+- [x] Overlay builder: pick/order widgets, strip / stack / phone-grid layouts, scale,
+  background opacity, green-screen page mode, placeholder telemetry for designing,
+  per-device URLs (path-based for strict validators, LAN URL shown)
+- [x] Multi-lap racing-line overlay on the track map (GT7 Data Logger-style) with a
+  synced cursor dot per lap
+- [x] Synchronized click-and-drag section zoom across all charts + track map +
+  deviation chart (native ECharts dataZoomSelect), sector presets, double-click reset
+- [x] Live delta vs previous best (was: always +0.000), FIN state after the checkered flag
+- [x] Capture robustness: serialized UDP pipeline (duplicate-lap race fix), phantom-lap
+  guard, empty-session cleanup
+- [x] One-command dev environment (`./dev.sh`)
+
 ## Suggested starting point
 
 Sector timing + theoretical best (Tier 2), plus wiring the already-decoded **tire temps**

--- a/backend/app/processing/laps.py
+++ b/backend/app/processing/laps.py
@@ -14,6 +14,10 @@ log = logging.getLogger(__name__)
 TICK_SECONDS = 1 / 60
 FULL_INPUT = 250  # of 255; GT7 rarely reports exactly 255 with analog triggers
 TIRE_SPIN_THRESHOLD = 1.1
+# A "completed lap" with almost no samples is a phantom: GT7's lap counter
+# flickers through old values in menus/replays and re-reports a stale
+# last_lap_time. No real lap is shorter than this many ticks (~10 s).
+MIN_LAP_TICKS = 600
 
 # Columnar per-tick series kept for each lap. Column order matters for the
 # frontend; keep in sync with frontend/src/lib/types.ts.
@@ -86,6 +90,7 @@ class LapProcessor:
 
     on_lap: LapCallback
     on_session: SessionCallback
+    min_lap_ticks: int = MIN_LAP_TICKS
 
     _session: SessionInfo | None = None
     _current_lap: int = -1
@@ -134,7 +139,12 @@ class LapProcessor:
 
     async def _handle_lap_boundary(self, p: TelemetryPacket) -> None:
         prev = self._current_lap
-        completing = prev > 0 and p.current_lap == prev + 1 and p.last_lap_time_ms > 0
+        completing = (
+            prev > 0
+            and p.current_lap == prev + 1
+            and p.last_lap_time_ms > 0
+            and len(self._samples["t"]) >= self.min_lap_ticks
+        )
         finished_samples = self._samples
         fuel_start = self._fuel_start
 

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -88,14 +88,7 @@ class TelemetryService:
             await self._broadcast({"type": "telemetry", "data": self._live_frame(p)})
 
     async def _on_session(self, info: SessionInfo) -> None:
-        await self._summarize_previous_session()
-        # Menu visits and race restarts open sessions that never get a lap;
-        # drop the previous session if it stayed empty so they don't pile up.
-        if self.session_id is not None:
-            prev_laps = await self.repo.list_laps(self.session_id)
-            if not prev_laps:
-                await self.repo.delete_session(self.session_id)
-                log.info("dropped empty session %s", self.session_id)
+        await self._close_previous_session()
         self.session_id = await self.repo.create_session(info, self.cars.name(info.car_id))
         self.track_name = ""
         self._session_best_ms = None
@@ -103,18 +96,27 @@ class TelemetryService:
         log.info("new session %s (car %s)", self.session_id, self.cars.name(info.car_id))
         await self._broadcast({"type": "session", "data": await self.status()})
 
-    async def _summarize_previous_session(self) -> None:
+    async def _close_previous_session(self) -> None:
+        """Summarize a finished session, or drop it if it never got a lap.
+
+        One aggregate query serves both paths — loading the lap rows would
+        drag every samples_json blob out of the DB just for bookkeeping.
+        """
         if self.session_id is None:
             return
-        laps = await self.repo.list_laps(self.session_id)
-        if not laps:
+        stats = await self.repo.session_lap_stats(self.session_id)
+        if stats["count"] == 0:
+            # Menu visits and race restarts open sessions that never get a
+            # lap; drop them so they don't pile up.
+            await self.repo.delete_session(self.session_id)
+            log.info("dropped empty session %s", self.session_id)
             return
         self.notifier.session_summary(
-            car=self.cars.name(laps[0]["car_id"]),
+            car=self.cars.name(stats["car_id"]),
             track=self.track_name,
-            lap_count=len(laps),
-            best_ms=min(lap["time_ms"] for lap in laps),
-            fuel_used=sum(lap["fuel_consumed"] for lap in laps),
+            lap_count=stats["count"],
+            best_ms=stats["best_ms"],
+            fuel_used=stats["fuel_used"],
         )
 
     async def _on_lap(self, lap: CompletedLap) -> None:

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -89,6 +89,13 @@ class TelemetryService:
 
     async def _on_session(self, info: SessionInfo) -> None:
         await self._summarize_previous_session()
+        # Menu visits and race restarts open sessions that never get a lap;
+        # drop the previous session if it stayed empty so they don't pile up.
+        if self.session_id is not None:
+            prev_laps = await self.repo.list_laps(self.session_id)
+            if not prev_laps:
+                await self.repo.delete_session(self.session_id)
+                log.info("dropped empty session %s", self.session_id)
         self.session_id = await self.repo.create_session(info, self.cars.name(info.car_id))
         self.track_name = ""
         self._session_best_ms = None

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -96,6 +96,30 @@ class Repository:
                 )
             return out
 
+    async def session_lap_stats(self, session_id: int) -> dict[str, Any]:
+        """Aggregates for a session without materializing lap rows.
+
+        Loading LapRow objects pulls the (large) samples_json column along;
+        session-boundary bookkeeping only needs these numbers.
+        """
+        async with self._sf() as db:
+            count, best_ms, fuel_used, car_id = (
+                await db.execute(
+                    select(
+                        func.count(LapRow.id),
+                        func.min(LapRow.time_ms),
+                        func.coalesce(func.sum(LapRow.fuel_consumed), 0.0),
+                        func.min(LapRow.car_id),
+                    ).where(LapRow.session_id == session_id)
+                )
+            ).one()
+            return {
+                "count": count,
+                "best_ms": best_ms if best_ms is not None else -1,
+                "fuel_used": fuel_used,
+                "car_id": car_id if car_id is not None else 0,
+            }
+
     async def list_laps(self, session_id: int | None = None) -> list[dict[str, Any]]:
         async with self._sf() as db:
             q = select(LapRow).order_by(LapRow.id.desc())

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -25,6 +25,7 @@ async def client(tmp_path):
     await init_db(engine)
     repo = Repository(make_session_factory(engine))
     service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
 
     app = create_app()
     app.router.lifespan_context = None  # type: ignore[assignment]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -22,6 +22,7 @@ async def client(tmp_path):
     await init_db(engine)
     repo = Repository(make_session_factory(engine))
     service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
 
     app = create_app()
     app.router.lifespan_context = None  # type: ignore[assignment]
@@ -63,6 +64,26 @@ async def drive_laps(service: TelemetryService, laps: int = 2) -> None:
             )
         )
     )
+
+
+async def test_empty_sessions_are_dropped(client) -> None:
+    """Menu bounces open sessions that never see a lap; when a new session
+    starts, the previous empty one is deleted instead of piling up."""
+    c, service = client
+    # Session A: one real lap
+    await drive_laps(service, laps=1)
+    # Session B: car change, no laps driven
+    await service._on_packet(
+        parse_packet(build_packet(current_lap=1, flags=ON_TRACK, car_id=42))
+    )
+    # Session C: another car change — session B was empty and must vanish
+    await service._on_packet(
+        parse_packet(build_packet(current_lap=1, flags=ON_TRACK, car_id=43))
+    )
+    sessions = (await c.get("/api/sessions")).json()
+    lap_counts = [s["lap_count"] for s in sessions]
+    assert len(sessions) == 2  # A (1 lap) + C (current, still empty)
+    assert sorted(lap_counts) == [0, 1]
 
 
 async def test_health(client) -> None:

--- a/backend/tests/test_laps.py
+++ b/backend/tests/test_laps.py
@@ -29,7 +29,7 @@ class Collector:
 @pytest.fixture
 def setup() -> tuple[LapProcessor, Collector]:
     c = Collector()
-    return LapProcessor(on_lap=c.on_lap, on_session=c.on_session), c
+    return LapProcessor(on_lap=c.on_lap, on_session=c.on_session, min_lap_ticks=1), c
 
 
 async def feed_lap(proc: LapProcessor, lap_number: int, ticks: int, **kw) -> None:
@@ -133,7 +133,7 @@ async def test_no_duplicate_laps_while_save_is_slow() -> None:
         await asyncio.sleep(0.05)  # simulate the DB write
         collector.laps.append(lap)
 
-    proc = LapProcessor(on_lap=slow_on_lap, on_session=collector.on_session)
+    proc = LapProcessor(on_lap=slow_on_lap, on_session=collector.on_session, min_lap_ticks=1)
     await feed_lap(proc, 1, 30, speed_mps=50.0)
 
     # The boundary packet plus a burst of following packets, processed
@@ -147,6 +147,21 @@ async def test_no_duplicate_laps_while_save_is_slow() -> None:
     await asyncio.gather(*tasks)
     assert len(collector.laps) == 1
     assert collector.laps[0].number == 1
+
+
+async def test_phantom_lap_with_few_samples_is_discarded() -> None:
+    """In menus/replays GT7's lap counter flickers through old values with a
+    stale last_lap_time; a 'lap' with almost no samples must not be saved."""
+    c = Collector()
+    proc = LapProcessor(on_lap=c.on_lap, on_session=c.on_session)  # real threshold
+    # A genuine lap: 700 ticks, then the boundary
+    await feed_lap(proc, 1, 700, speed_mps=50.0)
+    await proc.feed(make_packet(current_lap=2, last_lap_time_ms=61_000, speed_mps=50.0))
+    assert len(c.laps) == 1
+    # Counter flicker: 2 -> 1 (reset/new session) -> 2 again with a stale time
+    await proc.feed(make_packet(current_lap=1, last_lap_time_ms=61_000))
+    await proc.feed(make_packet(current_lap=2, last_lap_time_ms=61_000))
+    assert len(c.laps) == 1  # no phantom zero-sample lap
 
 
 async def test_no_samples_recorded_after_race_finish(setup) -> None:

--- a/backend/tests/test_tier3.py
+++ b/backend/tests/test_tier3.py
@@ -59,6 +59,7 @@ async def test_track_auto_identification(tmp_path) -> None:
 
     # Store a track whose signature matches the laps drive_laps produces
     service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
     await drive_laps(service, laps=1)
     laps = await repo.list_laps()
     samples = (await repo.get_lap(laps[0]["id"]))["samples"]
@@ -68,6 +69,7 @@ async def test_track_auto_identification(tmp_path) -> None:
 
     # A fresh service on the same "track" should auto-identify it
     service2 = TelemetryService(settings, repo, CarDatabase())
+    service2.processor.min_lap_ticks = 1
     await drive_laps(service2, laps=1)
     assert service2.track_name == "Test Ring"
     sessions = await repo.list_sessions()
@@ -85,6 +87,7 @@ async def client(tmp_path):
     await init_db(engine)
     repo = Repository(make_session_factory(engine))
     service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
     app = create_app()
     app.router.lifespan_context = None  # type: ignore[assignment]
     app.state.service = service

--- a/frontend/src/components/analysis/DeviationChart.tsx
+++ b/frontend/src/components/analysis/DeviationChart.tsx
@@ -7,7 +7,15 @@ import { CHART_COLORS, EChart } from "@/components/EChart";
 import { speedValue, type Units } from "@/lib/format";
 import type { DeviationResult } from "@/lib/types";
 
-export function DeviationChart({ data, units }: { data: DeviationResult; units: Units }) {
+export function DeviationChart({
+  data,
+  units,
+  zoomRange,
+}: {
+  data: DeviationResult;
+  units: Units;
+  zoomRange?: [number, number] | null;
+}) {
   const option = useMemo<EChartsOption>(() => {
     const median = data.median.map((v) => speedValue(v, units));
     const dev = data.deviation.map((v) => speedValue(v, units));
@@ -16,9 +24,9 @@ export function DeviationChart({ data, units }: { data: DeviationResult; units: 
       grid: { left: 48, right: 12, top: 24, bottom: 22 },
       xAxis: {
         type: "value",
-        min: 0,
-        max: "dataMax",
-        axisLabel: { color: CHART_COLORS.label, fontSize: 10, formatter: (v: number) => `${v} m` },
+        min: zoomRange ? zoomRange[0] : 0,
+        max: zoomRange ? zoomRange[1] : "dataMax",
+        axisLabel: { color: CHART_COLORS.label, fontSize: 10, formatter: (v: number) => `${Math.round(v)} m` },
         axisLine: { lineStyle: { color: CHART_COLORS.axis } },
         splitLine: { show: false },
       },
@@ -67,7 +75,7 @@ export function DeviationChart({ data, units }: { data: DeviationResult; units: 
         },
       ],
     };
-  }, [data, units]);
+  }, [data, units, zoomRange]);
 
-  return <EChart option={option} className="h-44 w-full" />;
+  return <EChart option={option} className="h-44 w-full" notMerge={false} />;
 }

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -82,25 +82,38 @@ export function RaceLineMap({
     }
 
     // Comparison laps first (under the reference), as solid colored lines.
+    // Per-point itemStyle only affects symbols, never the line stroke, so
+    // zoom-dimming needs two series: a dim full-lap line plus a bright
+    // overlay covering only the zoomed section.
     for (const lap of laps) {
       if (lap.isRef) continue;
       const s = lap.entry.series;
       series.push({
         id: `line-${lap.id}`,
         type: "line",
-        data: s.dist.map((d, i) => {
-          const inZoom = zoomRange ? d >= zoomRange[0] && d <= zoomRange[1] : true;
-          return {
-            value: [s.pos_x[i], s.pos_z[i]],
-            symbolSize: inZoom ? 3 : 1,
-            itemStyle: { opacity: inZoom ? 0.9 : 0.2 },
-          };
-        }),
+        data: s.dist.map((_, i) => [s.pos_x[i], s.pos_z[i]]),
         showSymbol: false,
-        lineStyle: { color: lap.color, width: zoomRange ? 2 : 1.6, opacity: zoomRange ? 0.85 : 0.9 },
+        lineStyle: { color: lap.color, width: 1.6, opacity: zoomRange ? 0.15 : 0.9 },
         silent: true,
         z: 2,
       });
+      if (zoomRange) {
+        const inZoom: [number, number][] = [];
+        for (let i = 0; i < s.dist.length; i++) {
+          if (s.dist[i] >= zoomRange[0] && s.dist[i] <= zoomRange[1]) {
+            inZoom.push([s.pos_x[i], s.pos_z[i]]);
+          }
+        }
+        series.push({
+          id: `line-zoom-${lap.id}`,
+          type: "line",
+          data: inZoom,
+          showSymbol: false,
+          lineStyle: { color: lap.color, width: 2, opacity: 0.9 },
+          silent: true,
+          z: 2,
+        });
+      }
     }
 
     if (ref) {

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -30,16 +30,56 @@ export function RaceLineMap({
   laps,
   cursorDist,
   step,
+  zoomRange,
 }: {
   laps: MapLap[];
   cursorDist: number | null;
   step: number;
+  zoomRange?: [number, number] | null;
 }) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   const ref = laps.find((lap) => lap.isRef);
 
   const option = useMemo<EChartsOption>(() => {
     const series: SeriesOption[] = [];
+
+    let xMin: number | undefined;
+    let xMax: number | undefined;
+    let zMin: number | undefined;
+    let zMax: number | undefined;
+
+    if (zoomRange && ref) {
+      const s = ref.entry.series;
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minZ = Infinity;
+      let maxZ = -Infinity;
+      let count = 0;
+
+      for (let i = 0; i < s.dist.length; i++) {
+        const d = s.dist[i];
+        if (d >= zoomRange[0] && d <= zoomRange[1]) {
+          const x = s.pos_x[i];
+          const z = s.pos_z[i];
+          if (x != null && z != null) {
+            if (x < minX) minX = x;
+            if (x > maxX) maxX = x;
+            if (z < minZ) minZ = z;
+            if (z > maxZ) maxZ = z;
+            count++;
+          }
+        }
+      }
+
+      if (count > 0 && isFinite(minX) && isFinite(maxX) && isFinite(minZ) && isFinite(maxZ)) {
+        const padX = Math.max((maxX - minX) * 0.15, 8);
+        const padZ = Math.max((maxZ - minZ) * 0.15, 8);
+        xMin = minX - padX;
+        xMax = maxX + padX;
+        zMin = minZ - padZ;
+        zMax = maxZ + padZ;
+      }
+    }
 
     // Comparison laps first (under the reference), as solid colored lines.
     for (const lap of laps) {
@@ -48,9 +88,16 @@ export function RaceLineMap({
       series.push({
         id: `line-${lap.id}`,
         type: "line",
-        data: s.dist.map((_, i) => [s.pos_x[i], s.pos_z[i]]),
+        data: s.dist.map((d, i) => {
+          const inZoom = zoomRange ? d >= zoomRange[0] && d <= zoomRange[1] : true;
+          return {
+            value: [s.pos_x[i], s.pos_z[i]],
+            symbolSize: inZoom ? 3 : 1,
+            itemStyle: { opacity: inZoom ? 0.9 : 0.2 },
+          };
+        }),
         showSymbol: false,
-        lineStyle: { color: lap.color, width: 1.6, opacity: 0.9 },
+        lineStyle: { color: lap.color, width: zoomRange ? 2 : 1.6, opacity: zoomRange ? 0.85 : 0.9 },
         silent: true,
         z: 2,
       });
@@ -58,16 +105,30 @@ export function RaceLineMap({
 
     if (ref) {
       const s = ref.entry.series;
-      const points = s.dist.map((_, i) => ({
-        value: [s.pos_x[i], s.pos_z[i]],
-        itemStyle: { color: ZONE_COLORS[zoneOf(s.throttle[i], s.brake[i])] },
-      }));
+      const points = s.dist.map((d, i) => {
+        const inZoom = zoomRange ? d >= zoomRange[0] && d <= zoomRange[1] : true;
+        return {
+          value: [s.pos_x[i], s.pos_z[i]],
+          symbolSize: inZoom ? 4 : 2,
+          itemStyle: {
+            color: ZONE_COLORS[zoneOf(s.throttle[i], s.brake[i])],
+            opacity: inZoom ? 1 : 0.15,
+          },
+        };
+      });
       const pv = ref.entry.peaks_valleys;
+      const peaks = pv.peaks.filter(
+        (p) => !zoomRange || (p.dist >= zoomRange[0] && p.dist <= zoomRange[1]),
+      );
+      const valleys = pv.valleys.filter(
+        (p) => !zoomRange || (p.dist >= zoomRange[0] && p.dist <= zoomRange[1]),
+      );
+
       series.push(
         { type: "scatter", data: points, symbolSize: 3.5, silent: true, z: 3 },
         {
           type: "scatter",
-          data: pv.peaks.map((p) => [p.x, p.z]),
+          data: peaks.map((p) => [p.x, p.z]),
           symbol: "triangle",
           symbolSize: 9,
           itemStyle: { color: "#facc15" },
@@ -76,7 +137,7 @@ export function RaceLineMap({
         },
         {
           type: "scatter",
-          data: pv.valleys.map((p) => [p.x, p.z]),
+          data: valleys.map((p) => [p.x, p.z]),
           symbol: "triangle",
           symbolRotate: 180,
           symbolSize: 9,
@@ -105,13 +166,24 @@ export function RaceLineMap({
     return {
       animation: false,
       grid: { left: 8, right: 8, top: 8, bottom: 8 },
-      xAxis: { type: "value", show: false, scale: true },
-      yAxis: { type: "value", show: false, scale: true, inverse: true },
+      xAxis: {
+        type: "value",
+        show: false,
+        scale: true,
+        ...(xMin != null ? { min: xMin, max: xMax } : {}),
+      },
+      yAxis: {
+        type: "value",
+        show: false,
+        scale: true,
+        inverse: true,
+        ...(zMin != null ? { min: zMin, max: zMax } : {}),
+      },
       tooltip: { show: false },
       series,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [laps]);
+  }, [laps, zoomRange]);
 
   // Cursor updates merge into the existing chart by series id — no rebuild.
   useEffect(() => {

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -3,7 +3,7 @@
 // distance in every panel. Far cheaper than N connected chart instances.
 
 import type { EChartsOption, SeriesOption } from "echarts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
 import { speedValue, type Units } from "@/lib/format";
 import type { CompareResult } from "@/lib/types";
@@ -48,14 +48,9 @@ export function StackedCharts({
   onZoomChange?: (range: [number, number] | null) => void;
 }) {
   const chartRef = useRef<echarts.ECharts | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  const [selection, setSelection] = useState<{
-    startX: number;
-    currentX: number;
-    startDist: number;
-    currentDist: number;
-  } | null>(null);
+  // True while WE dispatch a zoom action, so the resulting dataZoom event
+  // isn't echoed back through onZoomChange (which would loop).
+  const applyingZoom = useRef(false);
 
   const maxDist = useMemo(() => {
     let m = 0;
@@ -67,64 +62,42 @@ export function StackedCharts({
     }
     return m;
   }, [data]);
+  // The chart's event handlers are bound once (onInit) — read maxDist through
+  // a ref so they never see a stale value after the lap selection changes.
+  const maxDistRef = useRef(maxDist);
+  maxDistRef.current = maxDist;
 
-  // Handle click & drag crosshair selection box directly on the chart canvas
-  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    if (!chartRef.current || e.button !== 0) return; // Left mouse button only
-    const rect = containerRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const x = e.clientX - rect.left;
-    const dist = chartRef.current.convertFromPixel({ xAxisIndex: 0 }, x);
-    if (dist == null || isNaN(dist) || dist < 0) return;
-
-    setSelection({
-      startX: x,
-      currentX: x,
-      startDist: dist,
-      currentDist: dist,
+  // Drag-select zoom uses ECharts' native toolbox mechanism ("dataZoomSelect")
+  // instead of hand-rolled pixel math: activating the global cursor makes a
+  // plain left-drag draw the selection box and emit a dataZoom event.
+  const activateDragZoom = useCallback(() => {
+    chartRef.current?.dispatchAction({
+      type: "takeGlobalCursor",
+      key: "dataZoomSelect",
+      dataZoomSelectActive: true,
     });
   }, []);
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!chartRef.current || !selection || !containerRef.current) return;
-      const rect = containerRef.current.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const dist = chartRef.current.convertFromPixel({ xAxisIndex: 0 }, x);
-      if (dist != null && !isNaN(dist)) {
-        setSelection((prev) =>
-          prev
-            ? {
-                ...prev,
-                currentX: Math.max(0, Math.min(rect.width, x)),
-                currentDist: Math.max(0, Math.min(maxDist, dist)),
-              }
-            : null,
-        );
-      }
-    },
-    [selection, maxDist],
-  );
-
-  const handleMouseUp = useCallback(() => {
-    if (selection) {
-      const minDist = Math.min(selection.startDist, selection.currentDist);
-      const maxDistVal = Math.max(selection.startDist, selection.currentDist);
-
-      if (maxDistVal - minDist >= 10) {
-        onZoomChange?.([minDist, maxDistVal]);
-      }
-      setSelection(null);
-    }
-  }, [selection, onZoomChange]);
-
+  // Apply zoomRange (from drag, sector buttons, or reset) to all axes.
   useEffect(() => {
-    if (selection) {
-      const onGlobalMouseUp = () => handleMouseUp();
-      window.addEventListener("mouseup", onGlobalMouseUp);
-      return () => window.removeEventListener("mouseup", onGlobalMouseUp);
+    const chart = chartRef.current;
+    if (!chart) return;
+    applyingZoom.current = true;
+    try {
+      if (zoomRange) {
+        chart.dispatchAction({
+          type: "dataZoom",
+          startValue: zoomRange[0],
+          endValue: zoomRange[1],
+        });
+      } else {
+        chart.dispatchAction({ type: "dataZoom", start: 0, end: 100 });
+      }
+    } finally {
+      applyingZoom.current = false;
     }
-  }, [selection, handleMouseUp]);
+    activateDragZoom(); // option/action updates can drop the select cursor
+  }, [zoomRange, activateDragZoom, data]);
 
   const option = useMemo<EChartsOption>(() => {
     const lapIds = Object.keys(data.laps);
@@ -242,9 +215,8 @@ export function StackedCharts({
         moveHandleStyle: { color: "#38bdf8" },
         textStyle: { color: CHART_COLORS.label, fontSize: 10 },
         labelFormatter: (value: number) => `${Math.round(value)}m`,
-        ...(zoomRange
-          ? { startValue: zoomRange[0], endValue: zoomRange[1] }
-          : { start: 0, end: 100 }),
+        // Window state is applied via dispatchAction (single source of truth);
+        // baking start/end into the option here fights the merge updates.
       },
     ];
 
@@ -257,6 +229,24 @@ export function StackedCharts({
       yAxis: yAxes as EChartsOption["yAxis"],
       series,
       dataZoom,
+      // Declares the native drag-select zoom feature; its cursor is activated
+      // by dispatchAction(takeGlobalCursor) so no icon click is needed. The
+      // toolbox itself is parked off-screen.
+      toolbox: {
+        top: -100,
+        feature: {
+          dataZoom: {
+            xAxisIndex: allXAxisIndices,
+            yAxisIndex: false,
+            filterMode: "none",
+            brushStyle: {
+              color: "rgba(56, 189, 248, 0.15)",
+              borderColor: "#38bdf8",
+              borderWidth: 1,
+            },
+          },
+        },
+      },
       legend: {
         top: 0,
         right: 8,
@@ -280,7 +270,7 @@ export function StackedCharts({
         valueFormatter: (v) => (typeof v === "number" ? v.toFixed(2) : `${v}`),
       },
     };
-  }, [data, lapLabels, units, zoomRange]);
+  }, [data, lapLabels, units]);
 
   return (
     <div className="flex flex-col">
@@ -300,7 +290,7 @@ export function StackedCharts({
             <span className="text-ink-dim">Full lap (0m – {maxDist.toFixed(0)}m)</span>
           )}
           <span className="hidden text-[11px] text-ink-dim/70 sm:inline">
-            • Click & drag across chart to zoom into a section
+            • Drag across a chart to zoom · double-click to reset
           </span>
         </div>
         <div className="flex items-center gap-1.5">
@@ -334,27 +324,10 @@ export function StackedCharts({
         </div>
       </div>
       <div
-        ref={containerRef}
-        className="relative w-full cursor-crosshair select-none"
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
+        className="relative w-full select-none"
+        onDoubleClick={() => onZoomChange?.(null)}
+        title="Drag across a chart to zoom into that section; double-click to reset"
       >
-        {selection && Math.abs(selection.currentX - selection.startX) > 4 && (
-          <div
-            className="pointer-events-none absolute top-4 bottom-7 z-30 border-x-2 border-dashed border-[#38bdf8] bg-[#38bdf8]/20"
-            style={{
-              left: `${Math.min(selection.startX, selection.currentX)}px`,
-              width: `${Math.abs(selection.currentX - selection.startX)}px`,
-            }}
-          >
-            <div className="absolute -top-7 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-edge bg-panel-2 px-2 py-0.5 font-tabular text-[11px] font-semibold text-accent shadow-lg">
-              🔍 {Math.min(selection.startDist, selection.currentDist).toFixed(0)}m –{" "}
-              {Math.max(selection.startDist, selection.currentDist).toFixed(0)}m (
-              {Math.abs(selection.currentDist - selection.startDist).toFixed(0)}m section)
-            </div>
-          </div>
-        )}
         <EChart
           option={option}
           className="w-full"
@@ -368,7 +341,9 @@ export function StackedCharts({
               const x = info?.find((a) => a.axisDim === "x");
               onCursorDist?.(x ? x.value : null);
             });
+            // Fired by the native drag-select box and by the bottom slider.
             chart.on("dataZoom", (e: any) => {
+              if (applyingZoom.current) return; // our own dispatch echoing back
               let startVal: number | undefined;
               let endVal: number | undefined;
 
@@ -388,13 +363,14 @@ export function StackedCharts({
                 if (startPct <= 1 && endPct >= 99) {
                   onZoomChange?.(null);
                 } else {
-                  const minD = (startPct / 100) * maxDist;
-                  const maxD = (endPct / 100) * maxDist;
+                  const minD = (startPct / 100) * maxDistRef.current;
+                  const maxD = (endPct / 100) * maxDistRef.current;
                   onZoomChange?.([minD, maxD]);
                 }
               }
             });
             chart.getZr().on("globalout", () => onCursorDist?.(null));
+            activateDragZoom();
           }}
         />
       </div>

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -2,6 +2,7 @@
 // linked axis pointer: hovering any panel shows the cursor at the same
 // distance in every panel. Far cheaper than N connected chart instances.
 
+import type * as echarts from "echarts";
 import type { EChartsOption, SeriesOption } from "echarts";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -5,7 +5,7 @@
 import type { EChartsOption, SeriesOption } from "echarts";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
-import { speedValue, type Units } from "@/lib/format";
+import { speedUnit, speedValue, type Units } from "@/lib/format";
 import type { CompareResult } from "@/lib/types";
 
 interface PanelDef {
@@ -110,6 +110,35 @@ export function StackedCharts({
     const yAxes: object[] = [];
     const series: SeriesOption[] = [];
     const titles: object[] = [];
+    // Parallel to `series`: which panel each series belongs to, so the
+    // tooltip can label values instead of dumping bare numbers.
+    const seriesMeta: { panelKey: string; panelTitle: string }[] = [];
+
+    const formatValue = (key: string, v: number): string => {
+      switch (key) {
+        case "delta":
+          return `${v >= 0 ? "+" : ""}${v.toFixed(3)} s`;
+        case "speed":
+          return `${Math.round(v)} ${speedUnit(units)}`;
+        case "throttle":
+        case "brake":
+          return `${Math.round(v)}%`;
+        case "coast":
+          return v >= 0.5 ? "coasting" : "—";
+        case "gear":
+          return `${Math.round(v)}`;
+        case "rpm":
+          return `${Math.round(v).toLocaleString()} rpm`;
+        case "boost":
+          return `${v.toFixed(2)} bar`;
+        case "tire_slip":
+          return `${v.toFixed(2)}×`;
+        case "yaw_rate":
+          return `${v.toFixed(2)} rad/s`;
+        default:
+          return v.toFixed(2);
+      }
+    };
 
     let cursor = 2;
     PANELS.forEach((panel, gi) => {
@@ -158,6 +187,7 @@ export function StackedCharts({
           ? entry.delta!.delta_ms.map((v) => v / 1000)
           : entry.series[panel.key] ?? [];
         const values = panel.transform ? raw.map((v) => panel.transform!(v, units)) : raw;
+        seriesMeta.push({ panelKey: panel.key, panelTitle: panel.title });
         series.push({
           type: "line",
           name: lapLabels[lapId] ?? `Lap ${lapId}`,
@@ -267,7 +297,47 @@ export function StackedCharts({
         backgroundColor: "#1b1f26",
         borderColor: "#262b33",
         textStyle: { color: "#e6e9ee", fontSize: 11 },
-        valueFormatter: (v) => (typeof v === "number" ? v.toFixed(2) : `${v}`),
+        // One distance header, then one labeled row per metric — the default
+        // repeats the distance for every panel and shows unlabeled numbers.
+        formatter: (params: unknown) => {
+          const list = (Array.isArray(params) ? params : [params]) as {
+            seriesIndex: number;
+            axisValue: number | string;
+            value: [number, number] | number;
+            marker: string;
+          }[];
+          if (list.length === 0) return "";
+          const dist = Number(list[0].axisValue);
+          const multiLap = lapIds.length > 1;
+
+          // Group values by panel, preserving PANELS order.
+          const byPanel = new Map<string, { title: string; cells: string[] }>();
+          for (const p of list) {
+            const meta = seriesMeta[p.seriesIndex];
+            if (!meta) continue;
+            const v = Array.isArray(p.value) ? p.value[1] : p.value;
+            if (v == null || Number.isNaN(v)) continue;
+            const cell = `${multiLap ? p.marker : ""}<span style="font-variant-numeric:tabular-nums">${formatValue(meta.panelKey, v)}</span>`;
+            const group = byPanel.get(meta.panelKey) ?? { title: meta.panelTitle, cells: [] };
+            group.cells.push(cell);
+            byPanel.set(meta.panelKey, group);
+          }
+
+          const rows = PANELS.filter((p) => byPanel.has(p.key))
+            .map((p) => {
+              const g = byPanel.get(p.key)!;
+              const label = g.title.replace(/ \(.*\)| %/, "");
+              return `<div style="display:flex;justify-content:space-between;gap:16px;line-height:1.7">
+                <span style="color:#8b93a1">${label}</span>
+                <span style="display:flex;gap:10px">${g.cells.join("")}</span>
+              </div>`;
+            })
+            .join("");
+          return `<div style="min-width:150px">
+            <div style="font-weight:600;margin-bottom:4px">${Math.round(dist).toLocaleString()} m</div>
+            ${rows}
+          </div>`;
+        },
       },
     };
   }, [data, lapLabels, units]);

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -37,17 +37,32 @@ export function StackedCharts({
   lapLabels,
   units,
   onCursorDist,
+  zoomRange,
+  onZoomChange,
 }: {
   data: CompareResult;
   lapLabels: Record<string, string>;
   units: Units;
   onCursorDist?: (dist: number | null) => void;
+  zoomRange?: [number, number] | null;
+  onZoomChange?: (range: [number, number] | null) => void;
 }) {
+  const maxDist = useMemo(() => {
+    let m = 0;
+    for (const lap of Object.values(data.laps)) {
+      const dists = lap.series.dist;
+      if (dists && dists.length > 0) {
+        m = Math.max(m, dists[dists.length - 1]);
+      }
+    }
+    return m;
+  }, [data]);
+
   const option = useMemo<EChartsOption>(() => {
     const lapIds = Object.keys(data.laps);
     const heights = PANELS.map((p) => p.height);
     const totalWeight = heights.reduce((a, b) => a + b, 0);
-    const usable = 100 - 6; // percent, minus bottom margin
+    const usable = 100 - 8; // percent, minus bottom margin for slider
 
     const grids: NonNullable<EChartsOption["grid"]> = [];
     const xAxes: object[] = [];
@@ -127,6 +142,41 @@ export function StackedCharts({
       });
     });
 
+    const allXAxisIndices = PANELS.map((_, i) => i);
+
+    const dataZoom: EChartsOption["dataZoom"] = [
+      {
+        type: "inside",
+        xAxisIndex: allXAxisIndices,
+        filterMode: "none",
+      },
+      {
+        type: "slider",
+        xAxisIndex: allXAxisIndices,
+        filterMode: "none",
+        bottom: 2,
+        height: 18,
+        borderColor: CHART_COLORS.axis,
+        backgroundColor: "#16191e",
+        dataBackground: {
+          lineStyle: { color: CHART_COLORS.axis },
+          areaStyle: { color: CHART_COLORS.split },
+        },
+        selectedDataBackground: {
+          lineStyle: { color: "#38bdf8" },
+          areaStyle: { color: "#38bdf8", opacity: 0.2 },
+        },
+        fillerColor: "rgba(56, 189, 248, 0.15)",
+        handleStyle: { color: "#38bdf8", borderColor: "#38bdf8" },
+        moveHandleStyle: { color: "#38bdf8" },
+        textStyle: { color: CHART_COLORS.label, fontSize: 10 },
+        labelFormatter: (value: number) => `${Math.round(value)}m`,
+        ...(zoomRange
+          ? { startValue: zoomRange[0], endValue: zoomRange[1] }
+          : { start: 0, end: 100 }),
+      },
+    ];
+
     return {
       animation: false,
       backgroundColor: "transparent",
@@ -135,6 +185,7 @@ export function StackedCharts({
       xAxis: xAxes as EChartsOption["xAxis"],
       yAxis: yAxes as EChartsOption["yAxis"],
       series,
+      dataZoom,
       legend: {
         top: 0,
         right: 8,
@@ -156,23 +207,97 @@ export function StackedCharts({
         valueFormatter: (v) => (typeof v === "number" ? v.toFixed(2) : `${v}`),
       },
     };
-  }, [data, lapLabels, units]);
+  }, [data, lapLabels, units, zoomRange]);
 
-  // Height: enough vertical room for all panels
   return (
-    <EChart
-      option={option}
-      className="w-full"
-      onInit={(chart) => {
-        chart.getDom().style.height = `${PANELS.length * 110 + TOP_PAD + PANEL_GAP}px`;
-        chart.resize();
-        chart.on("updateAxisPointer", (e) => {
-          const info = (e as { axesInfo?: { axisDim: string; value: number }[] }).axesInfo;
-          const x = info?.find((a) => a.axisDim === "x");
-          onCursorDist?.(x ? x.value : null);
-        });
-        chart.getZr().on("globalout", () => onCursorDist?.(null));
-      }}
-    />
+    <div className="flex flex-col">
+      <div className="mb-2 flex items-center justify-between border-b border-edge/60 pb-2 text-xs">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-ink-dim">Zoom Level:</span>
+          {zoomRange ? (
+            <span className="inline-flex items-center gap-1.5 rounded-md bg-accent/15 px-2 py-0.5 font-tabular text-accent">
+              <span>
+                🔍 {zoomRange[0].toFixed(0)}m – {zoomRange[1].toFixed(0)}m
+              </span>
+              <span className="text-[10px] opacity-75">
+                ({(zoomRange[1] - zoomRange[0]).toFixed(0)}m section)
+              </span>
+            </span>
+          ) : (
+            <span className="text-ink-dim">Full lap (0m – {maxDist.toFixed(0)}m)</span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {zoomRange && (
+            <button
+              onClick={() => onZoomChange?.(null)}
+              className="rounded border border-edge bg-panel-2 px-2 py-0.5 text-xs font-medium text-ink transition-colors hover:border-accent hover:text-accent"
+              title="Reset zoom to full lap"
+            >
+              Reset Zoom
+            </button>
+          )}
+          <button
+            onClick={() => onZoomChange?.([0, maxDist * 0.33])}
+            className="rounded border border-edge px-2 py-0.5 text-[11px] text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+          >
+            S1 (0-33%)
+          </button>
+          <button
+            onClick={() => onZoomChange?.([maxDist * 0.33, maxDist * 0.66])}
+            className="rounded border border-edge px-2 py-0.5 text-[11px] text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+          >
+            S2 (33-66%)
+          </button>
+          <button
+            onClick={() => onZoomChange?.([maxDist * 0.66, maxDist])}
+            className="rounded border border-edge px-2 py-0.5 text-[11px] text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+          >
+            S3 (66-100%)
+          </button>
+        </div>
+      </div>
+      <EChart
+        option={option}
+        className="w-full"
+        notMerge={false}
+        onInit={(chart) => {
+          chart.getDom().style.height = `${PANELS.length * 110 + TOP_PAD + PANEL_GAP}px`;
+          chart.resize();
+          chart.on("updateAxisPointer", (e) => {
+            const info = (e as { axesInfo?: { axisDim: string; value: number }[] }).axesInfo;
+            const x = info?.find((a) => a.axisDim === "x");
+            onCursorDist?.(x ? x.value : null);
+          });
+          chart.on("dataZoom", (e: any) => {
+            let startVal: number | undefined;
+            let endVal: number | undefined;
+
+            if (e.batch && e.batch[0]) {
+              startVal = e.batch[0].startValue;
+              endVal = e.batch[0].endValue;
+            } else if (e.startValue != null && e.endValue != null) {
+              startVal = e.startValue;
+              endVal = e.endValue;
+            }
+
+            if (startVal != null && endVal != null) {
+              onZoomChange?.([startVal, endVal]);
+            } else {
+              const startPct = e.batch?.[0]?.start ?? e.start ?? 0;
+              const endPct = e.batch?.[0]?.end ?? e.end ?? 100;
+              if (startPct <= 1 && endPct >= 99) {
+                onZoomChange?.(null);
+              } else {
+                const minD = (startPct / 100) * maxDist;
+                const maxD = (endPct / 100) * maxDist;
+                onZoomChange?.([minD, maxD]);
+              }
+            }
+          });
+          chart.getZr().on("globalout", () => onCursorDist?.(null));
+        }}
+      />
+    </div>
   );
 }

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -3,7 +3,7 @@
 // distance in every panel. Far cheaper than N connected chart instances.
 
 import type { EChartsOption, SeriesOption } from "echarts";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
 import { speedValue, type Units } from "@/lib/format";
 import type { CompareResult } from "@/lib/types";
@@ -57,6 +57,20 @@ export function StackedCharts({
     }
     return m;
   }, [data]);
+
+  const [isBoxZoom, setIsBoxZoom] = useState(false);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+
+  const toggleBoxZoom = useCallback(() => {
+    if (!chartRef.current) return;
+    const next = !isBoxZoom;
+    setIsBoxZoom(next);
+    chartRef.current.dispatchAction({
+      type: "takeGlobalCursor",
+      key: "dataZoomSelect",
+      dataZoomSelectActive: next,
+    });
+  }, [isBoxZoom]);
 
   const option = useMemo<EChartsOption>(() => {
     const lapIds = Object.keys(data.laps);
@@ -149,6 +163,9 @@ export function StackedCharts({
         type: "inside",
         xAxisIndex: allXAxisIndices,
         filterMode: "none",
+        zoomOnMouseWheel: "shift", // Prevent accidental page-scroll zooming; require Shift+Scroll
+        moveOnMouseMove: true,
+        moveOnMouseWheel: false,
       },
       {
         type: "slider",
@@ -195,9 +212,11 @@ export function StackedCharts({
         itemHeight: 3,
       },
       axisPointer: {
+        type: "cross",
         link: [{ xAxisIndex: "all" }],
-        lineStyle: { color: CHART_COLORS.label },
-        label: { backgroundColor: "#2a3140", fontSize: 10 },
+        lineStyle: { color: "#38bdf8", width: 1, type: "dashed" },
+        crossStyle: { color: "#38bdf8", width: 1, type: "dashed" },
+        label: { backgroundColor: "#1e232b", color: "#38bdf8", fontSize: 10, padding: [2, 5] },
       },
       tooltip: {
         trigger: "axis",
@@ -211,7 +230,7 @@ export function StackedCharts({
 
   return (
     <div className="flex flex-col">
-      <div className="mb-2 flex items-center justify-between border-b border-edge/60 pb-2 text-xs">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2 border-b border-edge/60 pb-2 text-xs">
         <div className="flex items-center gap-2">
           <span className="font-semibold text-ink-dim">Zoom Level:</span>
           {zoomRange ? (
@@ -226,11 +245,29 @@ export function StackedCharts({
           ) : (
             <span className="text-ink-dim">Full lap (0m – {maxDist.toFixed(0)}m)</span>
           )}
+          <span className="hidden text-[11px] text-ink-dim/70 sm:inline">
+            • Hold <kbd className="rounded border border-edge bg-panel-2 px-1 text-[10px]">Shift</kbd> + Scroll to scale
+          </span>
         </div>
         <div className="flex items-center gap-1.5">
+          <button
+            onClick={toggleBoxZoom}
+            className={`rounded border px-2 py-0.5 text-xs transition-colors ${
+              isBoxZoom
+                ? "border-accent bg-accent/20 font-semibold text-accent"
+                : "border-edge text-ink-dim hover:border-edge-bright hover:text-ink"
+            }`}
+            title="Click to activate crosshair drag section zoom tool"
+          >
+            🎯 {isBoxZoom ? "Cancel Box Select" : "Drag Section to Zoom"}
+          </button>
+
           {zoomRange && (
             <button
-              onClick={() => onZoomChange?.(null)}
+              onClick={() => {
+                onZoomChange?.(null);
+                if (isBoxZoom) toggleBoxZoom();
+              }}
               className="rounded border border-edge bg-panel-2 px-2 py-0.5 text-xs font-medium text-ink transition-colors hover:border-accent hover:text-accent"
               title="Reset zoom to full lap"
             >
@@ -262,6 +299,7 @@ export function StackedCharts({
         className="w-full"
         notMerge={false}
         onInit={(chart) => {
+          chartRef.current = chart;
           chart.getDom().style.height = `${PANELS.length * 110 + TOP_PAD + PANEL_GAP}px`;
           chart.resize();
           chart.on("updateAxisPointer", (e) => {

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -3,7 +3,7 @@
 // distance in every panel. Far cheaper than N connected chart instances.
 
 import type { EChartsOption, SeriesOption } from "echarts";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
 import { speedValue, type Units } from "@/lib/format";
 import type { CompareResult } from "@/lib/types";
@@ -47,6 +47,16 @@ export function StackedCharts({
   zoomRange?: [number, number] | null;
   onZoomChange?: (range: [number, number] | null) => void;
 }) {
+  const chartRef = useRef<echarts.ECharts | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const [selection, setSelection] = useState<{
+    startX: number;
+    currentX: number;
+    startDist: number;
+    currentDist: number;
+  } | null>(null);
+
   const maxDist = useMemo(() => {
     let m = 0;
     for (const lap of Object.values(data.laps)) {
@@ -58,19 +68,63 @@ export function StackedCharts({
     return m;
   }, [data]);
 
-  const [isBoxZoom, setIsBoxZoom] = useState(false);
-  const chartRef = useRef<echarts.ECharts | null>(null);
+  // Handle click & drag crosshair selection box directly on the chart canvas
+  const handleMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!chartRef.current || e.button !== 0) return; // Left mouse button only
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = e.clientX - rect.left;
+    const dist = chartRef.current.convertFromPixel({ xAxisIndex: 0 }, x);
+    if (dist == null || isNaN(dist) || dist < 0) return;
 
-  const toggleBoxZoom = useCallback(() => {
-    if (!chartRef.current) return;
-    const next = !isBoxZoom;
-    setIsBoxZoom(next);
-    chartRef.current.dispatchAction({
-      type: "takeGlobalCursor",
-      key: "dataZoomSelect",
-      dataZoomSelectActive: next,
+    setSelection({
+      startX: x,
+      currentX: x,
+      startDist: dist,
+      currentDist: dist,
     });
-  }, [isBoxZoom]);
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!chartRef.current || !selection || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const dist = chartRef.current.convertFromPixel({ xAxisIndex: 0 }, x);
+      if (dist != null && !isNaN(dist)) {
+        setSelection((prev) =>
+          prev
+            ? {
+                ...prev,
+                currentX: Math.max(0, Math.min(rect.width, x)),
+                currentDist: Math.max(0, Math.min(maxDist, dist)),
+              }
+            : null,
+        );
+      }
+    },
+    [selection, maxDist],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (selection) {
+      const minDist = Math.min(selection.startDist, selection.currentDist);
+      const maxDistVal = Math.max(selection.startDist, selection.currentDist);
+
+      if (maxDistVal - minDist >= 10) {
+        onZoomChange?.([minDist, maxDistVal]);
+      }
+      setSelection(null);
+    }
+  }, [selection, onZoomChange]);
+
+  useEffect(() => {
+    if (selection) {
+      const onGlobalMouseUp = () => handleMouseUp();
+      window.addEventListener("mouseup", onGlobalMouseUp);
+      return () => window.removeEventListener("mouseup", onGlobalMouseUp);
+    }
+  }, [selection, handleMouseUp]);
 
   const option = useMemo<EChartsOption>(() => {
     const lapIds = Object.keys(data.laps);
@@ -163,8 +217,8 @@ export function StackedCharts({
         type: "inside",
         xAxisIndex: allXAxisIndices,
         filterMode: "none",
-        zoomOnMouseWheel: "shift", // Prevent accidental page-scroll zooming; require Shift+Scroll
-        moveOnMouseMove: true,
+        zoomOnMouseWheel: false, // Disable scroll wheel zoom so web page scrolling is natural
+        moveOnMouseMove: false,
         moveOnMouseWheel: false,
       },
       {
@@ -246,28 +300,13 @@ export function StackedCharts({
             <span className="text-ink-dim">Full lap (0m – {maxDist.toFixed(0)}m)</span>
           )}
           <span className="hidden text-[11px] text-ink-dim/70 sm:inline">
-            • Hold <kbd className="rounded border border-edge bg-panel-2 px-1 text-[10px]">Shift</kbd> + Scroll to scale
+            • Click & drag across chart to zoom into a section
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <button
-            onClick={toggleBoxZoom}
-            className={`rounded border px-2 py-0.5 text-xs transition-colors ${
-              isBoxZoom
-                ? "border-accent bg-accent/20 font-semibold text-accent"
-                : "border-edge text-ink-dim hover:border-edge-bright hover:text-ink"
-            }`}
-            title="Click to activate crosshair drag section zoom tool"
-          >
-            🎯 {isBoxZoom ? "Cancel Box Select" : "Drag Section to Zoom"}
-          </button>
-
           {zoomRange && (
             <button
-              onClick={() => {
-                onZoomChange?.(null);
-                if (isBoxZoom) toggleBoxZoom();
-              }}
+              onClick={() => onZoomChange?.(null)}
               className="rounded border border-edge bg-panel-2 px-2 py-0.5 text-xs font-medium text-ink transition-colors hover:border-accent hover:text-accent"
               title="Reset zoom to full lap"
             >
@@ -294,48 +333,71 @@ export function StackedCharts({
           </button>
         </div>
       </div>
-      <EChart
-        option={option}
-        className="w-full"
-        notMerge={false}
-        onInit={(chart) => {
-          chartRef.current = chart;
-          chart.getDom().style.height = `${PANELS.length * 110 + TOP_PAD + PANEL_GAP}px`;
-          chart.resize();
-          chart.on("updateAxisPointer", (e) => {
-            const info = (e as { axesInfo?: { axisDim: string; value: number }[] }).axesInfo;
-            const x = info?.find((a) => a.axisDim === "x");
-            onCursorDist?.(x ? x.value : null);
-          });
-          chart.on("dataZoom", (e: any) => {
-            let startVal: number | undefined;
-            let endVal: number | undefined;
+      <div
+        ref={containerRef}
+        className="relative w-full cursor-crosshair select-none"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+      >
+        {selection && Math.abs(selection.currentX - selection.startX) > 4 && (
+          <div
+            className="pointer-events-none absolute top-4 bottom-7 z-30 border-x-2 border-dashed border-[#38bdf8] bg-[#38bdf8]/20"
+            style={{
+              left: `${Math.min(selection.startX, selection.currentX)}px`,
+              width: `${Math.abs(selection.currentX - selection.startX)}px`,
+            }}
+          >
+            <div className="absolute -top-7 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-edge bg-panel-2 px-2 py-0.5 font-tabular text-[11px] font-semibold text-accent shadow-lg">
+              🔍 {Math.min(selection.startDist, selection.currentDist).toFixed(0)}m –{" "}
+              {Math.max(selection.startDist, selection.currentDist).toFixed(0)}m (
+              {Math.abs(selection.currentDist - selection.startDist).toFixed(0)}m section)
+            </div>
+          </div>
+        )}
+        <EChart
+          option={option}
+          className="w-full"
+          notMerge={false}
+          onInit={(chart) => {
+            chartRef.current = chart;
+            chart.getDom().style.height = `${PANELS.length * 110 + TOP_PAD + PANEL_GAP}px`;
+            chart.resize();
+            chart.on("updateAxisPointer", (e) => {
+              const info = (e as { axesInfo?: { axisDim: string; value: number }[] }).axesInfo;
+              const x = info?.find((a) => a.axisDim === "x");
+              onCursorDist?.(x ? x.value : null);
+            });
+            chart.on("dataZoom", (e: any) => {
+              let startVal: number | undefined;
+              let endVal: number | undefined;
 
-            if (e.batch && e.batch[0]) {
-              startVal = e.batch[0].startValue;
-              endVal = e.batch[0].endValue;
-            } else if (e.startValue != null && e.endValue != null) {
-              startVal = e.startValue;
-              endVal = e.endValue;
-            }
-
-            if (startVal != null && endVal != null) {
-              onZoomChange?.([startVal, endVal]);
-            } else {
-              const startPct = e.batch?.[0]?.start ?? e.start ?? 0;
-              const endPct = e.batch?.[0]?.end ?? e.end ?? 100;
-              if (startPct <= 1 && endPct >= 99) {
-                onZoomChange?.(null);
-              } else {
-                const minD = (startPct / 100) * maxDist;
-                const maxD = (endPct / 100) * maxDist;
-                onZoomChange?.([minD, maxD]);
+              if (e.batch && e.batch[0]) {
+                startVal = e.batch[0].startValue;
+                endVal = e.batch[0].endValue;
+              } else if (e.startValue != null && e.endValue != null) {
+                startVal = e.startValue;
+                endVal = e.endValue;
               }
-            }
-          });
-          chart.getZr().on("globalout", () => onCursorDist?.(null));
-        }}
-      />
+
+              if (startVal != null && endVal != null) {
+                onZoomChange?.([startVal, endVal]);
+              } else {
+                const startPct = e.batch?.[0]?.start ?? e.start ?? 0;
+                const endPct = e.batch?.[0]?.end ?? e.end ?? 100;
+                if (startPct <= 1 && endPct >= 99) {
+                  onZoomChange?.(null);
+                } else {
+                  const minD = (startPct / 100) * maxDist;
+                  const maxD = (endPct / 100) * maxDist;
+                  onZoomChange?.([minD, maxD]);
+                }
+              }
+            });
+            chart.getZr().on("globalout", () => onCursorDist?.(null));
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -78,6 +78,14 @@ export function AnalysisView() {
     api.deviation(sessionId).then(setDeviation).catch(() => setDeviation(null));
   }, [sessionId, lapEpoch]);
 
+  // Synchronized zoom state across all charts (minDist, maxDist in meters)
+  const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
+
+  // Reset zoom window when session or lap selection changes
+  useEffect(() => {
+    setZoomRange(null);
+  }, [sessionId, selected, refLap]);
+
   // Cursor sync (rAF-throttled to keep hover smooth)
   const [cursorDist, setCursorDist] = useState<number | null>(null);
   const pendingCursor = useRef<number | null>(null);
@@ -204,6 +212,8 @@ export function AnalysisView() {
               lapLabels={lapLabels}
               units={units}
               onCursorDist={onCursorDist}
+              zoomRange={zoomRange}
+              onZoomChange={setZoomRange}
             />
           </div>
         )}
@@ -215,12 +225,17 @@ export function AnalysisView() {
           <SidePanel
             title={mapLaps.length > 1 ? "Race lines — selected laps" : "Race line (reference lap)"}
           >
-            <RaceLineMap laps={mapLaps} cursorDist={cursorDist} step={compare!.step} />
+            <RaceLineMap
+              laps={mapLaps}
+              cursorDist={cursorDist}
+              step={compare!.step}
+              zoomRange={zoomRange}
+            />
           </SidePanel>
         )}
         {deviation && deviation.dist.length > 0 && (
           <SidePanel title={`Consistency — best ${deviation.lap_ids.length} laps`}>
-            <DeviationChart data={deviation} units={units} />
+            <DeviationChart data={deviation} units={units} zoomRange={zoomRange} />
           </SidePanel>
         )}
         {refLap != null && (

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -31,7 +31,8 @@ export function AnalysisView() {
   useEffect(() => {
     api.sessions().then((s) => {
       setSessions(s);
-      setSessionId((cur) => cur ?? s[0]?.id ?? null);
+      // Default to the newest session that actually has laps to chart.
+      setSessionId((cur) => cur ?? s.find((x) => x.lap_count > 0)?.id ?? s[0]?.id ?? null);
     }).catch(() => setError("Could not load sessions"));
   }, [lapEpoch]);
 
@@ -40,7 +41,10 @@ export function AnalysisView() {
   const manualSelection = useRef(false);
   useEffect(() => {
     if (sessionId == null) return;
-    api.sessionLaps(sessionId).then((ls) => {
+    api.sessionLaps(sessionId).then((all) => {
+      // Laps without samples (phantoms from menu/replay flicker in old
+      // recordings) have nothing to chart — keep them out of the picker.
+      const ls = all.filter((lap) => (lap.total_ticks ?? 1) > 0);
       setLaps(ls);
       if (ls.length === 0) return;
       const best = [...ls].sort((a, b) => a.time_ms - b.time_ms)[0];

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -44,7 +44,8 @@ export function AnalysisView() {
     api.sessionLaps(sessionId).then((all) => {
       // Laps without samples (phantoms from menu/replay flicker in old
       // recordings) have nothing to chart — keep them out of the picker.
-      const ls = all.filter((lap) => (lap.total_ticks ?? 1) > 0);
+      // Unknown tick counts are treated as empty, not as chartable.
+      const ls = all.filter((lap) => (lap.total_ticks ?? 0) > 0);
       setLaps(ls);
       if (ls.length === 0) return;
       const best = [...ls].sort((a, b) => a.time_ms - b.time_ms)[0];


### PR DESCRIPTION
## What changed

**Synchronized section zoom across the analysis view** (the headline feature):
- Click-and-drag across any telemetry chart selects a distance section and zooms every panel, the track map (which dims out-of-range and re-frames), and the deviation chart to it. Sector preset buttons (S1/S2/S3), a bottom slider, a zoom-range chip, and double-click / Reset Zoom to return to the full lap.
- The drag interaction uses ECharts' native `dataZoomSelect` toolbox mechanism activated via `takeGlobalCursor` — an earlier hand-rolled pixel-math implementation never engaged reliably. Zoom state is applied through `dispatchAction` as the single source of truth, with a guard flag so our own dispatches don't echo back through the change handler.

**Capture robustness — bugs found in the first real-PlayStation sessions:**
- **Phantom laps discarded**: GT7's lap counter flickers through stale values in menus/replays, emitting "completed laps" with a stale time and zero samples. Lap boundaries now require ≥ 10 s of samples (regression test reproduces the flicker sequence).
- **Empty sessions dropped**: menu bounces opened dozens of 0-lap sessions; starting a new session now deletes the previous one if it never recorded a lap.
- The analysis view hides zero-sample laps and defaults to the newest session that actually has laps (a phantom lap being auto-selected was feeding empty series to the charts, which made drag-zoom silently no-op with `maxDist = 0`).

**Readable chart tooltip**: the default axis tooltip repeated the hover distance once per panel and showed unlabeled bare numbers. Replaced with a custom formatter — one distance header, one labeled row per metric with units (km/h-or-mph, %, rpm, bar, ×, rad/s, signed seconds for time diff), and per-lap colored values when comparing laps.

**Docs**: TODO records shipped work and tables two investigated features (track borders via edge tracing; auto-numbered corners — including why the naive unsigned-curvature detector was wrong and the OSM/ODbL route for real circuits' outlines).

## Why

Real-console racing (911 GT3 on the Nordschleife and a GP circuit) surfaced both the capture bugs and the need to inspect single corners: full-lap charts at 20 km scale are unreadable, and duplicated/phantom laps were corrupting sessions and the lap picker.

## Reviewer notes

- The zoom fix replaced most of `StackedCharts.tsx`'s interaction code; the event handler binds once at chart init and reads `maxDist` through a ref to avoid stale closures after session switches.
- `min_lap_ticks` is a `LapProcessor` field (default 600 ticks ≈ 10 s); test fixtures set it to 1 because they drive short synthetic laps. Two dedicated tests cover the real threshold.
- Verified end-to-end in the browser with real recorded laps: drag-zoom, sector buttons, double-click reset, map highlight sync, and the tooltip (single- and multi-lap).
- Backend suite: 54 tests green; ruff and strict mypy clean; frontend `tsc` + Vite build clean.