### PR TITLE
docs: GitHub Pages documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,11 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ data/*.db
 data/*.db-journal
 data/*.sqlite*
 
+# Docs
+site/
+
 # IDE / OS
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ A telemetry datalogger and analysis dashboard for **Gran Turismo 7**. It capture
 PlayStation's live telemetry stream, records every lap, and serves a modern dark-themed
 web dashboard for live driving, lap comparison, and session management.
 
-Functional parity with [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard),
-rebuilt with a cleaner architecture and a modern UI.
+Full feature parity with [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard) —
+plus additional features like the analysis channel picker, Corner Detail widget, chassis
+event detection, track auto-identification, the overlay builder, and webhook
+notifications — rebuilt with a cleaner architecture and a modern UI.
 
 **📖 Full documentation: [jbhoorasingh.github.io/gt7-datalogger](https://jbhoorasingh.github.io/gt7-datalogger/)** —
 per-feature guides, how every calculation works, and the API reference.
@@ -382,6 +384,13 @@ newer channels are simply absent and the charts skip them.
   the stream, or the packet format changed after a game update.
 - **No laps recorded** — laps are only recorded while the car is on track and not paused;
   the first (out) lap completes when you cross the start line.
+
+## Related projects
+
+- [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard) — the original Python
+  race-telemetry dashboard this project reached full parity with (and then extended).
+- [MacManley/gt7-udp](https://github.com/MacManley/gt7-udp) — a GT7 UDP telemetry
+  parser for ESP32 / ESP8266 boards, and a great reference for the packet format.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![ghcr.io](https://img.shields.io/badge/ghcr.io-gt7--datalogger-2496ED?logo=docker&logoColor=white)](https://github.com/jbhoorasingh/gt7-datalogger/pkgs/container/gt7-datalogger)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-github%20pages-8B5CF6)](https://jbhoorasingh.github.io/gt7-datalogger/)
 
 A telemetry datalogger and analysis dashboard for **Gran Turismo 7**. It captures the
 PlayStation's live telemetry stream, records every lap, and serves a modern dark-themed
@@ -12,6 +13,9 @@ web dashboard for live driving, lap comparison, and session management.
 
 Functional parity with [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard),
 rebuilt with a cleaner architecture and a modern UI.
+
+**📖 Full documentation: [jbhoorasingh.github.io/gt7-datalogger](https://jbhoorasingh.github.io/gt7-datalogger/)** —
+per-feature guides, how every calculation works, and the API reference.
 
 ![Analysis view](docs/screenshots/analysis.png)
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,56 @@
+# Configuration
+
+Most day-to-day settings — the console IP, telemetry source, log level, and webhook URL —
+can be changed **at runtime from the Admin view** with no restart. Those values persist
+in the database and override the environment on the next start.
+
+Everything else is configured with environment variables, or a `.env` file in the
+working directory.
+
+## Environment variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `GT7_SOURCE` | `udp` | `udp` (PlayStation) or `sim` (simulated laps) |
+| `GT7_PS_IP` | *(empty)* | Console IP; empty = broadcast auto-discovery |
+| `GT7_DB_PATH` | `data/gt7.db` | SQLite database path — also accepts a full SQLAlchemy async URL (e.g. Postgres) |
+| `GT7_CARS_CSV` | `data/cars.csv` | Car ID → name lookup table |
+| `GT7_WS_RATE` | `30` | Live stream rate to the browser (Hz); capture stays at ~60 Hz |
+| `GT7_WEBHOOK_URL` | *(empty)* | Webhook for PB / session notifications (also settable in Admin) |
+| `GT7_LOG_LEVEL` | `INFO` | Root log level (also settable in Admin) |
+| `GT7_HTTP_HOST` | `0.0.0.0` | HTTP bind host |
+| `GT7_HTTP_PORT` | `8000` | HTTP port |
+| `GT7_TELEMETRY_PORT` | `33740` | Inbound telemetry UDP port |
+| `GT7_HEARTBEAT_PORT` | `33739` | Outbound heartbeat UDP port |
+
+!!! note "Precedence"
+    Settings changed in the **Admin** view are persisted to the database and take
+    precedence over environment variables on subsequent starts.
+
+## The car database
+
+Telemetry identifies the car by a numeric ID; a CSV lookup table maps IDs to names. The
+bundled `cars.csv` only contains a sample entry. Fetch the full community-maintained
+list either:
+
+- from the UI: **Admin → Update car database**, or
+- from the command line:
+
+```bash
+python backend/scripts/update_cars.py
+```
+
+## Units & browser settings
+
+Display units (km/h vs mph) and other UI preferences are set from the dashboard itself
+and persist in the browser's local storage — they are per-device, not server-side.
+
+## Notifications
+
+Set a webhook URL (environment variable or **Admin** view) to get:
+
+- **New personal best** notifications as they happen
+- **End-of-session summaries**
+
+Discord webhook URLs receive a rich embed; any other URL receives plain JSON.
+See [Admin view](../guide/admin.md) for details.

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -1,0 +1,81 @@
+# Local development
+
+## One-command dev environment
+
+From the repo root, one command starts everything — backend with auto-reload on `:8000`,
+frontend with hot reload on `:5173` — and bootstraps the virtualenv and `node_modules`
+on first run. ++ctrl+c++ stops both:
+
+```bash
+./dev.sh
+```
+
+Settings come from a `.env` file in the repo root. Set `GT7_SOURCE=sim` there to develop
+against the simulated telemetry source without a PlayStation:
+
+```bash
+# .env
+GT7_SOURCE=sim
+```
+
+## Running the pieces individually
+
+**Backend** (Python 3.12+):
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+GT7_SOURCE=sim python -m uvicorn app.main:app --reload
+```
+
+**Frontend** (Node 22+):
+
+```bash
+cd frontend
+npm install
+npm run dev   # http://localhost:5173, proxies /api and /ws to :8000
+```
+
+## Tests and linting
+
+```bash
+cd backend
+ruff check app tests scripts
+mypy app
+pytest
+```
+
+The test suite exercises the packet decoder, lap detection, derived-channel math, event
+detection, and the REST API against fixture data — no PlayStation required.
+
+## Project layout
+
+```
+backend/
+  app/
+    telemetry/    # UDP listener, Salsa20 decrypt, packet decode, simulator
+    processing/   # lap detection, derived channels, events, tracks, cars
+    storage/      # SQLAlchemy async engine + repository
+    api/          # REST routes, WebSocket, admin endpoints
+    service.py    # wires capture → processing → storage → broadcast
+  tests/
+frontend/
+  src/
+    views/        # Live, Analysis, Sessions, Overlay, Admin
+    components/   # charts, overlay builder, UI primitives
+    lib/          # API client, channels, strategy math, overlay config
+    store/        # settings, telemetry, analysis state
+docs/             # this documentation site (MkDocs)
+```
+
+## Docs site
+
+The documentation you are reading is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
+from the `docs/` folder and deployed to GitHub Pages by `.github/workflows/docs.yml` on
+every push to `main`. To preview locally:
+
+```bash
+pip install mkdocs-material
+mkdocs serve   # http://localhost:8000 (stop the backend first, same port)
+```

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,79 @@
+# Quick start (Docker)
+
+The fastest way to run GT7 Datalogger is with Docker Compose. One container serves the
+dashboard, REST API, and WebSocket on port 8000 and listens for PlayStation telemetry on
+UDP 33740.
+
+## Prerequisites
+
+- Docker with the Compose plugin
+- A PlayStation 4/5 running Gran Turismo 7 on the **same network** as the machine running
+  the datalogger
+- Motion-data / telemetry is streamed automatically by GT7 — no in-game setting is needed,
+  but the console and server must be able to exchange UDP packets
+
+## Run it
+
+From a clone of the repository:
+
+```bash
+GT7_PS_IP=<your playstation ip> docker compose up --build
+```
+
+Open <http://localhost:8000> and start driving. Laps are recorded automatically whenever
+you are on track.
+
+!!! tip "No PlayStation handy?"
+    Run the built-in simulated telemetry source instead — it drives laps around a
+    synthetic circuit at 60 Hz, complete with lockups, wheelspin, kerb strikes, and
+    driver-aid activity:
+
+    ```bash
+    GT7_SOURCE=sim docker compose up --build
+    ```
+
+## Use the prebuilt image
+
+Images are published to GitHub Container Registry, so you can skip the build entirely:
+
+```bash
+docker pull ghcr.io/jbhoorasingh/gt7-datalogger:latest
+
+docker run -d --name gt7-datalogger \
+  -p 8000:8000 -p 33740:33740/udp \
+  -e GT7_PS_IP=<your playstation ip> \
+  -v gt7-data:/data \
+  ghcr.io/jbhoorasingh/gt7-datalogger:latest
+```
+
+| Tag | Built from | Architectures |
+| --- | --- | --- |
+| `latest`, `main` | tip of `main`, every push | `amd64` |
+| `sha-<short sha>` | a specific commit | `amd64` |
+| `X.Y.Z`, `X.Y`, `X` | `vX.Y.Z` release tags | `amd64` + `arm64` |
+
+!!! warning "arm64 (Raspberry Pi 4/5, Zero 2 W)"
+    Pull a **release tag** (for example `0.1.0`), not `latest` — only tagged releases
+    build the `arm64` image.
+
+With Compose, `docker compose pull && docker compose up -d` runs the published image;
+`docker compose up --build` still builds from source.
+
+## Ports
+
+| Port | Protocol | Purpose |
+| --- | --- | --- |
+| 8000 | HTTP | Dashboard, REST API, WebSocket |
+| 33740 | UDP | Telemetry from the PlayStation |
+| 33739 | UDP (outbound) | Heartbeat to the PlayStation |
+
+!!! note "Auto-discovery"
+    Broadcast auto-discovery of the console requires the container to share the LAN's
+    broadcast domain. With Docker's default bridge network, set `GT7_PS_IP` explicitly
+    (recommended), or run with `network_mode: host` on Linux.
+
+## Next steps
+
+- Point OBS at the [overlay](../guide/overlay.md) for streaming
+- Learn what every panel in the [Live view](../guide/live-view.md) shows
+- See all [configuration options](configuration.md)

--- a/docs/getting-started/raspberry-pi.md
+++ b/docs/getting-started/raspberry-pi.md
@@ -1,0 +1,133 @@
+# Running on a Raspberry Pi
+
+The capture workload is light — decrypting and decoding a ~300-byte UDP packet at 60 Hz —
+so even a Pi Zero W handles it comfortably. There are two routes:
+
+- **Docker on a 64-bit Pi (recommended)** — Pi Zero 2 W / 4 / 5 running 64-bit
+  Raspberry Pi OS can pull a release-tagged `arm64` image and skip everything below.
+- **Native install** — required on ARMv6 (original Pi Zero W), or for anyone who would
+  rather not run Docker.
+
+## Docker route (Pi Zero 2 W / 4 / 5, 64-bit OS)
+
+Tagged releases publish an `arm64` image. Pull a **release tag**, not `latest`:
+
+```bash
+docker run -d --name gt7-datalogger \
+  -p 8000:8000 -p 33740:33740/udp \
+  -e GT7_PS_IP=<your playstation ip> \
+  -v gt7-data:/data \
+  ghcr.io/jbhoorasingh/gt7-datalogger:0.1.0
+```
+
+That's it. The rest of this page covers the native route.
+
+## Native route
+
+!!! tip "Which Pi?"
+    A **Pi Zero 2 W** (quad-core, 64-bit capable) is strongly recommended: on arm64
+    every dependency has a prebuilt wheel and the steps below "just work". A **Pi Zero W**
+    (single-core, ARMv6) also works but depends on piwheels shipping ARMv6 wheels for the
+    Rust-based packages (`pydantic-core`, `watchfiles`) — see the ARMv6 note at the end.
+
+### 1. Build the frontend on your dev machine
+
+Never run `npm run build` on the Pi (slow, and likely to run out of memory). Build on
+your laptop and copy the output across:
+
+```bash
+# on your dev machine, from the repo root
+cd frontend
+npm ci
+npm run build          # produces frontend/dist
+
+# copy the whole repo (or at least backend/ + frontend/dist) to the Pi
+rsync -av --exclude node_modules --exclude .venv ../  pi@raspberrypi.local:~/gt7-datalogger/
+```
+
+The backend serves `frontend/dist` automatically when that folder is present — no web
+server or reverse proxy needed.
+
+### 2. Prepare the Pi
+
+Use a current **Raspberry Pi OS (Trixie-based)** image, which ships Python 3.12+ (the
+project requires ≥ 3.12). On an older Bookworm image you would have to build Python 3.12
+yourself.
+
+```bash
+sudo apt update
+sudo apt install -y python3 python3-venv python3-dev build-essential
+python3 --version      # must be 3.12 or newer
+```
+
+### 3. Install the backend
+
+Raspberry Pi OS points pip at **piwheels**, which provides prebuilt ARM wheels for
+`pydantic-core`, `pycryptodome`, and friends — this makes the install fast instead of an
+hours-long compile.
+
+```bash
+cd ~/gt7-datalogger/backend
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+```
+
+### 4. Configure
+
+Set the console IP (or leave it unset for broadcast auto-discovery) in an `.env` file in
+the directory you launch from, or as environment variables:
+
+```bash
+# ~/gt7-datalogger/backend/.env
+GT7_SOURCE=udp
+GT7_PS_IP=192.168.1.50        # your PlayStation's IP
+GT7_DB_PATH=/home/pi/gt7-data/gt7.db
+GT7_CARS_CSV=data/cars.csv
+```
+
+### 5. Run it
+
+```bash
+cd ~/gt7-datalogger/backend
+source .venv/bin/activate
+python -m app.main            # listens on 0.0.0.0:8000
+```
+
+Open `http://<pi-ip>:8000` from any device on the LAN. Fetch the full car list once with
+`python scripts/update_cars.py` (or from **Admin → Update car database**).
+
+### 6. Start automatically with systemd
+
+```ini
+# /etc/systemd/system/gt7-datalogger.service
+[Unit]
+Description=GT7 Datalogger
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=pi
+WorkingDirectory=/home/pi/gt7-datalogger/backend
+EnvironmentFile=/home/pi/gt7-datalogger/backend/.env
+ExecStart=/home/pi/gt7-datalogger/backend/.venv/bin/python -m app.main
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now gt7-datalogger
+journalctl -u gt7-datalogger -f      # follow the logs
+```
+
+Make sure the Pi and PlayStation share the same 2.4 GHz network and that UDP port 33740
+is not firewalled.
+
+!!! warning "ARMv6 (Pi Zero W) note"
+    If `pip install` tries to compile `pydantic-core` or `watchfiles` from source (i.e.
+    piwheels has no wheel for the exact version), the build can take a very long time or
+    exhaust the 512 MB of RAM. Options: pin to a package version piwheels does provide a
+    wheel for, add temporary swap for the one-time build, or — the easy path — use a
+    **Pi Zero 2 W** on 64-bit Raspberry Pi OS, where prebuilt wheels are always available.

--- a/docs/guide/admin.md
+++ b/docs/guide/admin.md
@@ -1,0 +1,61 @@
+# Admin view
+
+`#/admin` — runtime configuration, diagnostics, the overlay builder, and data
+management. Settings changed here apply **immediately, no restart**, persist in the
+database, and override environment variables on the next start.
+
+## Connection
+
+- **PlayStation IP address** — set or change the console IP at runtime; leave empty for
+  broadcast auto-discovery. Applying resets discovery so the change takes effect at
+  once.
+- **Telemetry source** — switch between **PlayStation** (UDP capture) and **Simulated**
+  (the built-in synthetic 60 Hz source) live. This is the in-app equivalent of
+  `GT7_SOURCE=sim` — everything (live view, recording, analysis, overlay) works against
+  the simulator.
+- **Log level** — DEBUG / INFO / WARNING / ERROR, applied server-side immediately.
+
+## Diagnostics
+
+Auto-refreshing stats: telemetry connection state, console IP, packets received,
+decode errors (amber when non-zero), server uptime, connected live clients,
+session/lap counts, database size, and loaded car names. Two actions:
+
+- **Restart telemetry source** — stop/start the current source (rebinds the UDP socket,
+  restarts discovery).
+- **Update car database** — downloads the community-maintained car list (from the
+  [ddm999/gt7info](https://github.com/ddm999/gt7info) project) so car IDs resolve to
+  real names. Run this once after install — the bundled `cars.csv` only has a sample
+  entry.
+
+## Notifications
+
+Set a **webhook URL** to get notified about:
+
+- **New personal bests** — fired the moment a session best is beaten (never on the
+  first lap of a session), with lap, improvement, car, and track.
+- **Session summaries** — when a session ends, with car, track, lap count, best lap,
+  and fuel used.
+
+**Discord** webhook URLs get a rich embed; **any other URL** receives plain JSON
+(snake-cased fields), so n8n / Home Assistant–style automations work out of the box.
+The **Test** button sends a test event so you can verify delivery. Notifications are
+fire-and-forget — a failed delivery logs a warning and never blocks capture.
+
+## Overlay & dashboard builder
+
+Documented on its own page: [Overlay & streaming](overlay.md).
+
+## Logs
+
+A live viewer over the server's in-memory log ring buffer (last 2,000 records):
+severity filter (`DEBUG+` … `ERROR+`), pause/resume, clear, auto-scroll that only
+follows when you're already at the bottom. This is the first place to look when
+telemetry isn't arriving.
+
+## Data management
+
+- **Compact database** — SQLite `VACUUM` to reclaim space after deleting laps.
+- **Delete all recorded data** — removes **every session and lap** (confirmed). Settings
+  and track signatures are kept. Export any laps you want to keep first
+  (Sessions → json).

--- a/docs/guide/analysis-view.md
+++ b/docs/guide/analysis-view.md
@@ -1,0 +1,94 @@
+# Analysis view
+
+`#/analysis` — overlay any number of laps against a reference lap and find where the
+time goes. The x-axis everywhere is **distance into the lap**, so laps of different
+speeds line up corner-for-corner (see [Lap comparison math](../internals/analysis-math.md)).
+
+![Analysis view](../screenshots/analysis.png)
+
+## Selecting laps
+
+1. Pick a **session** from the dropdown (`#id · car · n laps`). The newest session with
+   laps is selected by default.
+2. **Click lap chips** to toggle them into the comparison.
+3. **Double-click a chip** (or use the `ref:` dropdown) to make it the **reference
+   lap** — the lap everything else is measured against.
+
+Until you pick manually, the view auto-selects *latest vs best* and keeps following as
+new laps arrive live — useful on a second screen while driving. Any manual change pins
+your selection.
+
+!!! tip "Deep links"
+    The full selection is encoded in the URL —
+    `#/analysis?session=3&laps=12,15&ref=15&ch=speed,brake` — so a bookmark or shared
+    link reproduces the exact view. The Sessions and Live views use these links for
+    their *compare* / *analyze* shortcuts.
+
+## Stacked charts
+
+The first panel is always **Time diff (s)** — each lap's gap to the reference over
+distance (positive = slower; where the curve climbs is where you lose time). Below it,
+one panel per selected channel.
+
+- **Synced cursors** — hover any panel and a crosshair appears at the same distance in
+  every panel, on the race line map, and in the Corner Detail widget. The tooltip shows
+  one column per lap, unit-formatted.
+- **Zoom** — drag across any chart to zoom a section; every panel, the map, and the
+  deviation chart crop to it. Double-click to reset, or use the **S1 / S2 / S3** buttons
+  to jump to thirds of the lap. (Mouse-wheel zoom is off on purpose so page scrolling
+  stays normal.)
+- **Event shading** — detected [chassis events](../internals/event-detection.md) shade
+  the panel that explains them: lockups on Brake, wheelspin on Throttle,
+  bottoming/kerbs on suspension panels; TCS activity shades Throttle, ASM shades Speed.
+  Bands are tinted in the lap's color.
+
+## Channel picker
+
+The **Channels (n)** button opens a grouped picker with ~20 channels:
+
+| Group | Channels |
+| --- | --- |
+| Driving | Speed, Throttle, Brake, Coasting, Gear, Yaw rate |
+| Engine | RPM, Boost |
+| Tires & wheels | Tire spd/car spd, slip front/rear avg, slip per wheel, tire temp front/rear avg, **tire temp F−R balance** |
+| Chassis | Ride height, susp travel front/rear avg |
+
+Your selection persists in the browser and is added to the URL when it differs from the
+default nine-panel stack. Laps recorded before a channel existed simply skip that line.
+
+## Race line map
+
+A top-down plot of the reference lap's driven line, colored by input zone — green =
+throttle, red = braking, blue = coasting — with ▲ speed peaks and ▼ valleys marked.
+Other selected laps overlay as colored lines. The map has no direct mouse interaction:
+it follows the chart cursor, placing one dot per lap at the hovered distance so you can
+see the spatial gap between lines, and it auto-crops when you zoom a section.
+
+## Corner Detail widget
+
+A top-down car with four corner cells that replays the load-transfer story as you scrub
+the charts:
+
+- **cell color** = that wheel's tire temp (blue < 55 °C, green 55–95 °C, red ≥ 95 °C)
+- **bars** = suspension compression, normalized to that lap's travel range
+- **LOCK / SPIN badges** using the live thresholds (brake ≥ 20 % & slip < 0.9;
+  throttle ≥ 40 % & slip > 1.1)
+- **F/R temp balance** readout at the bottom
+
+One lap is in focus at a time; the reference lap is always the *ghost* — small secondary
+temps and dashed suspension levels — and a cell gets a red/blue ring when the focus lap
+runs more than 3 °C hotter/cooler than the reference at that point. With 3+ compared
+laps, focus chips let you switch the focus lap.
+
+## Side panels
+
+- **Gearing (reference lap)** — per-gear ratios with estimated speed at redline, tune
+  top speed, and redline RPM.
+- **Consistency — best 5 laps** — median speed plus a deviation band across the
+  session's best laps; a wide band marks corners you drive differently every lap.
+- **Fuel strategy** — the relative [fuel-map table](../internals/fuel-strategy.md):
+  for each setting −5…+5 vs the reference lap's, projected fuel/lap, laps remaining,
+  time remaining, and lap-time cost.
+- **Tuning info (reference lap)** — max speed, min ride height, input percentages, tire
+  spin, fuel used, aid usage (TCS/ASM %), engine health (max water/oil temp, min oil
+  pressure), and the detected-event summary.

--- a/docs/guide/live-view.md
+++ b/docs/guide/live-view.md
@@ -1,0 +1,70 @@
+# Live view
+
+`#/live` — the default view. Big race readouts that update continuously from the
+telemetry stream while you drive.
+
+![Live view](../screenshots/live.png)
+
+## Panels
+
+**RPM bar** — fills toward the shift point (`rpm ÷ redline`). It turns red at ≥ 95 % of
+the redline or when the rev limiter engages, and pulses while you're actually on the
+limiter.
+
+**Speed** — converted to your units setting (toggle km/h ↔ mph in the status bar).
+
+**Gear** — `R` for reverse, `N` for neutral. When the game suggests a downshift, a
+`gear → N` hint appears under the number.
+
+**Inputs** — throttle (green) and brake (red) bars with percentages. A boost row
+(`x.xx bar`) appears automatically on turbocharged cars.
+
+**Lap panel** — current lap (with `/total` in races, or `FIN` after the flag), last lap,
+best lap, and **Δ best** — your last lap compared against the best *before* it, so a new
+personal best shows the actual improvement (green ≤ 0, red if slower).
+
+**Fuel** — percentage of tank with a bar that turns red below 15 %, plus liters
+remaining / capacity.
+
+**Tires °C** — the four tire temperatures in a 2×2 layout, tinted by temperature:
+blue below 55 °C (cold), green 55–95 °C (optimal), red at 95 °C and above (hot). A
+`TIRE SPIN` warning flashes when average slip exceeds 1.1×.
+
+**Race panel** — position (`P3/16`), water and oil temperature with warning colors for
+long stints (water: amber ≥ 100 °C, red ≥ 110 °C; oil: amber ≥ 115 °C, red ≥ 130 °C),
+and three **driver-aid pills** — `TCS`, `ASM`, `HB` — that light amber while that aid is
+actively intervening.
+
+The footer shows the car name, plus `PAUSED` / `not on track` states.
+
+## Race strategy panel
+
+On larger screens the right column projects your fuel strategy from a rolling average of
+the last 3 fuel-consuming laps:
+
+- **Fuel to empty** — laps left at current consumption (amber < 4 laps, red < 2)
+- **Time to empty** — the same, in time
+- **Pit before lap** — the last lap you can complete on this tank
+- **To finish** — in races with a known length: green *fuel OK*, or red *x.x L short*
+- **Avg fuel / lap** and the **in-game clock** (handy for endurance day/night cycles)
+
+The panel stays empty until you complete a lap that actually consumed fuel — see
+[Fuel & race strategy](../internals/fuel-strategy.md) for the math.
+
+## Recent laps feed
+
+Every completed lap appears in the feed (newest first) with its color dot, lap number,
+time, and fuel used. **Click any lap to open it in the Analysis view** with that session
+and lap pre-selected.
+
+## Status bar (all views)
+
+- **Status dot** — green pulsing: receiving telemetry; amber: server up but no
+  telemetry (check console IP / UDP 33740); red: browser lost the server.
+- **● REC / ○ Paused** — toggle lap recording on/off.
+- **km/h / mph** — units toggle, persisted in the browser.
+
+## Empty state
+
+Before any telemetry arrives, the view shows *"Waiting for telemetry…"*. Start driving
+in GT7, or run the server with `GT7_SOURCE=sim` to demo without a console.

--- a/docs/guide/overlay.md
+++ b/docs/guide/overlay.md
@@ -1,0 +1,94 @@
+# Overlay & streaming
+
+The overlay is a standalone, chrome-less telemetry page at **`/overlay`** designed to be
+added as an **OBS Browser source**, opened in TikTok LIVE Studio, or loaded on a phone /
+pit-wall tablet. Its entire configuration lives in the URL, so OBS, a phone, and a
+second monitor can each load a different setup from the same server.
+
+![Overlay strip](../screenshots/overlay.png)
+
+## Building an overlay
+
+Open **Admin → Overlay & dashboard builder**. Two one-click starting points:
+
+- **OBS strip** — transparent 1920×260 bottom strip
+- **Phone dashboard** — full-screen dark grid with 9 widgets
+
+Then customize:
+
+- **Widgets** — check/uncheck any of the 11 widgets, reorder with ↑/↓, and scale each
+  one individually (75–200 %).
+- **Layout** — *Strip* (horizontal, for OBS), *Stack* (vertical column), or *Grid*
+  (phone dashboard).
+- **Canvas size** — *Fill source*, or exact-pixel presets: 1920×1080, 1920×260 strip,
+  1080×1920 (TikTok / Shorts), 720×1280, or any custom size. The overlay renders at
+  exactly those pixels.
+- **Appearance** — global scale, card background opacity (0 = bare floating widgets),
+  edge padding, vertical alignment.
+- **Page behind the widgets** — *Transparent* (OBS Browser sources with alpha), *Green
+  screen* (#00FF00 — chroma-key it in apps without alpha support), or *Solid dark*
+  (phones/tablets).
+
+The **live preview** renders the real overlay at true pixel size scaled to fit, with
+optional **safe-area guides** (action-safe 5 %, title-safe 10 %). Below it, ready-made
+URLs for *this device* and for *other devices* (built from the server's LAN IP) with
+copy/open buttons.
+
+**Presets** — save the current setup under a name, reload it with one click, and
+export/import the whole config as JSON. Presets live in the browser's local storage.
+
+## Widgets
+
+| Widget | Shows |
+| --- | --- |
+| `gear` | current gear, with suggested-gear hint |
+| `speed` | speed in your units |
+| `rpm` | RPM bar with a red `SHIFT` cue at ≥ 95 % of redline |
+| `inputs` | throttle / brake bars |
+| `times` | lap counter, best, last with Δ |
+| `delta` | big Δ-to-best number, green/red |
+| `position` | race position `P n/total` |
+| `tires` | 2×2 color-coded tire temps |
+| `fuel` | fuel % and bar (red < 15 %) |
+| `strategy` | fuel laps remaining and `PIT ≤ L<n>` |
+| `clock` | in-game time of day |
+
+## Setting up OBS
+
+1. Build your overlay and copy the *Other devices* URL.
+2. In OBS: **Sources → + → Browser**, paste the URL.
+3. Set the source's width/height to **the same canvas size** you picked in the builder.
+4. Done — the transparent page mode gives you clean alpha compositing. If your app
+   renders transparent pages as black, switch to *Green screen* and add a chroma-key
+   filter for `#00FF00`.
+
+If the stream drops, the strip/stack layouts render nothing (an empty source, not a
+frozen box) until telemetry resumes.
+
+## URL parameters
+
+Everything the builder does is expressible by hand:
+
+```
+http://<host>:8000/overlay?w=gear:1.25,speed,rpm,times&layout=strip&size=1920x260&bg=70&align=bottom
+```
+
+| Param | Values | Default |
+| --- | --- | --- |
+| `w` | comma list of widget ids, each optionally `id:scale` (0.5–3) | `gear,speed,rpm,inputs,times,tires,fuel` |
+| `layout` | `strip` · `stack` · `grid` | `strip` |
+| `scale` | 0.5–2 global zoom | `1` |
+| `bg` | card opacity 0–100 | `70` |
+| `align` | `top` · `center` · `bottom` (strip/stack) | `bottom` |
+| `size` | `WxH` exact pixels | fill source |
+| `pad` | `XxY` edge inset px | `16x16` |
+| `page` | `transparent` · `green` · `dark` | `transparent` (`dark` for grid) |
+| `demo` | `1` for placeholder data | off |
+
+## Placeholder mode
+
+`demo=1` shows an animated fake lap **only while no real telemetry is arriving**, with a
+small amber *placeholder* tag. The moment real data resumes it switches back
+automatically — so it's safe to leave on: you can design your layout without driving,
+and a mid-stream connection hiccup shows moving (clearly labeled) widgets instead of a
+frozen overlay.

--- a/docs/guide/sessions-view.md
+++ b/docs/guide/sessions-view.md
@@ -1,0 +1,58 @@
+# Sessions view
+
+`#/sessions` — your lap archive. Sessions are created automatically (split on car change
+or race restart — see [Lap detection & sessions](../internals/lap-detection.md)) and
+listed newest first.
+
+![Sessions view](../screenshots/sessions.png)
+
+## Session rows
+
+Each row shows the session id, car, start time, lap count, best lap, a **lap-time
+sparkline** (chronological lap times with the best lap dotted in accent), and the track:
+
+- a track **badge** when the track is known;
+- a dashed **name track…** button when it isn't. Naming it fingerprints the circuit from
+  the session's first lap, and **every future session on that track is tagged
+  automatically** — see [Track identification](../internals/track-identification.md).
+
+Click a row (or the chevron) to expand its lap table; **Analyze** opens the session in
+Analysis with *latest vs best* selected.
+
+## Lap table
+
+Per lap: time (best in accent), Δ to session best, fuel used, full-throttle %,
+full-brake %, coasting %, tire-spin %, events, and max speed.
+
+The **Events** column is a compact code — `2L·1S·3B·1K` means 2 lockups, 1 wheelspin,
+3 suspension bottomings, 1 kerb strike; `–` means a clean lap.
+
+Row actions:
+
+| Action | What it does |
+| --- | --- |
+| **compare** | opens Analysis with this lap vs the session's best (best as reference) |
+| **set ref** | opens Analysis with this lap as the reference |
+| **json** | downloads the lap as `gt7-lap-<id>.json` — the full 60 Hz recording, shareable and re-importable |
+| **csv** | downloads a **MoTeC-compatible CSV** for MoTeC i2 or Excel |
+| **delete** | removes the lap and its telemetry (confirmed, irreversible) |
+
+**Delete session** at the bottom of an expanded session removes the session and all its
+laps.
+
+## Header actions
+
+- **Log lap now** — saves the in-progress lap immediately without waiting for the start
+  line. Handy for capturing a partial run or a test.
+- **Import lap…** — load a `.json` lap file exported from any GT7 Datalogger instance.
+  Older v1 files import cleanly; the newer per-corner channels are simply absent and
+  the charts skip them. Events and aid metrics are recomputed from the samples on
+  import.
+
+## Recording control
+
+The **● REC / ○ Paused** toggle in the status bar pauses lap recording globally — the
+live view keeps streaming, but nothing is written to the database until you resume.
+
+See [Lap file format](../reference/lap-file-format.md) for what's inside the JSON and
+CSV exports.

--- a/docs/index.md
+++ b/docs/index.md
@@ -89,8 +89,17 @@ detail:
 - [Fuel & race strategy](internals/fuel-strategy.md) — the live pit-window and
   fuel-to-empty calculations
 
-## Credits
+## Credits & related projects
 
-Functional parity with [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard),
-rebuilt with a cleaner architecture and a modern UI. Licensed under the
+GT7 Datalogger has **full feature parity with
+[snipem/gt7dashboard](https://github.com/snipem/gt7dashboard)** — the original Python
+race-telemetry dashboard — plus additional features: the analysis channel picker,
+Corner Detail widget, chassis event detection, track auto-identification, the
+overlay builder, and webhook notifications, all rebuilt on a cleaner architecture with
+a modern UI.
+
+Also see [MacManley/gt7-udp](https://github.com/MacManley/gt7-udp), a GT7 UDP telemetry
+parser for ESP32 / ESP8266 boards and a great reference for the packet format.
+
+Licensed under the
 [MIT License](https://github.com/jbhoorasingh/gt7-datalogger/blob/main/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,96 @@
+# GT7 Datalogger
+
+A telemetry datalogger and analysis dashboard for **Gran Turismo 7**. It captures the
+PlayStation's live telemetry stream, records every lap, and serves a modern dark-themed
+web dashboard for live driving, lap comparison, race strategy, and session management.
+
+![Analysis view](screenshots/analysis.png)
+
+## What it does
+
+GT7 streams encrypted telemetry over UDP at 60 Hz while you drive. GT7 Datalogger:
+
+1. **Captures** that stream — Salsa20 decryption, heartbeat keep-alive, auto-discovery,
+   automatic reconnect.
+2. **Records** every lap — ~28 channels at 60 Hz including per-wheel slip, per-corner
+   tire temps, and suspension travel, plus per-lap aggregates and detected chassis
+   events (lockups, wheelspin, bottoming, kerb strikes).
+3. **Serves** a web dashboard — live race readouts, multi-lap analysis with synced
+   cursors and a race line map, session history, and a fully customizable OBS/phone
+   overlay builder.
+
+Everything runs in a single container (or natively on hardware as small as a Raspberry
+Pi Zero) and is viewed from any browser on your network.
+
+## Quick start
+
+```bash
+GT7_PS_IP=<your playstation ip> docker compose up --build
+```
+
+Open <http://localhost:8000> and start driving. No PlayStation handy? Run
+`GT7_SOURCE=sim docker compose up --build` for a fully simulated demo.
+→ [Full quick-start guide](getting-started/quick-start.md)
+
+## The four views
+
+<div class="grid cards" markdown>
+
+- **[Live view](guide/live-view.md)** — big race readouts: speed, gear, RPM with limiter
+  flash, inputs, tires, fuel, delta, driver-aid pills, live strategy, and a clickable
+  feed of completed laps.
+
+- **[Analysis view](guide/analysis-view.md)** — overlay multiple laps against a
+  reference: ~20 telemetry channels, time-diff over distance, synced cursors, race line
+  map, corner detail widget, detected events, and a gearing panel.
+
+- **[Sessions view](guide/sessions-view.md)** — browse history with lap-time sparklines
+  and per-lap metrics; export laps as JSON or CSV/MoTeC, import shared laps, manage
+  recording.
+
+- **[Overlay & streaming](guide/overlay.md)** — build a custom overlay for OBS, a phone
+  dashboard, or a pit-wall tablet: pick and scale widgets, choose layouts and canvas
+  sizes, save named presets.
+
+</div>
+
+## Screenshots
+
+**Live view** — race readouts, driver-aid pills, strategy, and the clickable lap feed:
+
+![Live view](screenshots/live.png)
+
+**Sessions view** — lap-time sparklines and per-lap metrics with event counts
+(`2L·1S·4B` = lockups · wheelspins · bottoming):
+
+![Sessions view](screenshots/sessions.png)
+
+**OBS overlay** — one of the layouts from the overlay builder, at an exact canvas size:
+
+![Overlay strip](screenshots/overlay.png)
+
+*All screenshots were captured against the built-in simulated telemetry source.*
+
+## How it works
+
+Curious about the internals? The **How it works** section explains the machinery in
+detail:
+
+- [Architecture](internals/architecture.md) — how capture, processing, storage, and the
+  UI fit together
+- [Telemetry capture](internals/telemetry-capture.md) — the GT7 UDP protocol, Salsa20
+  decryption, and every decoded field
+- [Lap detection & sessions](internals/lap-detection.md) — how laps are cut from the
+  stream and grouped into sessions
+- [Derived channels & metrics](internals/derived-channels.md) — the math behind every
+  computed channel and per-lap aggregate
+- [Chassis event detection](internals/event-detection.md) — how lockups, wheelspin,
+  bottoming, and kerb strikes are found
+- [Fuel & race strategy](internals/fuel-strategy.md) — the live pit-window and
+  fuel-to-empty calculations
+
+## Credits
+
+Functional parity with [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard),
+rebuilt with a cleaner architecture and a modern UI. Licensed under the
+[MIT License](https://github.com/jbhoorasingh/gt7-datalogger/blob/main/LICENSE).

--- a/docs/internals/analysis-math.md
+++ b/docs/internals/analysis-math.md
@@ -1,0 +1,82 @@
+# Lap comparison math
+
+The Analysis view compares laps of different lengths and speeds on one set of axes.
+This page explains the alignment, delta, consistency, and map math behind it.
+
+## Distance resampling — how laps are aligned
+
+Laps are aligned **by distance traveled**, not by time. Every lap's sample series is
+resampled onto a uniform distance grid:
+
+- grid points at `0, step, 2×step, …` up to the lap's total distance (default **step =
+  5 m**; the API accepts 0.5–50 m);
+- each channel is **linearly interpolated** onto the grid, with edge clamping (values
+  before the first / after the last sample take the boundary value).
+
+Two laps resampled this way have directly comparable values at every grid index: "what
+was each lap doing 850 m into the lap?" This is also a read-time downsample — a 2-minute
+lap goes from ~7,200 ticks to a few hundred grid points per channel.
+
+## Time delta
+
+For each compared lap, at every grid distance `d` up to the shorter of the two laps:
+
+```
+delta_ms(d) = t_lap(d) − t_ref(d)      # both via interpolation of dist → t
+```
+
+**Positive = slower than the reference** at that point. The curve's *slope* is the
+insight: rising = losing time right here, flat = holding the gap, falling = gaining.
+The reference lap compared with itself is exactly zero, so it isn't drawn.
+
+## Speed deviation (consistency chart)
+
+Across the session's best N laps (default 5), on the common distance grid (cut to the
+shortest lap):
+
+- **median speed** at each grid point (middle value, or mean of the two middles);
+- **population standard deviation** `sqrt(Σ(v − mean)² ÷ n)` at each grid point.
+
+A spike in the deviation band marks a corner where your speed varies lap to lap — the
+first place to look for consistency gains.
+
+## Race line map
+
+The map is a raw top-down plot of the recorded world coordinates (`pos_x`, `pos_z`) —
+no projection or rotation, GT7's coordinates are used as-is. Each reference-lap point is
+classified into an input zone:
+
+| Zone | Condition | Color |
+| --- | --- | --- |
+| Braking | brake ≥ 1 % | red |
+| Throttle | else throttle ≥ 1 % | green |
+| Coasting | otherwise | blue |
+
+Other selected laps overlay as solid lines in their chart colors, so line differences
+are visible spatially. The chart cursor maps distance → grid index → coordinates, which
+is how hovering a chart moves the dots on the map.
+
+## Speed peaks & valleys
+
+The ▲/▼ markers on the map are local speed extrema, found with a sliding window:
+
+- a point is a **peak** if it is the maximum of the surrounding ±30 ticks (~0.5 s each
+  side), a **valley** if it is the minimum;
+- consecutive markers of the same kind must be at least **100 m** apart.
+
+Valleys approximate apexes (minimum corner speed) and peaks approximate the end of
+acceleration zones — without needing full corner detection.
+
+!!! note "Why no numbered corners?"
+    Curvature-based corner numbering was prototyped and removed: unsigned curvature
+    splits hairpins into two "corners" and merges S-sections into one. Doing it right
+    needs signed curvature with hysteresis — it's on the roadmap; until then the
+    peaks/valleys markers plus the **S1/S2/S3** section-zoom buttons (fixed thirds of
+    the lap distance) cover the workflow.
+
+## Cursor synchronization
+
+All the "synced" behavior is one shared value: the cursor's grid index
+(`round(distance ÷ step)`). Every consumer — each chart panel, the race line map dots,
+the Corner Detail widget — reads the same index into its own resampled arrays, which is
+why everything stays in lockstep as you scrub.

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,0 +1,92 @@
+# Architecture
+
+```
+PlayStation (GT7) ──UDP 33740──▶ Telemetry service (FastAPI, Python 3.12)
+       ▲                          ├─ Salsa20 decrypt + typed packet parser
+       └──heartbeat 33739──────── ├─ Lap detection, session grouping, metrics
+                                  ├─ SQLite storage (SQLAlchemy async)
+                                  ├─ REST API  (/api/…)  – history & analysis
+                                  └─ WebSocket (/ws/live) – 30 Hz live stream
+                                              │
+                                              ▼
+                                  React 18 + TypeScript + Vite + Tailwind
+                                  (ECharts for high-frequency chart rendering)
+```
+
+## One process, one event loop
+
+The whole backend is a **single-process, single-threaded asyncio** application
+(FastAPI + uvicorn). There are no worker threads or subprocesses. The data flow is:
+
+```
+UdpTelemetrySource (or SimTelemetrySource)
+        │  decrypt + parse (~60 Hz)
+        ▼
+   asyncio.Queue (600 packets ≈ 10 s buffer)
+        │  single consumer task — strictly ordered
+        ▼
+TelemetryService._on_packet
+        ├──▶ LapProcessor.feed  ──▶ lap/session callbacks ──▶ SQLite (async)
+        └──▶ WebSocket broadcast (rate-limited to GT7_WS_RATE, default 30 Hz)
+```
+
+Design points worth knowing:
+
+- **Strict ordering** — exactly one consumer task drains the packet queue, so lap
+  detection never runs concurrently with itself. Overlapping feeds could duplicate a lap
+  save while a database write is in flight.
+- **Backpressure that favors freshness** — if the queue fills (e.g. a slow disk stalls a
+  write), the *oldest* packet is dropped and counted in `packets_dropped`, so the live
+  view always shows current data.
+- **Commit before await** — inside the lap processor, all state transitions (lap counter,
+  sample buffer, fuel/engine aggregates) are committed *before* any `await`. At 60 Hz, a
+  lap boundary that stayed "open" across an await would re-trigger and duplicate laps.
+
+## Why FastAPI?
+
+Native async fits a 60 Hz UDP stream plus WebSocket fan-out in one process; Pydantic
+gives typed models and settings; and the Python ecosystem has mature Salsa20 support
+(`pycryptodome`).
+
+## Storage
+
+SQLite via SQLAlchemy 2.x **async** engine (`sqlite+aiosqlite`). Because the storage
+layer only sees a SQLAlchemy URL, SQLite can be swapped for Postgres
+(`postgresql+asyncpg://…`) by changing `GT7_DB_PATH` — no code changes.
+
+Four tables:
+
+| Table | Contents |
+| --- | --- |
+| `sessions` | one row per driving session: start time, car ID/name, note, track name |
+| `laps` | one row per lap: timing, per-lap metrics, detected events (JSON), gearing (JSON), and the **full 60 Hz sample series** (JSON) |
+| `tracks` | named track signatures for auto-identification (length + bounding box) |
+| `settings` | runtime overrides set from the Admin view (console IP, source, log level, webhook URL) |
+
+Schema evolution is handled with an idempotent additive-column migration list — on
+startup, missing columns are added with `ALTER TABLE`, so old databases upgrade in place.
+
+**No downsampling on write**: every 60 Hz tick of a lap is stored. Downsampling happens
+at *read* time — the analysis endpoints resample onto a uniform distance grid (default
+5 m steps), and the live WebSocket stream is capped at `GT7_WS_RATE` (default 30 Hz).
+
+## Frontend
+
+React 18 + TypeScript, built with Vite, styled with Tailwind. High-frequency charts
+(the stacked analysis panels, race line map, sparklines) render with **ECharts**, which
+handles thousands of points per series without breaking a sweat. State lives in small
+stores (settings, telemetry, analysis); the current analysis view is fully encoded in
+the URL hash so links reproduce exact comparisons.
+
+In production the backend serves the built frontend from `frontend/dist` — one container,
+one port. `GET /overlay` returns the SPA directly (a plain path, because some streaming
+apps reject URLs with `#fragment`s).
+
+## The simulator
+
+`GT7_SOURCE=sim` replaces the UDP listener with a deterministic synthetic source: a
+3,200 m rounded-rectangle circuit driven at 60 Hz with two braking zones, deliberate
+front lockups under braking, rear wheelspin on slow launches, a kerb strike, and
+TCS/ASM/rev-limiter activity. Lap detection, event detection, charts, and the overlay
+all get realistic data with no console — it's how the project is developed, demoed, and
+screenshotted.

--- a/docs/internals/derived-channels.md
+++ b/docs/internals/derived-channels.md
@@ -1,0 +1,95 @@
+# Derived channels & metrics
+
+Every lap stores a full 60 Hz sample series. Some columns are raw packet values; others
+are computed at capture time. This page lists every stored channel with its exact
+formula, then the per-lap aggregates, then the channels the frontend derives on the fly.
+
+## Stored sample columns
+
+One value per column per tick (~60/s):
+
+| Column | Formula | Unit |
+| --- | --- | --- |
+| `t` | `tick_index × 1/60` | s |
+| `dist` | running `Σ speed_mps × 1/60` | m |
+| `speed` | `speed_mps × 3.6` | km/h |
+| `throttle` | `raw_byte ÷ 2.55` | % (0–100) |
+| `brake` | `raw_byte ÷ 2.55` | % |
+| `coast` | `1` if throttle < 1 % **and** brake < 1 % | flag |
+| `gear` | low nibble of the gear byte (15 = neutral) | — |
+| `rpm` | raw | rpm |
+| `boost` | `raw − 1.0` (packet stores bar + 1) | bar |
+| `tire_slip` | mean of the four wheel slips | ratio |
+| `yaw_rate` | `abs(angular_velocity_y)` | rad/s |
+| `pos_x`, `pos_z` | raw world coordinates | m |
+| `body_height` | `raw × 1000` | mm |
+| `fuel` | raw fuel level | L |
+| `slip_fl/fr/rl/rr` | `abs(wheel_rad_per_s) × tire_radius ÷ speed_mps` | ratio |
+| `tt_fl/fr/rl/rr` | raw tire temps | °C |
+| `sus_fl/fr/rl/rr` | `suspension_travel × 1000` | mm |
+| `aids` | bitmask: TCS=1, ASM=2, handbrake=4, rev limiter=8 | mask |
+
+**Wheel slip** is a slip-ratio proxy: wheel surface speed divided by car speed. `< 1`
+under braking means the wheel is locking; `> 1` under power means it's spinning. Below
+1 m/s car speed the ratio is meaningless, so all four are pinned to `1.0`.
+
+## Per-lap aggregates
+
+Computed once when the lap is saved (`n` = number of samples):
+
+| Metric | Formula |
+| --- | --- |
+| Fuel consumed | `max(0, fuel_at_lap_start − fuel_at_lap_end)` L |
+| Full throttle % | `100 × count(throttle ≥ 98 %) ÷ n` |
+| Full brake % | `100 × count(brake ≥ 98 %) ÷ n` |
+| Coasting % | `100 × count(coast flag set) ÷ n` |
+| Tire spin % | `100 × count(tire_slip ≥ 1.1) ÷ n` |
+| Max speed | `max(speed)` km/h |
+| Min body height | `min(body_height)` mm |
+| TCS / ASM active % | `100 × count(aid bit set) ÷ n` |
+
+**Engine health** is tracked as running per-lap extremes rather than per-tick columns
+(these values drift over minutes, not corners):
+
+- `max_water_temp`, `max_oil_temp` — running maxima (°C)
+- `min_oil_pressure` — running minimum (bar), **sampled only while RPM > 1200** so idling
+  in the pits doesn't record a misleading low; `−1` means unknown
+
+**Gearing** is captured once per lap from the lap-boundary packet: the non-zero gear
+ratios, the tune's transmission top speed, and the redline (`rpm_alert_max`).
+
+## Frontend-derived channels
+
+These are computed in the browser from the stored columns, never persisted:
+
+| Channel | Formula |
+| --- | --- |
+| Slip front / rear avg | `(slip_fl + slip_fr) ÷ 2`, `(slip_rl + slip_rr) ÷ 2` |
+| Tire temp front / rear avg | mean of the two front / rear corners |
+| **Tire temp F−R balance** | `mean(tt_fl, tt_fr) − mean(tt_rl, tt_rr)` °C — positive = fronts running hotter (push/understeer working the fronts) |
+| Susp travel front / rear avg | mean of the two front / rear corners |
+
+Laps recorded before per-corner channels existed simply skip these lines rather than
+erroring.
+
+**Units**: speed is the only channel with a display transform (km/h → mph × 0.621371
+when imperial units are selected). Everything else displays in its stored unit.
+
+## Gearing panel math
+
+The estimated speed at redline for gear *i* assumes the tune's top speed is reached in
+top gear, then scales by ratio:
+
+```
+speed_i = top_speed × (ratio_top ÷ ratio_i)
+```
+
+## A note on "tiers"
+
+If you browse the code or `TODO.md` you'll see channels grouped into tiers. That's a
+**roadmap grouping**, not a runtime concept: Tier 1 = surface data already in the packet
+(per-corner slip/temps/suspension, aids, engine health, gearing — all implemented),
+Tier 2 = derived analytics like sector splits and g-g diagrams (largely future work),
+Tier 3+ = larger features (overlay, webhooks, strategy — implemented). There is no
+lateral-G, brake-temp, or slip-angle channel — GT7 doesn't send them and they aren't
+synthesized.

--- a/docs/internals/event-detection.md
+++ b/docs/internals/event-detection.md
@@ -1,0 +1,70 @@
+# Chassis event detection
+
+When a lap is saved (and when one is imported), the sample series is scanned once for
+four kinds of chassis events. They are stored with the lap, shaded onto the analysis
+charts, counted in the Sessions table (`2L·1S·4B·1K`), and summarized in the tuning
+panel.
+
+Each event records its type, start/end distance, the wheels involved, and a severity
+score.
+
+## Lockup
+
+A wheel turning slower than the car is moving, under braking:
+
+- **Active tick**: `brake ≥ 20 %` **and** any wheel's slip `< 0.9`
+- **Minimum duration**: 6 consecutive ticks (~0.1 s) — filters single-tick noise
+- **Wheels**: every wheel that crossed the threshold anywhere in the run
+- **Severity**: the *minimum* slip seen during the run (lower = harder lock; 0 = fully
+  locked)
+
+## Wheelspin
+
+A driven wheel overspeeding under power:
+
+- **Active tick**: `throttle ≥ 40 %` **and** any wheel's slip `> 1.1`
+- **Minimum duration**: 6 consecutive ticks
+- **Severity**: the *maximum* slip seen during the run (higher = more spin)
+
+## Suspension bottoming
+
+Absolute suspension travel varies by car and tune, so bottoming is detected on the
+lap-normalized range per wheel:
+
+- compute that wheel's min/max travel over the lap; skip if the range is ~0
+- **Active tick**: travel within the top **2 %** of the lap's range
+  (`≥ min + 0.98 × range`)
+- **Minimum duration**: 3 consecutive ticks
+- **Severity**: how far into the range the peak reached (0–1)
+
+## Kerb strike
+
+A kerb shows up as a single-tick spike in suspension travel rather than a sustained
+compression:
+
+- for each tick, compare against the average of its neighbors two ticks away:
+  `neighbors = (travel[i−2] + travel[i+2]) ÷ 2`
+- **Fires** when `travel[i] − neighbors > 35 %` of the lap's travel range
+- Recorded as a zero-length event (`start_dist = end_dist`)
+
+## Caps and robustness
+
+- At most **40 events per type** are stored per lap, so a spin-fest can't bloat the
+  database.
+- Laps imported from old (v1) files that lack per-corner columns simply produce no
+  events instead of erroring; events are **recomputed** on import when the data is
+  present.
+
+## How events are displayed
+
+- **Analysis charts** — each event shades the panel that explains it: lockups on the
+  Brake panel, wheelspin on Throttle, bottoming and kerbs on the suspension panels. The
+  band is tinted in the lap's color at 14 % opacity, and single-tick kerb strikes are
+  widened to a minimum of 2 m so they stay visible.
+- **Driver aids** — TCS-active stretches shade the Throttle panel and ASM-active
+  stretches shade the Speed panel, using the same mechanism.
+- **Sessions table** — the compact per-lap code `2L·1S·3B·1K` = 2 lockups, 1 wheelspin,
+  3 bottomings, 1 kerb strike.
+- **Corner Detail widget** — live `LOCK` / `SPIN` badges are re-derived per corner as
+  you scrub, using the same thresholds (brake ≥ 20 % & slip < 0.9; throttle ≥ 40 % &
+  slip > 1.1).

--- a/docs/internals/fuel-strategy.md
+++ b/docs/internals/fuel-strategy.md
@@ -1,0 +1,77 @@
+# Fuel & race strategy
+
+Two related calculations power the strategy features: a **live rolling projection**
+(Live view and the overlay `strategy` widget) and the **relative fuel map** (Analysis
+view).
+
+## Live strategy projection
+
+Computed in the browser from your most recent completed laps:
+
+```
+recent        = last 3 completed laps that consumed > 0.01 L
+avgFuelPerLap = mean(recent.fuel_consumed)        # L
+avgLapMs      = mean(recent.time_ms)              # ms
+
+lapsToEmpty   = current_fuel_level / avgFuelPerLap
+timeToEmpty   = lapsToEmpty × avgLapMs
+pitBeforeLap  = current_lap + floor(lapsToEmpty)
+```
+
+Details that matter:
+
+- The window is the **last 3 laps**, so the projection adapts quickly to a fuel-map
+  change or a different stint pace.
+- Laps that consumed ≤ 0.01 L (fuel-consumption off, time trials) are excluded — until
+  a lap actually burns fuel, no projection is shown at all rather than a misleading one.
+- **Warning colors**: the laps-to-empty readout turns amber below **4 laps** and red
+  below **2 laps**.
+
+### Race-distance fuel check
+
+When the race length is known (`total_laps > 0`), the projection also answers "will I
+make the flag?":
+
+```
+needed = (total_laps − current_lap + 1) × avgFuelPerLap
+```
+
+If `needed ≤ fuel_level` you get a green **fuel OK**; otherwise a red
+**`needed − fuel_level` L short** — i.e. a pit stop (or leaner fuel map) is required.
+
+The fuel gauge itself is simply `fuel_level ÷ fuel_capacity`, styled red below **15 %**.
+
+## The relative fuel map (Analysis)
+
+GT7's in-car fuel map trades power for consumption. The Analysis panel models settings
+**relative to the one you drove the reference lap on** (row `0` = current), using two
+approximation constants calibrated against observed in-game behavior:
+
+- consumption changes **±10 % per step**
+- lap time changes **∓250 ms per step** (richer = faster)
+
+For each setting −5…+5:
+
+```
+fuel_per_lap   = base_fuel_per_lap × (1 + 0.10 × setting)
+lap_time       = base_lap_time − 250 ms × setting
+laps_remaining = fuel_level ÷ fuel_per_lap
+time_remaining = laps_remaining × lap_time
+```
+
+The base consumption and lap time come from the selected reference lap; the fuel level
+is the **live** value when the console is connected, falling back to the lap's
+end-of-lap fuel otherwise. So during a race the table answers, in real time: *"if I lean
+the map two clicks, how many extra laps do I buy and what does it cost per lap?"*
+
+!!! note "Approximation, not simulation"
+    The ±10 % and 250 ms constants are deliberate approximations — real deltas vary by
+    car and track. The table is meant for relative comparisons between settings, and it
+    is refreshed by real consumption data every lap, so errors don't accumulate.
+
+## Time of day
+
+GT7 streams the in-game clock (`day_progression_ms`). It is shown live in the strategy
+panel and the overlay `clock` widget — useful for endurance races with day/night
+transitions — and recorded per lap (`tod_ms`), so you can see later at what in-game
+time each lap was set.

--- a/docs/internals/lap-detection.md
+++ b/docs/internals/lap-detection.md
@@ -1,0 +1,97 @@
+# Lap detection & sessions
+
+GT7 doesn't send "lap completed" messages — the datalogger has to cut clean laps out of
+a 60 Hz packet stream that also includes menus, replays, pauses, and restarts. This page
+explains exactly how.
+
+## What gets sampled
+
+For every packet, a sample is recorded onto the in-progress lap **only if all of these
+hold**:
+
+- the car is **on track** (flag bit 0) and the game is **not paused** (bit 1);
+- `current_lap > 0` — GT7 reports the out-lap in time trials as "lap 0", which is never
+  recorded;
+- the race isn't already finished — after the checkered flag GT7 reports
+  `current_lap = total_laps + 1` for the cool-down lap, which is skipped.
+
+Packets with the `LOADING` flag set are dropped entirely before any processing.
+
+**Time and distance** are synthesized, not taken from packet timestamps:
+
+- `t = tick_index × 1/60` seconds
+- `dist += speed_mps × 1/60` meters, accumulated per recorded tick
+
+Because distance only accumulates on recorded ticks, paused or off-track time adds no
+distance and the distance axis stays clean.
+
+## When a lap completes
+
+A lap-counter change is only accepted as a real completed lap when **all four**
+conditions hold:
+
+1. the previous lap number was `> 0` (a real lap, not the out-lap);
+2. the counter moved **exactly +1** (monotonic step);
+3. the game reported a positive `last_lap_time_ms`;
+4. the lap collected at least **600 samples** (~10 s at 60 Hz).
+
+Condition 4 is the **phantom-lap guard**: in menus and replays GT7's lap counter
+flickers through stale values and re-reports an old `last_lap_time`. Requiring 10
+seconds of actual on-track samples filters all of that out.
+
+The lap time itself is taken **verbatim from GT7's `last_lap_time_ms`** — it is never
+computed from tick counts, so it matches the in-game timing exactly. (The one exception
+is the manual *Log lap now* action, which saves a partial lap and derives its time from
+the sample clock.)
+
+!!! note "Why state is committed before the database write"
+    Packets keep arriving at 60 Hz while a lap is being written to SQLite. All processor
+    state — lap counter, sample buffer, fuel and engine aggregates — is committed
+    *before* the asynchronous save starts; otherwise the lap boundary would re-trigger
+    on the next packet and duplicate the lap. There's a regression test for exactly this.
+
+## What's stored per lap
+
+- The **full 60 Hz sample series** (~28 channels — see
+  [Derived channels](derived-channels.md)), JSON-encoded.
+- Per-lap aggregates: fuel used, full-throttle / full-brake / coasting / tire-spin
+  percentages, max speed, min body height, TCS/ASM usage, engine health, time of day.
+- [Detected chassis events](event-detection.md), computed once at save time.
+- Gearing metadata (ratios, tune top speed, redline) captured from the boundary packet.
+
+## Session lifecycle
+
+A **session** groups consecutive laps that belong together. A new session starts when:
+
+- the **car changes** (`car_id` differs from the session's car), or
+- the **lap counter resets** — `current_lap` drops below where it was (race restart,
+  return to menu and back out).
+
+When a new session starts, the previous one is closed first:
+
+- a session that ended with **zero laps is deleted** — menu visits and quick restarts
+  don't pile up as empty rows;
+- a session with laps triggers the `session_summary`
+  [webhook notification](../guide/admin.md#notifications) (car, track, laps, best lap,
+  fuel used).
+
+On the **first completed lap** of a session, the lap's geometry is compared against the
+saved track signatures and the session is tagged automatically if it matches — see
+[Track identification](track-identification.md).
+
+## Best-lap tracking
+
+The service tracks the session best and, separately, the best *before* the
+just-completed lap (`prev_best_ms`). The live "Δ best" readout compares against
+`prev_best_ms`, so when you set a new personal best you see the improvement
+(e.g. `−0.312`) instead of a useless `+0.000`.
+
+The `personal_best` webhook fires only when an existing session best is actually beaten —
+never on the first lap of a session.
+
+## What "invalid lap" means here
+
+There is no track-limits detection (GT7 doesn't expose it). Laps are excluded only by
+the structural rules above: lap-0 out-laps, laps under 600 ticks, post-finish laps, and
+paused/off-track ticks. The Analysis view additionally hides laps that ended up with no
+samples.

--- a/docs/internals/telemetry-capture.md
+++ b/docs/internals/telemetry-capture.md
@@ -103,6 +103,13 @@ If the queue ever fills (slow disk), the **oldest** packet is dropped so the liv
 never lags behind reality. Received/dropped/decode-error counters are visible in
 `GET /api/status` and the Admin view.
 
+!!! info "Protocol references"
+    The GT7 telemetry format is community-reverse-engineered. Useful companion
+    projects: [snipem/gt7dashboard](https://github.com/snipem/gt7dashboard) (Python
+    dashboard this project reached parity with) and
+    [MacManley/gt7-udp](https://github.com/MacManley/gt7-udp) (a C++ parser for
+    ESP32 / ESP8266 boards with well-documented packet offsets).
+
 ## The simulated source
 
 `GT7_SOURCE=sim` swaps the UDP listener for a synthetic source that emits the same

--- a/docs/internals/telemetry-capture.md
+++ b/docs/internals/telemetry-capture.md
@@ -1,0 +1,112 @@
+# Telemetry capture
+
+GT7 streams encrypted telemetry over UDP at roughly **60 Hz** while driving is on
+screen. This page describes exactly how the datalogger captures and decodes it.
+
+## The handshake
+
+The console only streams to a client that keeps asking for data:
+
+1. The datalogger binds UDP port **33740** and sends a **heartbeat** — a single byte
+   `A` — to the console's port **33739** every **1.6 s**. (GT7 stops sending after
+   ~100 packets without a heartbeat.)
+2. The heartbeat is addressed to `GT7_PS_IP` if configured. If not, it is
+   **broadcast** (`255.255.255.255`), and the console's address is learned from the
+   source address of the first telemetry packet that arrives — that's the
+   auto-discovery mechanism.
+3. If no packet arrives for **5 s** the connection is considered stale and the status
+   indicator drops to "waiting for telemetry" while heartbeats continue.
+
+## Decryption
+
+Each 296-byte datagram is encrypted with **Salsa20**:
+
+- **Key** — the first 32 bytes of the ASCII string
+  `Simulator Interface Packet GT7 ver 0.0` (i.e. `Simulator Interface Packet GT7 v`).
+- **Nonce** — a 4-byte little-endian seed `iv1` is read *unencrypted* at offset `0x40`
+  of the datagram. A second value is derived as `iv2 = iv1 XOR 0xDEADBEAF` (yes,
+  `BEAF` — that is the real GT7 constant), and the 8-byte Salsa20 nonce is `iv2`
+  followed by `iv1` (both little-endian).
+- **Validation** — after decryption, the first four bytes must equal the magic
+  `0x47375330` (`"G7S0"`). Anything else is counted as a decode error and dropped.
+
+!!! note "Packet format support"
+    The datalogger implements the classic **296-byte format-A packet** with the `A`
+    heartbeat. The extended formats introduced in later GT7 patches (the "B" / `~`
+    variants) are not used — format A carries everything the dashboard needs.
+
+## Decoded fields
+
+Every packet decodes to a typed structure with ~50 fields. The important ones:
+
+| Offset | Field | Units / notes |
+| --- | --- | --- |
+| 0x04 | position X/Y/Z | m, GT7 world coordinates |
+| 0x10 | velocity X/Y/Z | m/s |
+| 0x2C | angular velocity X/Y/Z | rad/s (Y = yaw rate) |
+| 0x38 | body height | m |
+| 0x3C | engine RPM | rpm |
+| 0x44 | fuel level / capacity | L (capacity 0 for EVs) |
+| 0x4C | speed | m/s |
+| 0x50 | boost | raw − 1.0 → bar |
+| 0x54–0x5C | oil pressure, water temp, oil temp | bar, °C, °C |
+| 0x60 | tire temps FL/FR/RL/RR | °C |
+| 0x74 | current lap / total laps | total = 0 in time trial |
+| 0x78 | best / last lap time | ms, −1 when unset |
+| 0x80 | in-game time of day | ms |
+| 0x84 | race position / total | |
+| 0x88 | RPM alert min/max | shift-light thresholds |
+| 0x8E | flags | bitmask, see below |
+| 0x90 | current gear (low nibble) / suggested gear (high nibble) | 15 = neutral |
+| 0x91 | throttle / brake | 0–255 → % via ÷2.55 |
+| 0xA4 | wheel angular speed FL/FR/RL/RR | rad/s, signed |
+| 0xB4 | tire radius FL/FR/RL/RR | m |
+| 0xC4 | suspension travel FL/FR/RL/RR | m |
+| 0xF4 | clutch, clutch engagement, RPM after clutch | |
+| 0x104 | gear ratios (8) + transmission top speed | |
+| 0x124 | car ID | maps to `cars.csv` |
+
+**Flags bitmask** — `CAR_ON_TRACK` (bit 0), `PAUSED` (1), `LOADING` (2), `IN_GEAR` (3),
+`HAS_TURBO` (4), `REV_LIMITER` (5), `HANDBRAKE` (6), lights (7–9), `ASM_ACTIVE` (10),
+`TCS_ACTIVE` (11).
+
+For storage, the aid flags are remapped into a stable, compact **aids bitmask** persisted
+with every sample: `TCS=1`, `ASM=2`, `HANDBRAKE=4`, `REV_LIMITER=8`. This keeps recorded
+laps immune to any future changes in GT7's flag layout.
+
+### Wheel slip (computed at decode time)
+
+GT7 doesn't send slip directly; it sends wheel angular speed and tire radius. Per wheel:
+
+```
+slip = |wheel_rad_per_s| × tire_radius / car_speed_mps
+```
+
+- `slip < 1` under braking → the wheel is turning slower than the car is moving —
+  **locking**
+- `slip > 1` under power → the wheel is spinning faster than the car — **wheelspin**
+- Below 1 m/s car speed the ratio is meaningless, so all four are forced to `1.0`.
+
+This is a slip-*ratio proxy* (wheel surface speed ÷ car speed), unsigned — not a signed
+SAE slip ratio — but it is exactly what's needed to spot lockups and wheelspin.
+
+## From packet to dashboard
+
+Decoded packets flow through a bounded queue (600 packets ≈ 10 s) into a single
+ordered consumer:
+
+- if recording is on, the packet feeds [lap detection](lap-detection.md);
+- the latest frame is broadcast to all WebSocket clients, throttled to `GT7_WS_RATE`
+  (default **30 Hz**) — capture stays at 60 Hz regardless.
+
+If the queue ever fills (slow disk), the **oldest** packet is dropped so the live view
+never lags behind reality. Received/dropped/decode-error counters are visible in
+`GET /api/status` and the Admin view.
+
+## The simulated source
+
+`GT7_SOURCE=sim` swaps the UDP listener for a synthetic source that emits the same
+packet stream at exactly 60 Hz: a 3,200 m circuit, ~223 km/h baseline with two braking
+zones, deliberate front lockups, rear wheelspin on slow launches, a kerb strike at ~21 %
+of the lap, and TCS/ASM/rev-limiter activity. It uses a fixed random seed, so demo data
+is reproducible.

--- a/docs/internals/track-identification.md
+++ b/docs/internals/track-identification.md
@@ -1,0 +1,53 @@
+# Track identification
+
+GT7 telemetry doesn't include the track name — but its world coordinates are fixed per
+circuit. The datalogger exploits that: name a circuit once, and every future session on
+it is tagged automatically from lap geometry.
+
+## The signature
+
+When you name a track (**Sessions → name track…**), a signature is computed from one
+completed lap on it:
+
+| Component | Meaning |
+| --- | --- |
+| `length_m` | total lap distance (integrated from speed) |
+| `min_x`, `max_x`, `min_z`, `max_z` | the lap's world-coordinate bounding box |
+
+That's the whole fingerprint — five numbers.
+
+## Matching
+
+On the **first completed lap** of every new session, if the session has no track name
+yet, the lap's signature is compared against every stored track. A match requires **all
+four** gates to pass:
+
+1. Both lengths are positive.
+2. **Length within 4 %**: `|lap_length − track_length| ÷ track_length ≤ 0.04` — loose
+   enough to absorb different racing lines, tight enough to separate layouts.
+3. **Bounding-box centre within 120 m** on both the x and z axes — different circuits
+   sit in different places in GT7's world space.
+4. **Each extent within 20 %** of the stored width/depth.
+
+The first matching track's name is applied to the session and broadcast live, so the
+track badge appears in the UI immediately.
+
+## Why this works
+
+- The signature is car- and pace-independent: a slow lap and a hot lap on the same
+  circuit produce nearly identical bounding boxes and lengths.
+- Different layouts of the same venue (e.g. full circuit vs short course) differ in
+  length by far more than 4 %, so they register as separate tracks — name each layout
+  once.
+- Reverse layouts share geometry, so they will match the forward layout's signature.
+  If you drive both directions regularly, include the direction in the name you give
+  the first one you record.
+
+## Managing tracks
+
+- `POST /api/tracks {name, lap_id}` — what the *name track…* dialog calls; stores the
+  signature and back-fills the current session's track name.
+- `GET /api/tracks` / `DELETE /api/tracks/{id}` — list and remove signatures.
+
+Deleting a track signature doesn't touch any session data — it only stops future
+auto-matching.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,91 @@
+# REST & WebSocket API
+
+Everything the dashboard does goes through this API, so anything the UI can do, a
+script can too. All REST routes live under `/api`; responses are JSON.
+
+## Status & health
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/health` | `{"status": "ok"}` |
+| GET | `/api/status` | source kind, connection state, packet/error counters, recording flag, current session id, track name |
+
+## Sessions & laps
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/sessions` | all sessions, newest first, with lap count and best lap |
+| DELETE | `/api/sessions/{id}` | delete a session and its laps |
+| GET | `/api/sessions/{id}/laps` | lap summaries for one session |
+| GET | `/api/laps` | all lap summaries, newest first |
+| GET | `/api/laps/{id}?samples=true` | full lap detail: metrics, events, gearing, and (optionally) the 60 Hz samples |
+| DELETE | `/api/laps/{id}` | delete a lap |
+| GET | `/api/laps/{id}/export` | JSON export envelope (see [Lap file format](lap-file-format.md)) |
+| GET | `/api/laps/{id}/export.csv` | MoTeC-compatible CSV (one row per tick, 27 channels with units) |
+| POST | `/api/laps/import` | import an exported lap file |
+
+## Tracks
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/tracks` | stored track signatures |
+| POST | `/api/tracks` | `{name, lap_id}` — name a circuit from a lap's geometry |
+| DELETE | `/api/tracks/{id}` | remove a signature (session data untouched) |
+
+## Analysis
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/analysis/compare` | `laps` (CSV ids), `ref` (id), `step` (m, default 5, 0.5–50), `channels` (optional CSV) → per-lap distance-resampled series, speed peaks/valleys, events, and delta-vs-reference |
+| GET | `/api/analysis/deviation` | `session_id`, `count` (2–20, default 5) → median speed + standard deviation by distance across the best N laps |
+| GET | `/api/analysis/fuel` | `lap_id` → relative fuel-map table for settings −5…+5 |
+
+Default compare channels: `t, speed, throttle, brake, coast, gear, rpm, boost,
+tire_slip, yaw_rate, pos_x, pos_z`. Any other stored column can be requested via
+`channels=`; `t`, `pos_x`, `pos_z` are always included (the delta and map need them).
+Delta values are milliseconds, **positive = slower than the reference**.
+
+## Controls
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| POST | `/api/control/recording` | `{"recording": bool}` — pause/resume lap recording |
+| POST | `/api/control/log-lap-now` | save the in-progress lap immediately (409 if none) |
+
+## Admin
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/admin/settings` | current runtime settings |
+| PUT | `/api/admin/settings` | `{ps_ip?, source?, log_level?, webhook_url?}` — applied live, persisted to the DB |
+| POST | `/api/admin/test-webhook` | send a test notification |
+| GET | `/api/admin/logs` | `limit` (≤2000), `level` — recent log records from the ring buffer |
+| DELETE | `/api/admin/logs` | clear the ring buffer |
+| GET | `/api/admin/stats` | uptime, DB stats, source stats, client count, LAN IP |
+| POST | `/api/admin/restart-source` | stop/start the telemetry source |
+| POST | `/api/admin/clear-data` | delete **all** sessions and laps (settings/tracks kept) |
+| POST | `/api/admin/vacuum` | SQLite `VACUUM` |
+| POST | `/api/admin/update-cars` | download the community car list and reload the lookup |
+
+## WebSocket — `/ws/live`
+
+One endpoint, server-push only (client messages are ignored/pings). Every message is
+`{"type": ..., "data": ...}` with four types:
+
+- **`telemetry`** — the live frame, throttled to `GT7_WS_RATE` (default 30 Hz):
+  speed, RPM + redline, gear + suggested gear, throttle/brake %, boost, fuel level and
+  capacity, lap counters, best/last lap, session best and previous best, race position,
+  tire temps (FL/FR/RL/RR), tire slip, water/oil temps, oil pressure, driver-aids
+  bitmask (TCS=1, ASM=2, handbrake=4, rev limiter=8), car id/name, world position,
+  in-game time of day, track name, on-track/paused flags.
+- **`lap`** — sent when a lap is saved: id, session, number, time, per-lap metrics, and
+  event counts. The UI uses this to refresh lists live.
+- **`session`** — sent on new session, track identification, or track naming.
+- **`status`** — sent on connect and whenever the source or console IP changes.
+
+On connect the client immediately receives a `status` message. The frontend
+auto-reconnects every 2 s if the socket closes.
+
+!!! note "CORS"
+    CORS is wide open (`*`) — the API is designed for a trusted home network, not
+    public exposure. Don't port-forward it to the internet.

--- a/docs/reference/lap-file-format.md
+++ b/docs/reference/lap-file-format.md
@@ -1,0 +1,63 @@
+# Lap file format
+
+Laps export and import as JSON (**Sessions → json** / **Import lap…**) so they can be
+shared or backed up, and export as CSV for MoTeC i2 or Excel.
+
+## JSON export (v2)
+
+```json
+{
+  "format": "gt7-datalogger-lap",
+  "version": 2,
+  "lap": {
+    "number": 4,
+    "time_ms": 92450,
+    "car_id": 3298,
+    "fuel_start": 42.1,
+    "fuel_end": 40.3,
+    "...": "per-lap metrics, engine health, tod_ms",
+    "events": [ { "type": "lockup", "start_dist": 812.4, "end_dist": 818.0,
+                  "wheels": ["fl"], "severity": 0.71 } ],
+    "gearing": { "ratios": [3.21, 2.44, 1.88, 1.51, 1.24, 1.03],
+                 "top_speed": 289.0, "rpm_alert": 7500 },
+    "samples": { "t": [...], "dist": [...], "speed": [...], "...": "..." }
+  }
+}
+```
+
+The `samples` object holds the **full 60 Hz series** as parallel arrays, one per
+channel — see [Derived channels & metrics](../internals/derived-channels.md) for the
+complete column list with formulas and units (~28 columns: time, distance, speed,
+inputs, gear, RPM, boost, per-wheel slip, per-corner tire temps and suspension travel,
+world position, fuel, driver-aids bitmask, …).
+
+### Importing
+
+`POST /api/laps/import` (or the **Import lap…** button) accepts the envelope above:
+
+- If no session is active, an `imported` session is created to hold the lap.
+- **Events and aid-usage metrics are recomputed** from the samples on import (so
+  imports benefit from detector improvements), while engine-health aggregates and
+  gearing are carried over verbatim.
+- **v1 files** (from older versions) import cleanly — the newer per-corner channels are
+  simply absent and the charts skip them; events stay empty since the columns they need
+  aren't there.
+
+## CSV export (MoTeC-compatible)
+
+`GET /api/laps/{id}/export.csv` — a CSV that MoTeC i2's *CSV file* import (and Excel)
+understands:
+
+- Header rows: `Format`, `Device`, `Vehicle` (the car name), `Comment`, `Log Date`, and
+  `Sample Rate: 60.000`
+- Then a channel-name row and a unit row, followed by one row per tick
+
+27 channels with explicit units: Time (s), Distance (m), Ground Speed (km/h), Throttle
+Pos (%), Brake Pos (%), Gear, Engine RPM (rpm), Boost Pressure (bar), Tyre Slip Ratio,
+Yaw Rate (rad/s), Pos X/Z (m), Ride Height (mm), Fuel Level (L), Tyre Slip FL/FR/RL/RR,
+Tyre Temp FL/FR/RL/RR (C), Susp Travel FL/FR/RL/RR (mm), and Driver Aids (bitmask).
+
+!!! tip
+    In MoTeC i2, create a new workspace, then *File → Import* and choose the CSV. The
+    distance channel makes distance-based overlays work the same way they do in the
+    built-in Analysis view.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+## "Server up, no telemetry" (amber status dot)
+
+The backend is running but no packets are arriving from the console.
+
+- Check `GT7_PS_IP` is the PlayStation's current IP (it can change after a router
+  reboot — consider a DHCP reservation).
+- Make sure the PlayStation and the server are on the **same network / subnet**.
+- Check that UDP port **33740** is not blocked by a firewall on the server.
+- If you rely on broadcast auto-discovery inside Docker, note that the default bridge
+  network cannot see LAN broadcasts — set `GT7_PS_IP` explicitly or use
+  `network_mode: host` (Linux only).
+- You must be **in a race, time trial, or replay** — GT7 only streams telemetry while
+  driving is on screen, not in menus.
+
+## Wrong or garbled data (decode errors in `/api/status`)
+
+- Another tool on the network may be consuming or interfering with the stream.
+- The packet format may have changed after a game update — check for a newer release of
+  the datalogger.
+
+## No laps recorded
+
+- Laps are only recorded while the car is **on track and not paused**; menu and replay
+  time is ignored.
+- The first (out) lap completes when you cross the start line — until then nothing is
+  saved.
+- Check that recording hasn't been toggled off in the **Sessions** view.
+
+## Dashboard loads but shows "demo" data
+
+The frontend falls back to a demo frame when it cannot reach the backend WebSocket.
+Check that the backend is running and reachable at the same host/port you loaded the
+page from.
+
+## Overlay shows a black background in OBS
+
+Use a **Browser source** in OBS and make sure the overlay layout is set to the
+transparent strip; alternatively use the green-screen page mode and add a chroma-key
+filter for apps without alpha support. See [Overlay & streaming](../guide/overlay.md).
+
+## Getting more detail
+
+- **Admin → Logs** shows the live backend log with level filtering.
+- `GET /api/status` reports connection state, packet rates, and decode errors — useful
+  when filing an issue.
+- Database growing large? **Admin → Database** shows stats and offers compact/clear
+  actions.
+
+Still stuck? [Open an issue](https://github.com/jbhoorasingh/gt7-datalogger/issues) with
+your setup (Docker/native, network layout) and the output of `/api/status`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,81 @@
+site_name: GT7 Datalogger
+site_description: >-
+  Telemetry datalogger and analysis dashboard for Gran Turismo 7 — live view,
+  lap comparison, OBS overlays, and race strategy.
+site_url: https://jbhoorasingh.github.io/gt7-datalogger/
+repo_url: https://github.com/jbhoorasingh/gt7-datalogger
+repo_name: jbhoorasingh/gt7-datalogger
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - navigation.indexes
+    - content.code.copy
+    - content.action.edit
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+nav:
+  - Home: index.md
+  - Getting started:
+      - Quick start (Docker): getting-started/quick-start.md
+      - Raspberry Pi: getting-started/raspberry-pi.md
+      - Local development: getting-started/local-development.md
+      - Configuration: getting-started/configuration.md
+  - User guide:
+      - Live view: guide/live-view.md
+      - Analysis view: guide/analysis-view.md
+      - Sessions view: guide/sessions-view.md
+      - Overlay & streaming: guide/overlay.md
+      - Admin view: guide/admin.md
+  - How it works:
+      - Architecture: internals/architecture.md
+      - Telemetry capture: internals/telemetry-capture.md
+      - Lap detection & sessions: internals/lap-detection.md
+      - Derived channels & metrics: internals/derived-channels.md
+      - Lap comparison math: internals/analysis-math.md
+      - Chassis event detection: internals/event-detection.md
+      - Track identification: internals/track-identification.md
+      - Fuel & race strategy: internals/fuel-strategy.md
+  - Reference:
+      - REST & WebSocket API: reference/api.md
+      - Lap file format: reference/lap-file-format.md
+      - Troubleshooting: reference/troubleshooting.md


### PR DESCRIPTION
## Summary

Adds a full documentation site built with **MkDocs Material**, deployed to GitHub Pages at
**https://jbhoorasingh.github.io/gt7-datalogger/** (Pages is already enabled with the
GitHub-Actions build type; the site deploys on merge).

### Contents (23 pages)

- **Home** — what the project is, the four views, screenshots (reuses `docs/screenshots/`)
- **Getting started** — Docker quick start, Raspberry Pi (Docker + native), local development, full configuration reference
- **User guide** — one page per feature: Live view, Analysis view, Sessions view, Overlay & streaming (incl. URL params and OBS setup), Admin view
- **How it works** — the actual algorithms with real constants from the code:
  - architecture & data flow
  - telemetry capture (UDP protocol, Salsa20 key/nonce, full field table, wheel-slip formula)
  - lap detection & session lifecycle (phantom-lap guard, session auto-split)
  - derived channels & per-lap metrics (every formula and unit)
  - lap comparison math (distance resampling, delta, deviation, peaks/valleys)
  - chassis event detection (lockup/wheelspin/bottoming/kerb thresholds)
  - track identification (signature + matching tolerances)
  - fuel & race strategy (rolling projection, fuel-map model)
- **Reference** — REST & WebSocket API, lap file format (JSON v2 + MoTeC CSV), troubleshooting

### Infrastructure

- `mkdocs.yml` — Material theme (dark default), search, per-page edit links
- `.github/workflows/docs.yml` — builds with `mkdocs build --strict` and deploys to Pages on pushes to `main` that touch `docs/**` / `mkdocs.yml`
- README: docs badge + link
- `site/` added to `.gitignore`

Verified locally: `mkdocs build --strict` passes and the rendered site was checked in a browser.