### PR TITLE
chore: bump version to 0.2.0 and backfill the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes to GT7 Datalogger. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-31
 
 ### Added
 
@@ -41,3 +41,34 @@ Notable changes to GT7 Datalogger. The format follows
 
 - The GitHub Pages docs deploy job no longer runs (and fails) on pull requests.
 - Concurrent layout create/rename with a duplicate name returns 409 instead of 500.
+
+## [0.1.0] - 2026-07-23
+
+Initial release.
+
+### Added
+
+- **Telemetry capture** from a PlayStation on the same network: Salsa20 decryption,
+  heartbeat keep-alive, console auto-discovery via UDP broadcast, automatic reconnect,
+  and a built-in **simulated telemetry source** for development without a console.
+- **Per-lap recording** at 60 Hz across ~28 channels (per-wheel slip, per-corner tire
+  temps, suspension travel, driver-aids bitmask, …) with per-lap aggregates: aid usage,
+  engine health, gearing metadata, and chassis events (lockup / wheelspin / bottoming /
+  kerb detection).
+- **Live view**: real-time dashboard with race readouts, driver-aid pills, fuel
+  strategy projection, and a clickable recent-lap feed, streamed over WebSocket.
+- **Analysis view**: multi-lap comparison against a selectable reference lap with time
+  delta, synced cursors, channel picker, event bands, race line map, corner detail,
+  consistency (deviation) view, fuel map, and gearing panel.
+- **Sessions view**: lap-time sparklines, per-lap metrics with event counts, JSON
+  export/import, CSV / MoTeC-compatible export, and record on/off + log-lap-now
+  controls.
+- **Track auto-identification** from lap geometry — name a circuit once and future
+  sessions are tagged automatically.
+- **OBS overlay** at `/overlay` with a URL-encoded builder: strip / stack / grid
+  layouts, exact-pixel canvas sizes, transparent / green-screen / dark page modes,
+  per-widget scaling, browser-stored presets, and placeholder demo data.
+- **Admin view**: connection settings, runtime source switching, log viewer, webhook
+  notifications (Discord-aware), car database updater, and data management.
+- **Deployment**: single Docker image (amd64/arm64) serving API + UI on one port,
+  Raspberry Pi guide, and a MkDocs Material documentation site on GitHub Pages.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gt7-datalogger"
-version = "0.1.0"
+version = "0.2.0"
 description = "GT7 telemetry datalogger and analysis dashboard"
 license = "MIT"
 requires-python = ">=3.12"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gt7-datalogger-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gt7-datalogger-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-select": "^2.3.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gt7-datalogger-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Follow-up to #6 (merged before this landed on the branch):

- Bump `frontend/package.json` (+lock) and `backend/pyproject.toml` from 0.1.0 to **0.2.0**.
- Changelog: the `Unreleased` section becomes **[0.2.0] - 2026-07-31**, and **[0.1.0] - 2026-07-23** gets a proper backfilled entry covering the initial feature set (capture, live/analysis/sessions views, track auto-ID, URL-based overlay, admin, Docker + docs site).

After this merges, tagging `v0.2.0` on main will trigger the release Docker build (`publish.yml` builds the multi-arch image for `v*.*.*` tags).