### PR TITLE
ci: publish container image to GHCR, add README badges

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# VCS, CI, editor, agent tooling
+.git
+.gitignore
+.github
+.claude
+.idea
+.vscode
+.DS_Store
+
+# Docs, meta, dev-only entrypoints
+README.md
+TODO.md
+CLAUDE.md
+LICENSE
+docs
+reference-docs
+dev.sh
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Root dev harness (concurrently) — backend/ and frontend/ have their own manifests
+package.json
+package-lock.json
+node_modules
+
+# Node artifacts — stage 1 runs npm ci and npm run build itself
+frontend/node_modules
+frontend/dist
+**/*.tsbuildinfo
+
+# Python build / venv / cache artifacts
+**/__pycache__
+**/*.py[cod]
+**/.venv
+**/venv
+**/*.egg-info
+**/.mypy_cache
+**/.pytest_cache
+**/.ruff_cache
+backend/build
+backend/dist
+
+# Tests aren't installed (pyproject packages.find include = ["app*"])
+backend/tests
+
+# Local databases and secrets
+**/*.db
+**/*.db-journal
+**/*.sqlite*
+.env
+**/.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,18 @@ jobs:
         run: npm run build
 
   docker:
+    # Publishing lives in publish.yml. On PRs we only verify the image still
+    # builds: amd64 only, and cache read-only so untrusted branches can't
+    # thrash the buildx cache that main writes.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - name: Build image
-        run: docker build -t gt7-datalogger .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Only needed for the arm64 leg, which runs on release tags.
+      - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=GT7 Datalogger
+            org.opencontainers.image.description=Telemetry datalogger and analysis dashboard for Gran Turismo 7
+            org.opencontainers.image.licenses=MIT
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # amd64 on main for fast feedback; full multi-arch on release tags.
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Without this, buildx attaches attestation manifests that show up in
+          # the GHCR package UI as junk unknown/unknown architecture entries.
+          provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Stage 1: build the frontend
-FROM node:22-alpine AS frontend
+# Stage 1: build the frontend.
+# Pinned to the *builder's* platform: the only output is static JS/CSS/HTML, so
+# on a multi-arch build this runs once natively instead of again under emulation.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS frontend
 WORKDIR /build
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci --no-fund --no-audit
@@ -9,6 +11,10 @@ RUN npm run build
 # Stage 2: runtime
 FROM python:3.12-slim
 WORKDIR /app
+
+# Links the image to the repo on GHCR. CI overrides this via docker/metadata-action;
+# it is set here so locally built images carry it too.
+LABEL org.opencontainers.image.source="https://github.com/jbhoorasingh/gt7-datalogger"
 
 COPY backend/ backend/
 RUN pip install --no-cache-dir ./backend

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jermaine Bhoorasingh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -138,13 +138,15 @@ GT7_SOURCE=sim docker compose up --build
 Images are published to GitHub Container Registry, so you can skip the build:
 
 ```bash
-docker pull ghcr.io/jbhoorasingh/gt7-datalogger:latest
+TAG=latest  # amd64 (use a release tag like 0.1.0 on arm64)
+
+docker pull ghcr.io/jbhoorasingh/gt7-datalogger:${TAG}
 
 docker run -d --name gt7-datalogger \
   -p 8000:8000 -p 33740:33740/udp \
   -e GT7_PS_IP=<your playstation ip> \
   -v gt7-data:/data \
-  ghcr.io/jbhoorasingh/gt7-datalogger:latest
+  ghcr.io/jbhoorasingh/gt7-datalogger:${TAG}
 ```
 
 | Tag | Built from | Architectures |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # GT7 Datalogger
 
