### PR TITLE
Live delta-to-best during the lap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Notable changes to GT7 Datalogger. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- Docs: a full **widget reference** page (`guide/widgets.md`) covering every widget's
+  styles, color thresholds, alert triggers, and behavior under each track condition
+  (paused, menus, first lap, past the reference lap, race finished, unlimited
+  sessions, lost telemetry, placeholder mode).
+
 ### Changed
 
 - The delta widget (overlay, `/dash`, Live view) now updates **live during the lap**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Notable changes to GT7 Datalogger. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- The delta widget (overlay, `/dash`, Live view) now updates **live during the lap**:
+  it compares your current track position against the session-best lap's trace
+  (positive = slower). Before a reference lap exists it falls back to the end-of-lap
+  comparison, labeled *Δ best (last lap)*. Live frames gain `delta_ms` and
+  `lap_elapsed_ms` fields.
+
 ## [0.2.0] - 2026-07-31
 
 ### Added

--- a/backend/app/processing/analysis.py
+++ b/backend/app/processing/analysis.py
@@ -47,6 +47,18 @@ def resample_by_distance(
     return out
 
 
+def time_delta_at(dist_m: float, t_s: float, ref: Samples) -> float | None:
+    """Live gap vs a reference lap at the same distance (ms; positive = slower).
+
+    None when the reference is empty or dist_m runs past its final sample —
+    edge clamping would otherwise inflate the gap at 1 ms per ms once the
+    reference lap "finishes".
+    """
+    if not ref["dist"] or dist_m > ref["dist"][-1]:
+        return None
+    return (t_s - _interp(ref["dist"], ref["t"], dist_m)) * 1000
+
+
 def time_delta_series(
     lap: Samples, reference: Samples, step: float = DEFAULT_STEP_M
 ) -> dict[str, list[float]]:

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -13,6 +13,7 @@ from fastapi import WebSocket
 from app.config import Settings
 from app.models import TelemetryPacket
 from app.notify import Notifier
+from app.processing.analysis import Samples, time_delta_at
 from app.processing.cars import CarDatabase
 from app.processing.laps import CompletedLap, LapProcessor, SessionInfo
 from app.processing.tracks import signature_from_samples
@@ -52,6 +53,10 @@ class TelemetryService:
         self.notifier.url = settings.webhook_url
         self._session_best_ms: int | None = None
         self._prev_best_ms: int | None = None
+        # (dist, t) trace of the session-best lap — the reference for the
+        # live delta. Safe to hold by reference: the processor allocates a
+        # fresh sample store at every lap boundary.
+        self._best_ref: Samples | None = None
         self._clients: set[WebSocket] = set()
         self._last_ws_send = 0.0
         self._ws_interval = 1.0 / settings.ws_rate
@@ -101,6 +106,7 @@ class TelemetryService:
         self.track_name = ""
         self._session_best_ms = None
         self._prev_best_ms = None
+        self._best_ref = None
         log.info("new session %s (car %s)", self.session_id, self.cars.name(info.car_id))
         await self._broadcast({"type": "session", "data": await self.status()})
 
@@ -149,6 +155,7 @@ class TelemetryService:
             )
         if self._session_best_ms is None or lap.time_ms < self._session_best_ms:
             self._session_best_ms = lap.time_ms
+            self._best_ref = {"dist": lap.samples["dist"], "t": lap.samples["t"]}
 
         # Track auto-identification from the first completed lap's geometry
         if not self.track_name:
@@ -200,6 +207,13 @@ class TelemetryService:
     def _live_frame(self, p: TelemetryPacket) -> dict[str, Any]:
         """Compact frame for the live view (~30 Hz)."""
         session = self.processor.session
+        live = self.processor.live_lap_samples
+        elapsed_ms = round(live["t"][-1] * 1000) if live["t"] else -1
+        delta_ms: float | None = None
+        if self._best_ref is not None and live["t"] and p.is_on_track and not p.is_paused:
+            delta_ms = time_delta_at(live["dist"][-1], live["t"][-1], self._best_ref)
+            if delta_ms is not None:
+                delta_ms = round(delta_ms)
         return {
             "on_track": p.is_on_track,
             "paused": p.is_paused,
@@ -232,6 +246,8 @@ class TelemetryService:
             "car_name": self.cars.name(p.car_id),
             "session_best_ms": session.best_lap_time_ms if session else -1,
             "prev_best_ms": self._prev_best_ms if self._prev_best_ms is not None else -1,
+            "delta_ms": delta_ms,
+            "lap_elapsed_ms": elapsed_ms,
             "pos_x": round(p.position_x, 2),
             "pos_z": round(p.position_z, 2),
             "tod_ms": p.day_progression_ms,

--- a/backend/tests/test_live_delta.py
+++ b/backend/tests/test_live_delta.py
@@ -1,0 +1,118 @@
+"""Live delta-to-best: the mid-lap gap vs the session-best lap's trace."""
+
+import pytest
+
+from app.config import Settings
+from app.models import SimulatorFlags
+from app.processing.analysis import time_delta_at
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+
+
+# --- pure helper ------------------------------------------------------------
+
+
+def test_time_delta_at_sign_and_interpolation() -> None:
+    # Reference: 1 m/s — t == dist numerically.
+    ref = {"dist": [0.0, 10.0, 20.0], "t": [0.0, 10.0, 20.0]}
+    # On pace at the same point
+    assert time_delta_at(10.0, 10.0, ref) == 0.0
+    # 2 s behind, halfway between samples (interpolated ref t = 15)
+    assert time_delta_at(15.0, 17.0, ref) == pytest.approx(2000.0)
+    # 3 s ahead
+    assert time_delta_at(5.0, 2.0, ref) == pytest.approx(-3000.0)
+
+
+def test_time_delta_at_edges() -> None:
+    assert time_delta_at(5.0, 5.0, {"dist": [], "t": []}) is None
+    # Past the reference's final sample: no comparison, not a clamped one
+    ref = {"dist": [0.0, 10.0], "t": [0.0, 10.0]}
+    assert time_delta_at(10.5, 11.0, ref) is None
+    assert time_delta_at(10.0, 12.0, ref) == pytest.approx(2000.0)
+
+
+# --- through the service ----------------------------------------------------
+
+
+@pytest.fixture
+async def service(tmp_path):
+    settings = Settings(source="udp", db_path=tmp_path / "test.db", ws_rate=1000)
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    svc = TelemetryService(settings, repo, CarDatabase())
+    svc.processor.min_lap_ticks = 1
+    yield svc
+    await engine.dispose()
+
+
+def packet(lap: int, speed: float, last_ms: int = -1):
+    return parse_packet(
+        build_packet(
+            current_lap=lap,
+            speed_mps=speed,
+            last_lap_time_ms=last_ms,
+            flags=ON_TRACK,
+            car_id=7,
+        )
+    )
+
+
+async def drive(service: TelemetryService, lap: int, speed: float, ticks: int):
+    p = None
+    for _ in range(ticks):
+        p = packet(lap, speed)
+        await service._on_packet(p)
+    return p
+
+
+async def test_live_delta_null_without_reference(service) -> None:
+    p = await drive(service, lap=1, speed=40.0, ticks=30)
+    frame = service._live_frame(p)
+    assert frame["delta_ms"] is None
+    assert frame["lap_elapsed_ms"] > 0
+
+
+async def test_live_delta_tracks_pace_vs_session_best(service) -> None:
+    # Lap 1 at 40 m/s becomes the session best (and the delta reference)
+    await drive(service, lap=1, speed=40.0, ticks=60)
+    await service._on_packet(packet(lap=2, speed=40.0, last_ms=59_000))
+    assert service._best_ref is not None
+
+    # Faster than the reference: gaining time, delta negative
+    p = await drive(service, lap=2, speed=50.0, ticks=20)
+    fast = service._live_frame(p)["delta_ms"]
+    assert fast is not None and fast < 0
+
+    # Complete lap 2 (slower time keeps lap 1 as the reference)
+    await service._on_packet(packet(lap=3, speed=40.0, last_ms=60_000))
+
+    # Slower than the reference: losing time, delta positive
+    p = await drive(service, lap=3, speed=30.0, ticks=20)
+    slow = service._live_frame(p)["delta_ms"]
+    assert slow is not None and slow > 0
+
+
+async def test_live_delta_null_past_reference_distance(service) -> None:
+    # Reference covers 60 ticks * 40/60 = 40 m
+    await drive(service, lap=1, speed=40.0, ticks=60)
+    await service._on_packet(packet(lap=2, speed=40.0, last_ms=59_000))
+    # 60 ticks at 50 m/s = 50 m > the reference's 40 m
+    p = await drive(service, lap=2, speed=50.0, ticks=60)
+    assert service._live_frame(p)["delta_ms"] is None
+
+
+async def test_live_delta_reference_resets_with_session(service) -> None:
+    await drive(service, lap=1, speed=40.0, ticks=60)
+    await service._on_packet(packet(lap=2, speed=40.0, last_ms=59_000))
+    assert service._best_ref is not None
+    # Car change starts a new session — the old trace must not leak into it
+    await service._on_packet(
+        parse_packet(build_packet(current_lap=1, speed_mps=40.0, flags=ON_TRACK, car_id=42))
+    )
+    assert service._best_ref is None

--- a/docs/guide/dash.md
+++ b/docs/guide/dash.md
@@ -22,6 +22,11 @@ waiting), next to a **⛶ fullscreen** toggle.
 - **Race engineer** (default) — alerts banner across the top; fuel laps remaining,
   pit-window countdown, live Δ-to-best, and lap times in the middle; tire temps + slip,
   detailed engine health, position, clock, driver-aid badges, and speed below.