+[![CI](https://github.com/jbhoorasingh/gt7-datalogger/actions/workflows/ci.yml/badge.svg)](https://github.com/jbhoorasingh/gt7-datalogger/actions/workflows/ci.yml)
+[![Publish](https://github.com/jbhoorasingh/gt7-datalogger/actions/workflows/publish.yml/badge.svg)](https://github.com/jbhoorasingh/gt7-datalogger/actions/workflows/publish.yml)
+[![ghcr.io](https://img.shields.io/badge/ghcr.io-gt7--datalogger-2496ED?logo=docker&logoColor=white)](https://github.com/jbhoorasingh/gt7-datalogger/pkgs/container/gt7-datalogger)
+[![Python 3.12](https://img.shields.io/badge/python-3.12-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+
 A telemetry datalogger and analysis dashboard for **Gran Turismo 7**. It captures the
 PlayStation's live telemetry stream, records every lap, and serves a modern dark-themed
 web dashboard for live driving, lap comparison, and session management.
@@ -127,6 +133,33 @@ No PlayStation handy? Demo with the simulated source:
 GT7_SOURCE=sim docker compose up --build
 ```
 
+### Use the prebuilt image
+
+Images are published to GitHub Container Registry, so you can skip the build:
+
+```bash
+docker pull ghcr.io/jbhoorasingh/gt7-datalogger:latest
+
+docker run -d --name gt7-datalogger \
+  -p 8000:8000 -p 33740:33740/udp \
+  -e GT7_PS_IP=<your playstation ip> \
+  -v gt7-data:/data \
+  ghcr.io/jbhoorasingh/gt7-datalogger:latest
+```
+
+| Tag | Built from | Architectures |
+| --- | --- | --- |
+| `latest`, `main` | tip of `main`, every push | `amd64` |
+| `sha-<short sha>` | a specific commit | `amd64` |
+| `X.Y.Z`, `X.Y`, `X` | `vX.Y.Z` release tags | `amd64` + `arm64` |
+
+**On arm64 (Raspberry Pi 4/5, Zero 2 W) pull a release tag, not `latest`** — only tagged
+releases build the `arm64` leg, because emulating it on every push to `main` would triple
+CI time for no one's benefit.
+
+With Compose, `docker compose pull && docker compose up -d` runs the published image;
+`docker compose up --build` still builds from source.
+
 ### Ports
 
 | Port | Protocol | Purpose |
@@ -145,6 +178,13 @@ Docker is impractical on the smallest Pis — the official `python` and `node` i
 no ARMv6 build — so on a Raspberry Pi Zero W / Zero 2 W you run the backend natively and
 serve a **pre-built** frontend. The capture workload itself is light (decrypt + decode a
 ~300-byte UDP packet at 60 Hz), so even a Zero W handles it comfortably.
+
+> **Prefer Docker on a 64-bit Pi.** Tagged releases publish an `arm64` image, so on a
+> Pi Zero 2 W / 4 / 5 running 64-bit Raspberry Pi OS you can pull a release tag
+> (`ghcr.io/jbhoorasingh/gt7-datalogger:0.1.0`, **not** `:latest` — see
+> [Use the prebuilt image](#use-the-prebuilt-image)) and skip this section entirely.
+> The native route below stays the right answer for ARMv6 (Zero W) and for anyone who'd
+> rather not run Docker.
 
 > **Which Pi?** A **Pi Zero 2 W** (quad-core, runs 64-bit) is strongly recommended: on
 > arm64 every dependency has a prebuilt wheel and the steps below "just work". A **Pi Zero W**

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -2,6 +2,7 @@
 name = "gt7-datalogger"
 version = "0.1.0"
 description = "GT7 telemetry datalogger and analysis dashboard"
+license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.111",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 services:
   gt7-datalogger:
+    # `up` builds locally if this tag isn't present; `docker compose pull` fetches
+    # the published image instead. `up --build` always rebuilds from source.
+    image: ghcr.io/jbhoorasingh/gt7-datalogger:latest
     build: .
     container_name: gt7-datalogger
     restart: unless-stopped


### PR DESCRIPTION
## Why

CI built the Docker image and threw it away — `docker build -t gt7-datalogger .` with no registry push. Anyone wanting to run this had to build from source, which the Raspberry Pi section makes especially painful. This publishes a real artifact and surfaces build status in the README.

## What changed

**New `.github/workflows/publish.yml`** — builds and pushes to `ghcr.io/jbhoorasingh/gt7-datalogger` on `main` pushes and `v*.*.*` tags, with `docker/metadata-action` for tags/labels and `type=gha` layer caching.

Separate workflow rather than a job in `ci.yml` because it needs different triggers and `packages: write`, which shouldn't be granted to the PR-triggered CI workflow. It has **no `pull_request` trigger** — fork PRs get a read-only `GITHUB_TOKEN`, so not triggering is the complete fix for "PRs must not push".

**`ci.yml`** — the `docker` job is now PR-only, so `main` pushes don't build the image twice. Switched to buildx with `cache-from` but no `cache-to`: PRs read the cache `main` writes, without untrusted branches churning the 10 GB Actions cache budget.

**New `.dockerignore`** — didn't exist. The build context was shipping `.git`, `docs/screenshots/*.png`, `TODO.md`, and any local `frontend/node_modules` / `backend/.venv`. The real bug: `COPY frontend/ ./` at Dockerfile:8 was **overwriting the `node_modules` that `npm ci` had just installed on the line above with the host's macOS-native one** — a cache-buster and a latent arch-mismatch. Worth fixing before CI starts pushing images people actually pull.

**`Dockerfile`** — `--platform=$BUILDPLATFORM` on the frontend stage. Its only output is static JS/CSS/HTML, so pinning it to the builder's platform means `npm ci && vite build` runs once natively instead of again under arm64 QEMU. Biggest multi-arch time saver here, no-op for single-arch. Also adds `org.opencontainers.image.source` so locally built images link back to the repo (CI gets it from metadata-action).

**`LICENSE` + `license = "MIT"` in `backend/pyproject.toml`** — ahead of the repo going public. Without a license, "public" legally means all-rights-reserved.

**`README.md`** — badge row (CI, Publish, ghcr, Python 3.12, MIT), a "Use the prebuilt image" section with a tag→architecture table, and a Pi note. **`docker-compose.yml`** gains an `image:` key above `build:`, so `docker compose pull` works while `up --build` behaves exactly as before.

## Reviewer notes

**`latest` is amd64-only, deliberately.** It's published from `main` (`enable={{is_default_branch}}`), and multi-arch only runs on release tags — emulating arm64 on every push would roughly triple CI time. So `docker pull …:latest` on a Pi would get the wrong architecture. Rather than paper over it, the README tag table and the Pi note both direct arm64 users to a release tag. If we'd rather `latest` just work everywhere, it's a one-line change: make `platforms:` unconditionally `linux/amd64,linux/arm64` and drop the QEMU `if:`.

**Static badges over dynamic ones.** No `shields.io/github/*` endpoints — they query the public API anonymously and render broken while the repo is private. The static equivalents never break.

**Two manual steps after merge:** flip the repo to public, then make the package public at `https://github.com/users/jbhoorasingh/packages/container/gt7-datalogger/settings` (UI-only; no workflow can do it — and the package only exists after the first successful publish run). Until both happen the badges show as broken to anyone not signed in with repo access, and the package is metered against the free 500 MB quota. Since `type=sha` tags every commit, untagged versions accumulate — if we end up staying private, add an `actions/delete-package-versions` prune step.

## Testing

- All three YAML files parse; `jobs`/`services` keys resolve as expected.
- Backend wheel builds with `License-Expression: MIT` in its metadata.
- The exact CI backend job in a fresh venv: `pip install -e ".[dev]"` → `ruff check` → `mypy app` → `pytest -q`. Clean, 64 passed.
- **Not verified locally: the Docker build.** The Docker daemon wasn't running, so the `.dockerignore` and `$BUILDPLATFORM` changes haven't been exercised against a real build. The PR's `CI / docker` job is the first real test of them.