+
+The **delta ticks live during the lap**: once a session-best lap exists, it shows the
+gap at your current track position vs where the best lap was at the same point
+(green = gaining, red = losing). On the first lap of a session — before any reference
+exists — it falls back to the end-of-lap comparison, labeled *Δ best (last lap)*.
 - **Endurance** — fuel is the hero readout, with a wide engine-health panel, fuel
   summary, clock, position, and lap times.
 

--- a/docs/guide/dash.md
+++ b/docs/guide/dash.md
@@ -52,3 +52,7 @@ first. Critical banners pulse red; warnings are amber; info is blue.
 Fuel projections use the rolling 3-lap average, the same numbers as the strategy
 widget. Alerts are suppressed while off-track or paused, so menus don't scream at you.
 The engine and tire widgets color their readouts with the same thresholds.
+
+Every widget's styles, thresholds, and behavior under each track condition (paused,
+menus, first lap, race finished, lost telemetry, …) are documented in the
+[widget reference](widgets.md).

--- a/docs/guide/overlay.md
+++ b/docs/guide/overlay.md
@@ -77,6 +77,9 @@ version are detected on first visit and can be imported in bulk.
 The `alerts` widget renders nothing while all is well, so it stays invisible in OBS
 until a warning actually fires.
 
+Full details for every widget — color thresholds, alert triggers, and behavior in
+each track condition — are in the [widget reference](widgets.md).
+
 ## Setting up OBS
 
 1. Build and **save** your layout, then copy the *Other devices* URL.

--- a/docs/guide/overlay.md
+++ b/docs/guide/overlay.md
@@ -63,7 +63,7 @@ version are detected on first visit and can be imported in bulk.
 | `rpm` | bar with `SHIFT` cue · shift-light LED strip · gauge · digits |
 | `inputs` | horizontal throttle/brake bars · vertical bars |
 | `times` | lap / best / last list · last lap (big) · best lap (big) |
-| `delta` | big Δ-to-best number · centered ± bar |
+| `delta` | live Δ vs the session-best lap (big number · centered ± bar) |
 | `position` | big `P n/total` · compact |
 | `tires` | 2×2 color-coded temps · temps + slip indicator |
 | `fuel` | percent · bar · laps remaining |

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -1,0 +1,193 @@
+# Widget reference
+
+Every widget available on the [overlay](overlay.md) grid and the
+[driver dashboard](dash.md), with its styles, color rules, and how it behaves in each
+track condition. Sizes are grid-cell footprints (w × h); the first listed size is the
+default when a widget is added in the builder.
+
+## Driving
+
+### Gear — `gear`
+
+| Style | Shows |
+| --- | --- |
+| Digit + suggested (default) | current gear, with `→ n` hint when GT7 suggests a downshift |
+| Digit only | current gear, no hint |
+
+Sizes 1×1 · 1×2 · 2×2 · 4×4. Special values: **R** = reverse, **N** = neutral. The
+suggested-gear hint disappears when GT7 isn't suggesting one.
+
+### Speed — `speed`
+
+| Style | Shows |
+| --- | --- |
+| Digits (default) | speed in your units (km/h / mph, set in the header) |
+| Bar | digits + horizontal bar, full scale 320 km/h |
+| Gauge | 240° arc gauge, full scale 320 km/h |
+
+Sizes 1×1 · 2×1 · 1×2 · 2×2 · 4×4.
+
+### RPM — `rpm`
+
+| Style | Shows |
+| --- | --- |
+| Bar (default) | fill vs the car's redline; turns red with a **SHIFT** cue at ≥ 95 % |
+| Shift lights | 10-LED strip filling from 55 % of redline (green → amber → red), all LEDs flash on the limiter |
+| Gauge | arc gauge in ×1000 rpm, red near the limit |
+| Digits | raw rpm, red near the limit |
+
+Sizes 2×1 · 4×1 · 2×2 · 4×2 · 4×4. The redline comes from the car itself
+(`rpm_alert`), so the thresholds adapt per car.
+
+### Throttle / brake — `inputs`
+
+| Style | Shows |
+| --- | --- |
+| Horizontal bars (default) | throttle (green) over brake (red), 0–100 % |
+| Vertical bars | side-by-side T/B columns |
+
+Sizes 2×1 · 4×1 · 1×2 · 2×2.
+
+### Boost — `boost`
+
+| Style | Shows |
+| --- | --- |
+| Digits (default) | manifold boost in bar, 2 decimals |
+| Gauge | arc gauge, full scale 2.0 bar |
+
+Sizes 1×1 · 2×1 · 2×2. Naturally-aspirated cars sit at ~0.
+
+## Timing
+
+### Lap times — `times`
+
+| Style | Shows |
+| --- | --- |
+| Lap / best / last (default) | lap counter, session best (blue), last lap with its Δ vs the best before it (green/red) |
+| Last lap (big) | last lap time large, Δ in the caption |
+| Best lap (big) | best lap time large, in the accent color |
+
+Sizes 2×1 · 2×2 · 4×2. `–:––.–––` until the first lap completes.
+
+### Delta — `delta`
+
+| Style | Shows |
+| --- | --- |
+| Big number (default) | the live gap, green (gaining) / red (losing), signed to 3 dp |
+| Centered bar | the same number over a ± bar, full deflection at 2.0 s |
+
+Sizes 1×1 · 2×1 · 2×2 · 4×4. **Live**: once a session-best lap exists, the value is
+your gap *right now* — current elapsed time vs where the best lap was at the same
+distance, updated every frame. Positive = slower. Falls back to the end-of-lap
+comparison (caption *Δ best (last lap)*) when the live gap is unavailable — see
+[track conditions](#track-conditions) below.
+
+## Race
+
+### Race position — `position`
+
+| Style | Shows |
+| --- | --- |
+| Big (default) | `P n` with `/total` |
+| Compact | one-line `P n/total` |
+
+Sizes 1×1 · 2×1 · 2×2. Only meaningful in races (time trials report P1/1).
+
+### In-game clock — `clock`
+
+Single style: the in-game time of day (GT7's day progression), `HH:MM`. Useful in
+endurance races with accelerated day cycles. Sizes 1×1 · 2×1.
+
+### Race alerts — `alerts`
+
+| Style | Shows |
+| --- | --- |
+| Banner (default) | stacked full-width callouts, most critical first |
+| List | compact text lines |
+
+Sizes 4×1 · 8×1 · 2×1 · 4×2 · 2×2. Severity styling: **critical** pulses red,
+**warning** is amber, **info** is blue. Renders *nothing* while all is well — the cell
+stays transparent in OBS. Every trigger:
+
+| Alert | Severity | Fires when |
+| --- | --- | --- |
+| `FUEL n LAPS` | warning / critical | projected fuel < 3 laps / < 1.5 laps |
+| `PIT THIS LAP` / `PIT NEXT LAP` | info | the projected pit lap is upon you (lapped races only, and only when the fuel doesn't last to the end) |
+| `Water n °C` | warning / critical | > 110 °C / > 120 °C |
+| `Oil n °C` | warning / critical | > 130 °C / > 140 °C |
+| `OIL PRESSURE n bar` | critical | < 2.0 bar with the engine above 2000 rpm |
+| `Tires hot n °C` | warning | any tire > 110 °C |
+
+All alerts are suppressed while paused or off-track, so menus stay quiet.
+
+## Car health
+
+### Tire temps — `tires`
+
+| Style | Shows |
+| --- | --- |
+| Temps (default) | 2×2 per-corner grid (FL FR / RL RR), °C |
+| Temps + slip | the grid plus the combined slip ratio, red when > ×1.10 (wheelspin/lockup) |
+
+Sizes 1×1 · 1×2 · 2×2 · 4×4. Color coding: **blue** < 55 °C (cold), **green**
+55–95 °C (working range), **red** > 95 °C (overheating).
+
+### Engine temps — `engine`
+
+| Style | Shows |
+| --- | --- |
+| Water / oil (default) | water and oil temperature |
+| Detailed | + oil pressure and boost |
+
+Sizes 1×1 · 2×1 · 2×2 · 4×2. Values color amber/red at the same thresholds the alerts
+fire at (water 110/120 °C, oil 130/140 °C, oil pressure < 2.0 bar under load). Oil
+pressure shows `–` when the car doesn't report it.
+
+### Driver aids — `aids`
+
+Single style: TCS / ASM / HB / LIM badges that light while the aid is actively
+intervening — **TCS**/**ASM** amber, **HB** (handbrake) blue, **LIM** (rev limiter)
+red; dim when inactive. Sizes 2×1 · 1×1 · 4×1.
+
+## Strategy
+
+### Fuel — `fuel`
+
+| Style | Shows |
+| --- | --- |
+| Percent (default) | tank percentage + mini bar, red below 15 % |
+| Bar | wide bar with the percentage |
+| Laps remaining | projected laps of fuel left, amber < 3 / red < 1.5 |
+
+Sizes 1×1 · 1×2 · 2×1 · 2×2 · 4×2. *Laps remaining* needs at least one completed lap
+with measurable fuel use (shows `–` until then).
+
+### Fuel strategy — `strategy`
+
+| Style | Shows |
+| --- | --- |
+| Summary (default) | laps of fuel left and `PIT ≤ L<n>` |
+| Pit window | the pit-before lap large, amber when it's this lap or the next |
+
+Sizes 2×1 · 2×2. Projections use the rolling average of the last 3 laps' fuel use;
+until a lap completes both styles show *fuel: need a lap*.
+
+## Track conditions
+
+The telemetry flags every state the game can be in; this is how the widgets respond.
+(GT7's UDP feed does **not** broadcast weather or track wetness, so conditions here
+are the drive states the telemetry actually exposes.)
+
+| Condition | What happens |
+| --- | --- |
+| **On track, driving** | everything live; the lap recorder samples at 60 Hz |
+| **Paused** | recording and the lap timer freeze; the live delta shows its fallback; alerts are suppressed |
+| **In menus / replay (off track)** | same as paused — no samples, no alerts, delta falls back |
+| **First lap of a session** | no reference lap yet: delta shows `–` (or *Δ best (last lap)* once a lap has completed but not yet been beaten into a reference), fuel projections show *need a lap* |
+| **Session best set** | that lap's trace becomes the live-delta reference; a new best replaces it from the next lap on |
+| **Past the reference's end** | near the finish line your lap can out-distance the best lap's recording; the delta blanks instead of showing an inflated value |
+| **New session** (car change or lap counter reset) | best lap, delta reference, and strategy history reset; a session that never completes a lap is dropped |
+| **Race finished** (`current_lap > total_laps`) | lap counter shows **FIN**; sampling stops |
+| **Unlimited session** (`total_laps = 0`, e.g. practice / time trial) | lap counter shows just `n`; pit-window alerts stay off (no race end to strategize against) |
+| **No telemetry** (game closed, connection lost) | after 3 s the overlay renders nothing (clean OBS source) and the dashboard shows *Waiting for telemetry…* with a red status dot |
+| **Placeholder mode** (`demo=1`) | while telemetry is absent, an animated fake lap drives every widget (fuel drains so alerts fire); an amber tag/dot marks it, and real data takes over automatically |

--- a/frontend/src/components/widgets/DeltaWidget.tsx
+++ b/frontend/src/components/widgets/DeltaWidget.tsx
@@ -1,25 +1,26 @@
 import { formatDelta } from "@/lib/format";
 import type { WidgetRenderProps } from "@/lib/widgetMeta";
-import { Caption, lastVsPrevBest } from "./shared";
+import { Caption, liveDelta } from "./shared";
 
 // Full deflection of the bar variant, either side of zero.
 const DELTA_BAR_MS = 2000;
 
 export function DeltaWidget({ frame, variant }: WidgetRenderProps) {
-  const delta = lastVsPrevBest(frame);
+  const delta = liveDelta(frame);
+  const caption = delta == null || delta.live ? "Δ best" : "Δ best (last lap)";
 
   if (variant === "bar") {
     const frac =
-      delta == null ? 0 : Math.max(-1, Math.min(1, delta / DELTA_BAR_MS));
+      delta == null ? 0 : Math.max(-1, Math.min(1, delta.ms / DELTA_BAR_MS));
     const width = Math.abs(frac) * 50;
     return (
       <div className="flex w-full min-w-40 flex-col items-center justify-center gap-1">
         <div
           className={`text-sm font-semibold leading-none ${
-            delta == null ? "text-ink-dim" : delta <= 0 ? "text-throttle" : "text-brake"
+            delta == null ? "text-ink-dim" : delta.ms <= 0 ? "text-throttle" : "text-brake"
           }`}
         >
-          {delta == null ? "–" : formatDelta(delta)}
+          {delta == null ? "–" : formatDelta(delta.ms)}
         </div>
         <div className="relative h-3 w-full overflow-hidden rounded-full bg-white/10">
           <div className="absolute inset-y-0 left-1/2 w-px bg-white/30" />
@@ -28,7 +29,7 @@ export function DeltaWidget({ frame, variant }: WidgetRenderProps) {
             style={{ width: `${width}%` }}
           />
         </div>
-        <Caption>Δ best</Caption>
+        <Caption>{caption}</Caption>
       </div>
     );
   }
@@ -37,12 +38,12 @@ export function DeltaWidget({ frame, variant }: WidgetRenderProps) {
     <div className="flex flex-col items-center justify-center">
       <div
         className={`text-3xl font-bold leading-none ${
-          delta == null ? "text-ink-dim" : delta <= 0 ? "text-throttle" : "text-brake"
+          delta == null ? "text-ink-dim" : delta.ms <= 0 ? "text-throttle" : "text-brake"
         }`}
       >
-        {delta == null ? "–" : formatDelta(delta)}
+        {delta == null ? "–" : formatDelta(delta.ms)}
       </div>
-      <Caption>Δ best</Caption>
+      <Caption>{caption}</Caption>
     </div>
   );
 }

--- a/frontend/src/components/widgets/shared.tsx
+++ b/frontend/src/components/widgets/shared.tsx
@@ -22,6 +22,14 @@ export function lastVsPrevBest(frame: LiveFrame): number | null {
     : null;
 }
 
+// Live gap to the session-best lap while driving; before a reference lap
+// exists (or past its end) it falls back to the end-of-lap comparison.
+export function liveDelta(frame: LiveFrame): { ms: number; live: boolean } | null {
+  if (frame.delta_ms != null) return { ms: frame.delta_ms, live: true };
+  const last = lastVsPrevBest(frame);
+  return last != null ? { ms: last, live: false } : null;
+}
+
 export function lapLabel(frame: LiveFrame): string {
   if (frame.total_laps > 0 && frame.current_lap > frame.total_laps) return "FIN";
   return `${frame.current_lap}${frame.total_laps > 0 ? `/${frame.total_laps}` : ""}`;

--- a/frontend/src/lib/demoFrame.ts
+++ b/frontend/src/lib/demoFrame.ts
@@ -61,6 +61,10 @@ export function demoFrame(nowMs: number): LiveFrame {
     car_name: "Placeholder GT '26",
     session_best_ms: 111_410,
     prev_best_ms: 112_050,
+    // Fake live delta: gains through the braking zones, drifts back on the
+    // straights, so both colors and bar directions show while designing.
+    delta_ms: Math.round(400 * Math.sin((t / LOOP_S) * 2 * Math.PI) - corner(t, 5, 2.2, 300)),
+    lap_elapsed_ms: Math.round(t * 1000),
     pos_x: 0,
     pos_z: 0,
     tod_ms: (14 * 3600 + Math.floor(nowMs / 1000) * 4) * 1000, // fast in-game clock

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -29,7 +29,9 @@ export interface LiveFrame {
   car_name: string;
   session_best_ms: number;
   prev_best_ms: number; // session best BEFORE the latest lap (-1 if none)
-  delta_ms: number | null; // live gap vs the session-best lap (null = no reference)
+  // Live gap vs the session-best lap; null whenever it's unavailable (no
+  // reference lap yet, paused/off-track, or past the reference's last sample)
+  delta_ms: number | null;
   lap_elapsed_ms: number; // time into the current lap (-1 before the first sample)
   pos_x: number;
   pos_z: number;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -29,6 +29,8 @@ export interface LiveFrame {
   car_name: string;
   session_best_ms: number;
   prev_best_ms: number; // session best BEFORE the latest lap (-1 if none)
+  delta_ms: number | null; // live gap vs the session-best lap (null = no reference)
+  lap_elapsed_ms: number; // time into the current lap (-1 before the first sample)
   pos_x: number;
   pos_z: number;
   tod_ms: number;

--- a/frontend/src/views/LiveView.tsx
+++ b/frontend/src/views/LiveView.tsx
@@ -136,7 +136,7 @@ function Dashboard({ frame }: { frame: LiveFrame }) {
               <Row k="Best" v={formatLapTime(frame.best_lap_ms)} accent />
               {delta !== null && (
                 <Row
-                  k={delta.live ? "Δ best" : "Δ best (last)"}
+                  k={delta.live ? "Δ best" : "Δ best (last lap)"}
                   v={formatDelta(delta.ms)}
                   className={delta.ms <= 0 ? "text-throttle" : "text-brake"}
                 />

--- a/frontend/src/views/LiveView.tsx
+++ b/frontend/src/views/LiveView.tsx
@@ -10,6 +10,7 @@ import {
   speedUnit,
   speedValue,
 } from "@/lib/format";
+import { liveDelta } from "@/components/widgets/shared";
 import { lapColor } from "@/lib/colors";
 import { openInAnalysis } from "@/lib/router";
 import { projectStrategy } from "@/lib/strategy";
@@ -61,12 +62,10 @@ function Dashboard({ frame }: { frame: LiveFrame }) {
   const onLimiter = (aids & AIDS_REV_LIMITER) !== 0;
   const nearLimit = onLimiter || frame.rpm >= frame.rpm_alert * 0.95;
   const fuelPct = (frame.fuel_level / Math.max(1, frame.fuel_capacity)) * 100;
-  // Compare the latest lap against the best BEFORE it, so a new personal
-  // best shows its improvement instead of +0.000.
-  const lastVsBest =
-    frame.last_lap_ms > 0 && frame.prev_best_ms > 0
-      ? frame.last_lap_ms - frame.prev_best_ms
-      : null;
+  // Live gap to the session-best lap; before a reference exists this is the
+  // latest lap vs the best BEFORE it, so a new personal best shows its
+  // improvement instead of +0.000.
+  const delta = liveDelta(frame);
   const finished = frame.total_laps > 0 && frame.current_lap > frame.total_laps;
 
   return (
@@ -135,11 +134,11 @@ function Dashboard({ frame }: { frame: LiveFrame }) {
             <div className="mt-2 space-y-1 font-tabular text-sm">
               <Row k="Last" v={formatLapTime(frame.last_lap_ms)} />
               <Row k="Best" v={formatLapTime(frame.best_lap_ms)} accent />
-              {lastVsBest !== null && (
+              {delta !== null && (
                 <Row
-                  k="Δ best"
-                  v={formatDelta(lastVsBest)}
-                  className={lastVsBest <= 0 ? "text-throttle" : "text-brake"}
+                  k={delta.live ? "Δ best" : "Δ best (last)"}
+                  v={formatDelta(delta.ms)}
+                  className={delta.ms <= 0 ? "text-throttle" : "text-brake"}
                 />
               )}
             </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
       - Sessions view: guide/sessions-view.md
       - Overlay & streaming: guide/overlay.md
       - Driver dashboard: guide/dash.md
+      - Widget reference: guide/widgets.md
       - Admin view: guide/admin.md
   - How it works:
       - Architecture: internals/architecture.md


### PR DESCRIPTION
## What

The delta widget previously only updated when a lap completed (`last_lap_ms - prev_best_ms`). It now ticks **live during the lap**: the gap between your current track position and where the session-best lap was at the same point.

## How

- `TelemetryService` retains the session-best lap's `(dist, t)` trace when a `CompletedLap` becomes the best (safe by reference — the processor re-allocates its sample store at every lap boundary). Cleared on session change.
- Every live frame computes `delta_ms = t_now - t_ref(dist_now)` using a new `analysis.time_delta_at()` — the single-point form of the interpolation the Analysis view's delta chart already uses (positive = slower). Frames also gain `lap_elapsed_ms`.
- `delta_ms` is `null` (widget shows the fallback) when: no reference lap yet, paused/off-track, or the current lap has run past the reference's final sample (edge clamping would otherwise inflate the gap 1 ms/ms).
- Frontend: `liveDelta()` helper in `widgets/shared.tsx` — live gap when available, else the old end-of-lap comparison labeled *Δ best (last lap)*. Used by DeltaWidget (both variants) and the Live view card. Demo mode fakes a swinging delta so both colors show.

## Testing

- 6 new backend tests (`test_live_delta.py`): pure-helper sign/interpolation/edge cases, plus service-level tests driving laps at different speeds — faster lap → negative delta, slower → positive, null before a reference / past its end / after a session reset. Full suite: 74 passed; ruff + strict mypy clean.
- `npm run lint && npm run build` clean.
- Verified against the simulator: lap 1 shows "–", from lap 2 the delta ticks continuously (observed +0.377 → +0.452 → +0.502 over 10 s on a slower lap, matching the sim's per-lap pace jitter).

## Docs

Overlay widget table, dash guide (live-delta explanation), and a new `[Unreleased]` changelog entry.