### PR TITLE
Release 0.3.0: packet B/~/C support, race-event webhooks, security & robustness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,24 @@
 Notable changes to GT7 Datalogger. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.3.0] - 2026-08-04
 
 ### Added
 
+- **Extended telemetry packet support (B / `~` / C)**: the listener can request any
+  of GT7's four packet formats via the heartbeat character, decrypts each format's
+  distinct Salsa20 IV constant, and parses the extra fields — steering wheel
+  rotation, sway/heave/surge, filtered inputs, per-wheel torque vectors, energy
+  recovery, per-wheel surface type, the live lap timer, front-wheel steering angles,
+  wheelbase, and car category. Default is now packet **C** (GT7 v1.68+);
+  configurable via `GT7_PACKET_FORMAT` or live in the Admin view. The simulated
+  source emits packet C.
 - **Race-event webhooks**: in addition to personal bests and session summaries, the
   webhook can now announce **overtakes**, **positions lost**, and **off-road
   excursions** (3+ wheels on a loose surface — requires packet format C). Position
   changes must hold ~1 s before firing so side-by-side battles don't spam. Every
   event type has a toggle in Admin → Notifications (`GT7_WEBHOOK_EVENTS` for
   env-based setups).
-- Admin view polish: per-event notification toggles with plain-language hints, and
-  descriptive subtitles on every panel.
 - **Opt-in admin auth**: set `GT7_ADMIN_TOKEN` to require a token (`X-API-Key`
   header) for the Admin API and every destructive/mutating endpoint; overlay, dash,
   and read endpoints stay open. The UI stores the token per browser and prompts on
@@ -22,6 +28,8 @@ Notable changes to GT7 Datalogger. The format follows
 - `GT7_CORS_ORIGINS` for cross-origin API consumers (see Breaking below).
 - `frames_dropped` counter in `/api/status` and the Admin diagnostics — 60 Hz frames
   the console numbered but the network lost.
+- Admin view polish: per-event notification toggles with plain-language hints, and
+  descriptive subtitles on every panel.
 
 ### Changed
 
@@ -34,9 +42,15 @@ Notable changes to GT7 Datalogger. The format follows
 - Lap CSV export is written with a proper CSV writer and neutralizes spreadsheet
   formula injection in text cells.
 - The sessions list is a single aggregate query (was one query per session).
+- `dev.sh` rebuilds the frontend on every start, so `:8000` always serves the
+  current UI instead of a stale `dist`.
 
 ### Fixed
 
+- **Fuel strategy widgets no longer mix sessions**: on a car change or race restart
+  the lap feed is pruned to the new session, so "laps of fuel" / "pit before" no
+  longer average fuel consumption from the previous car or track for the first laps
+  of a session.
 - Lap imports are validated (required columns, equal lengths, finite numbers, size
   cap) and return a clear 400 instead of storing a file that breaks analysis with a
   500 later; a rejected import no longer creates an empty session.
@@ -53,22 +67,6 @@ Notable changes to GT7 Datalogger. The format follows
 - The API no longer sends wildcard CORS headers. The bundled UI is unaffected
   (same-origin in both dev and prod). Separate cross-origin consumers must set
   `GT7_CORS_ORIGINS`.
-
-- **Extended telemetry packet support (B / `~` / C)**: the listener can request any
-  of GT7's four packet formats via the heartbeat character, decrypts each format's
-  distinct Salsa20 IV constant, and parses the extra fields — steering wheel
-  rotation, sway/heave/surge, filtered inputs, per-wheel torque vectors, energy
-  recovery, per-wheel surface type, the live lap timer, front-wheel steering angles,
-  wheelbase, and car category. Default is now packet **C** (GT7 v1.68+);
-  configurable via `GT7_PACKET_FORMAT` or live in the Admin view. The simulated
-  source emits packet C.
-
-### Fixed
-
-- **Fuel strategy widgets no longer mix sessions**: on a car change or race restart
-  the lap feed is pruned to the new session, so "laps of fuel" / "pit before" no
-  longer average fuel consumption from the previous car or track for the first laps
-  of a session.
 
 ## [0.2.1] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 Notable changes to GT7 Datalogger. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **Race-event webhooks**: in addition to personal bests and session summaries, the
+  webhook can now announce **overtakes**, **positions lost**, and **off-road
+  excursions** (3+ wheels on a loose surface — requires packet format C). Position
+  changes must hold ~1 s before firing so side-by-side battles don't spam. Every
+  event type has a toggle in Admin → Notifications (`GT7_WEBHOOK_EVENTS` for
+  env-based setups).
+- Admin view polish: per-event notification toggles with plain-language hints, and
+  descriptive subtitles on every panel.
+
+- **Extended telemetry packet support (B / `~` / C)**: the listener can request any
+  of GT7's four packet formats via the heartbeat character, decrypts each format's
+  distinct Salsa20 IV constant, and parses the extra fields — steering wheel
+  rotation, sway/heave/surge, filtered inputs, per-wheel torque vectors, energy
+  recovery, per-wheel surface type, the live lap timer, front-wheel steering angles,
+  wheelbase, and car category. Default is now packet **C** (GT7 v1.68+);
+  configurable via `GT7_PACKET_FORMAT` or live in the Admin view. The simulated
+  source emits packet C.
+
+### Fixed
+
+- **Fuel strategy widgets no longer mix sessions**: on a car change or race restart
+  the lap feed is pruned to the new session, so "laps of fuel" / "pit before" no
+  longer average fuel consumption from the previous car or track for the first laps
+  of a session.
+
 ## [0.2.1] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,44 @@ Notable changes to GT7 Datalogger. The format follows
   env-based setups).
 - Admin view polish: per-event notification toggles with plain-language hints, and
   descriptive subtitles on every panel.
+- **Opt-in admin auth**: set `GT7_ADMIN_TOKEN` to require a token (`X-API-Key`
+  header) for the Admin API and every destructive/mutating endpoint; overlay, dash,
+  and read endpoints stay open. The UI stores the token per browser and prompts on
+  401. Unset = fully open, as before.
+- `GT7_CORS_ORIGINS` for cross-origin API consumers (see Breaking below).
+- `frames_dropped` counter in `/api/status` and the Admin diagnostics — 60 Hz frames
+  the console numbered but the network lost.
+
+### Changed
+
+- **Lap timing is robust to packet loss**: the time/distance axes integrate the
+  console's packet counter (gaps clamped to 1 s) instead of assuming a perfect
+  60 Hz stream, and input percentages are time-weighted accordingly.
+- **Per-client WebSocket queues**: a slow or stalled viewer (browser, OBS) can no
+  longer stall telemetry capture — it just misses intermediate frames; lap and
+  session events are never dropped.
+- Lap CSV export is written with a proper CSV writer and neutralizes spreadsheet
+  formula injection in text cells.
+- The sessions list is a single aggregate query (was one query per session).
+
+### Fixed
+
+- Lap imports are validated (required columns, equal lengths, finite numbers, size
+  cap) and return a clear 400 instead of storing a file that breaks analysis with a
+  500 later; a rejected import no longer creates an empty session.
+- Restarting or switching the telemetry source fully awaits task shutdown and port
+  release — no more races when rebinding UDP 33740.
+
+### Security
+
+- Webhook requests never follow redirects, and the webhook trust model is
+  documented (LAN targets are intentional; the admin token guards configuration).
+
+### Breaking
+
+- The API no longer sends wildcard CORS headers. The bundled UI is unaffected
+  (same-origin in both dev and prod). Separate cross-origin consumers must set
+  `GT7_CORS_ORIGINS`.
 
 - **Extended telemetry packet support (B / `~` / C)**: the listener can request any
   of GT7's four packet formats via the heartbeat character, decrypts each format's

--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ per-feature guides, how every calculation works, and the API reference.
   (persisted in the database), live log viewer with level filtering, connection
   diagnostics, database stats with compact/clear actions, and one-click car-database
   updates.
-- **Webhook / Discord notifications** — new personal bests and end-of-session summaries
-  posted to any webhook URL (Discord URLs get a rich embed, others plain JSON).
+- **Webhook / Discord notifications** — personal bests, session summaries, overtakes,
+  positions lost, and off-road excursions posted to any webhook URL (Discord URLs get
+  a rich embed, others plain JSON), each event individually toggleable.
 - Configurable units (km/h / mph), persisted in the browser; dark-themed responsive UI
   built on accessible primitives with a colorblind-validated chart palette.
 

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -7,10 +7,11 @@ import time
 from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app import logbuffer
+from app.api.auth import require_admin
 from app.notify import ALL_EVENTS
 
 if TYPE_CHECKING:
@@ -18,7 +19,10 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/admin")
+# The whole router is token-gated (when a token is configured): even the
+# GETs leak secrets — /settings returns the webhook URL, which for Discord
+# is itself a write credential; /stats and /logs expose LAN details.
+router = APIRouter(prefix="/api/admin", dependencies=[Depends(require_admin)])
 
 CARS_URL = "https://raw.githubusercontent.com/ddm999/gt7info/web-new/_data/db/cars.csv"
 

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app import logbuffer
+from app.notify import ALL_EVENTS
 
 if TYPE_CHECKING:
     from app.service import TelemetryService
@@ -41,6 +42,8 @@ async def get_settings(request: Request) -> dict[str, Any]:
         "heartbeat_port": s.heartbeat_port,
         "telemetry_port": s.telemetry_port,
         "webhook_url": s.webhook_url,
+        "webhook_events": [e for e in ALL_EVENTS if e in s.enabled_webhook_events()],
+        "packet_format": s.packet_format,
     }
 
 
@@ -49,6 +52,11 @@ class SettingsPayload(BaseModel):
     source: Literal["udp", "sim"] | None = None
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] | None = None
     webhook_url: str | None = Field(default=None, max_length=500)
+    webhook_events: (
+        list[Literal["personal_best", "session_summary", "overtake", "position_lost", "off_road"]]
+        | None
+    ) = None
+    packet_format: Literal["A", "B", "~", "C"] | None = None
 
 
 @router.put("/settings")
@@ -67,6 +75,14 @@ async def put_settings(request: Request, payload: SettingsPayload) -> dict[str, 
         logging.getLogger().setLevel(payload.log_level)
         await service.repo.set_setting("log_level", payload.log_level)
         log.info("log level set to %s", payload.log_level)
+    if (
+        payload.packet_format is not None
+        and payload.packet_format != service.settings.packet_format
+    ):
+        # The listener reads this on every heartbeat, so it applies live.
+        service.settings.packet_format = payload.packet_format
+        await service.repo.set_setting("packet_format", payload.packet_format)
+        log.info("packet format set to %s", payload.packet_format)
     if payload.webhook_url is not None:
         url = payload.webhook_url.strip()
         if url and not url.startswith(("http://", "https://")):
@@ -75,6 +91,12 @@ async def put_settings(request: Request, payload: SettingsPayload) -> dict[str, 
         service.notifier.url = url
         await service.repo.set_setting("webhook_url", url)
         log.info("webhook %s", "configured" if url else "disabled")
+    if payload.webhook_events is not None:
+        spec = ",".join(dict.fromkeys(payload.webhook_events))  # dedupe, keep order
+        service.settings.webhook_events = spec
+        service.notifier.enabled = service.settings.enabled_webhook_events()
+        await service.repo.set_setting("webhook_events", spec)
+        log.info("webhook events: %s", spec or "none")
     return await get_settings(request)
 
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,33 @@
+"""Opt-in admin token gate for mutating and admin endpoints.
+
+With GT7_ADMIN_TOKEN unset (the default) every endpoint stays open — the
+LAN-trusted behavior this tool started with. When a token is configured,
+requests must carry it in the X-API-Key header. A custom header (rather
+than Authorization: Bearer) so reverse proxies / SSO middlewares that
+consume Authorization can't collide with it.
+
+Read-only telemetry endpoints (status, laps, analysis, the live WebSocket)
+are deliberately never gated so overlays and dash devices keep working.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import Annotated
+
+from fastapi import Header, HTTPException, Request
+
+
+async def require_admin(
+    request: Request,
+    x_api_key: Annotated[str | None, Header(alias="X-API-Key")] = None,
+) -> None:
+    # Via app.state, not the lru-cached get_settings(): tests and the admin
+    # API mutate the live Settings object the service holds.
+    token: str = request.app.state.service.settings.admin_token
+    if not token:
+        return
+    if x_api_key is None:
+        raise HTTPException(401, "admin token required (X-API-Key header)")
+    if not secrets.compare_digest(x_api_key.encode(), token.encode()):
+        raise HTTPException(403, "invalid admin token")

--- a/backend/app/api/layouts.py
+++ b/backend/app/api/layouts.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Literal
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
+
+from app.api.auth import require_admin
 
 if TYPE_CHECKING:
     from app.service import TelemetryService
@@ -58,7 +60,7 @@ async def get_layout(request: Request, ref: str) -> dict[str, Any]:
     return layout
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_admin)])
 async def create_layout(request: Request, payload: LayoutPayload) -> dict[str, Any]:
     _validate_config(payload.config)
     name = payload.name.strip()
@@ -75,7 +77,7 @@ async def create_layout(request: Request, payload: LayoutPayload) -> dict[str, A
         raise HTTPException(409, f'a layout named "{name}" already exists') from exc
 
 
-@router.put("/{layout_id}")
+@router.put("/{layout_id}", dependencies=[Depends(require_admin)])
 async def update_layout(
     request: Request, layout_id: int, patch: LayoutPatch
 ) -> dict[str, Any]:
@@ -98,7 +100,7 @@ async def update_layout(
     return updated
 
 
-@router.delete("/{layout_id}")
+@router.delete("/{layout_id}", dependencies=[Depends(require_admin)])
 async def delete_layout(request: Request, layout_id: int) -> dict[str, str]:
     await svc(request).repo.delete_layout(layout_id)
     return {"status": "deleted"}

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from app.processing import analysis
 from app.processing.laps import SAMPLE_COLUMNS
@@ -207,19 +208,79 @@ class ImportPayload(BaseModel):
     lap: dict[str, Any]
 
 
+# Columns every consumer indexes unconditionally (metrics, event detection,
+# distance resampling, peak/valley detection). Everything else in
+# SAMPLE_COLUMNS is optional and degrades gracefully via .get.
+REQUIRED_IMPORT_COLUMNS = frozenset(
+    {"t", "dist", "speed", "throttle", "brake", "coast", "tire_slip",
+     "body_height", "pos_x", "pos_z"}
+)
+# ~33 min at 60 Hz — roughly twice the slowest plausible GT7 lap; also caps
+# the samples_json blob at a size SQLite handles comfortably.
+MAX_IMPORT_SAMPLES = 120_000
+
+
+class LapImportModel(BaseModel):
+    """Validated shape of an exported lap file's `lap` object."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    number: int = Field(ge=0)
+    time_ms: int = Field(gt=0)
+    finished_at: str = ""
+    car_id: int = 0
+    fuel_start: float = 0.0
+    fuel_end: float = 0.0
+    max_water_temp: float = 0.0
+    max_oil_temp: float = 0.0
+    min_oil_pressure: float = -1.0
+    gearing: dict[str, Any] | None = None
+    samples: dict[str, list[float]]
+
+
+def _validate_import_samples(samples: dict[str, list[float]]) -> dict[str, list[float]]:
+    samples = {k: v for k, v in samples.items() if k in SAMPLE_COLUMNS}
+    missing = REQUIRED_IMPORT_COLUMNS - samples.keys()
+    if missing:
+        raise ValueError(f"missing sample columns: {', '.join(sorted(missing))}")
+    lengths = {len(v) for v in samples.values()}
+    if len(lengths) > 1:
+        raise ValueError("sample columns have unequal lengths")
+    n = lengths.pop()
+    if not 0 < n <= MAX_IMPORT_SAMPLES:
+        raise ValueError(f"sample count must be 1..{MAX_IMPORT_SAMPLES}, got {n}")
+    # json.loads happily parses NaN/Infinity literals; they poison metrics
+    # and can't be re-serialized as strict JSON.
+    if any(not math.isfinite(v) for col in samples.values() for v in col):
+        raise ValueError("samples contain non-finite values")
+    return samples
+
+
 @router.post("/laps/import")
 async def import_lap(request: Request, payload: ImportPayload) -> dict[str, Any]:
     service = svc(request)
+    if payload.format != "gt7-datalogger-lap":
+        raise HTTPException(400, "unrecognized lap export format")
+    try:
+        lap = LapImportModel.model_validate(payload.lap)
+        lap.samples = _validate_import_samples(lap.samples)
+    except (ValidationError, ValueError) as exc:
+        raise HTTPException(400, f"invalid lap file: {exc}") from exc
+
+    # Create the fallback session only after validation, so a rejected file
+    # doesn't leak an empty "imported" session.
     if service.session_id is None:
         from app.processing.laps import SessionInfo
 
-        info = SessionInfo(car_id=payload.lap.get("car_id", 0), started_at="imported")
+        info = SessionInfo(car_id=lap.car_id, started_at="imported")
         service.session_id = await service.repo.create_session(
             info, service.cars.name(info.car_id)
         )
+    clean = payload.model_dump()
+    clean["lap"] = lap.model_dump()
     try:
-        lap_id = await service.repo.import_lap(payload.model_dump(), service.session_id)
-    except (ValueError, KeyError) as exc:
+        lap_id = await service.repo.import_lap(clean, service.session_id)
+    except (ValueError, KeyError, TypeError) as exc:
         raise HTTPException(400, f"invalid lap file: {exc}") from exc
     return {"id": lap_id}
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -8,10 +8,11 @@ import math
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from app.api.auth import require_admin
 from app.processing import analysis
 from app.processing.laps import SAMPLE_COLUMNS
 from app.processing.tracks import signature_from_samples
@@ -45,7 +46,7 @@ async def sessions(request: Request) -> list[dict[str, Any]]:
     return await svc(request).repo.list_sessions()
 
 
-@router.delete("/sessions/{session_id}")
+@router.delete("/sessions/{session_id}", dependencies=[Depends(require_admin)])
 async def delete_session(request: Request, session_id: int) -> dict[str, str]:
     await svc(request).repo.delete_session(session_id)
     return {"status": "deleted"}
@@ -82,7 +83,7 @@ async def lap_detail(
     return lap
 
 
-@router.delete("/laps/{lap_id}")
+@router.delete("/laps/{lap_id}", dependencies=[Depends(require_admin)])
 async def delete_lap(request: Request, lap_id: int) -> dict[str, str]:
     await svc(request).repo.delete_lap(lap_id)
     return {"status": "deleted"}
@@ -189,7 +190,7 @@ class TrackPayload(BaseModel):
     lap_id: int
 
 
-@router.post("/tracks")
+@router.post("/tracks", dependencies=[Depends(require_admin)])
 async def create_track(request: Request, payload: TrackPayload) -> dict[str, Any]:
     """Name the circuit a lap was driven on; future sessions auto-match it."""
     service = svc(request)
@@ -207,7 +208,7 @@ async def create_track(request: Request, payload: TrackPayload) -> dict[str, Any
     return {"id": track_id, "name": name}
 
 
-@router.delete("/tracks/{track_id}")
+@router.delete("/tracks/{track_id}", dependencies=[Depends(require_admin)])
 async def delete_track(request: Request, track_id: int) -> dict[str, str]:
     await svc(request).repo.delete_track(track_id)
     return {"status": "deleted"}
@@ -267,7 +268,7 @@ def _validate_import_samples(samples: dict[str, list[float]]) -> dict[str, list[
     return samples
 
 
-@router.post("/laps/import")
+@router.post("/laps/import", dependencies=[Depends(require_admin)])
 async def import_lap(request: Request, payload: ImportPayload) -> dict[str, Any]:
     service = svc(request)
     if payload.format != "gt7-datalogger-lap":
@@ -403,13 +404,13 @@ class RecordingPayload(BaseModel):
     recording: bool
 
 
-@router.post("/control/recording")
+@router.post("/control/recording", dependencies=[Depends(require_admin)])
 async def set_recording(request: Request, payload: RecordingPayload) -> dict[str, Any]:
     svc(request).recording = payload.recording
     return await svc(request).status()
 
 
-@router.post("/control/log-lap-now")
+@router.post("/control/log-lap-now", dependencies=[Depends(require_admin)])
 async def log_lap_now(request: Request) -> dict[str, Any]:
     result = await svc(request).log_lap_now()
     if result is None:

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import math
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
@@ -126,9 +128,18 @@ CSV_CHANNELS = (
 )
 
 
+def _csv_text(value: str) -> str:
+    """Neutralize spreadsheet formula injection in text cells."""
+    return f"'{value}" if value[:1] in ("=", "+", "-", "@") else value
+
+
 @router.get("/laps/{lap_id}/export.csv")
 async def export_lap_csv(request: Request, lap_id: int) -> PlainTextResponse:
-    """MoTeC-compatible CSV export (i2 'CSV file' import, Excel, etc.)."""
+    """MoTeC-compatible CSV export (i2 'CSV file' import, Excel, etc.).
+
+    The "Sample Rate" header is nominal — the `t` column is authoritative
+    (it integrates packet-id deltas, so dropped frames widen its steps).
+    """
     lap = await svc(request).repo.get_lap(lap_id, with_samples=True)
     if lap is None:
         raise HTTPException(404, "lap not found")
@@ -138,28 +149,28 @@ async def export_lap_csv(request: Request, lap_id: int) -> PlainTextResponse:
     duration = f"{time_ms // 60000}:{(time_ms % 60000) / 1000:06.3f}"
     car = svc(request).cars.name(lap["car_id"])
 
-    lines = [
-        '"Format","MoTeC CSV File"',
-        '"Device","GT7 Datalogger"',
-        f'"Vehicle","{car}"',
-        f'"Comment","Lap {lap["number"]} - {duration}"',
-        f'"Log Date","{lap.get("finished_at", "")}"',
-        '"Sample Rate","60.000"',
-        "",
-        ",".join(f'"{name}"' for _, name, _ in cols),
-        ",".join(f'"{unit}"' for _, _, unit in cols),
-    ]
+    buf = io.StringIO()
+    meta = csv.writer(buf, quoting=csv.QUOTE_ALL, lineterminator="\n")
+    data = csv.writer(buf, quoting=csv.QUOTE_MINIMAL, lineterminator="\n")
+    meta.writerow(["Format", "MoTeC CSV File"])
+    meta.writerow(["Device", "GT7 Datalogger"])
+    meta.writerow(["Vehicle", _csv_text(car)])
+    meta.writerow(["Comment", _csv_text(f"Lap {lap['number']} - {duration}")])
+    meta.writerow(["Log Date", _csv_text(str(lap.get("finished_at", "")))])
+    meta.writerow(["Sample Rate", "60.000"])
+    buf.write("\n")  # blank separator line between metadata and channels
+    meta.writerow([name for _, name, _ in cols])
+    meta.writerow([unit for _, _, unit in cols])
     n = len(samples["t"])
     for i in range(n):
-        lines.append(
-            ",".join(
-                str(samples[key][i]) if i < len(samples[key]) else ""
-                for key, _, _ in cols
-            )
+        # Guard against ragged legacy rows; values are numeric so
+        # QUOTE_MINIMAL leaves them unquoted.
+        data.writerow(
+            [samples[key][i] if i < len(samples[key]) else "" for key, _, _ in cols]
         )
 
     return PlainTextResponse(
-        "\n".join(lines) + "\n",
+        buf.getvalue(),
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="gt7-lap-{lap_id}.csv"'},
     )

--- a/backend/app/api/ws.py
+++ b/backend/app/api/ws.py
@@ -19,4 +19,4 @@ async def live(ws: WebSocket) -> None:
     except WebSocketDisconnect:
         pass
     finally:
-        service.unregister(ws)
+        await service.unregister(ws)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     ps_ip: str = ""  # empty -> broadcast auto-discovery
     heartbeat_port: int = 33739
     telemetry_port: int = 33740
+    # Telemetry format requested from the console: "A", "B", "~", or "C".
+    # "C" (game v1.68+) is the richest; older game versions only answer "A".
+    packet_format: str = "C"
 
     db_path: Path = Path("data/gt7.db")
     cars_csv: Path = Path("data/cars.csv")
@@ -27,9 +30,16 @@ class Settings(BaseSettings):
 
     log_level: str = "INFO"
 
-    # Webhook for personal-best / session-summary notifications
+    # Webhook for race notifications
     # (Discord webhook URLs get a rich embed; other URLs get plain JSON).
     webhook_url: str = ""
+    # Comma-separated events to send; see app.notify.ALL_EVENTS.
+    webhook_events: str = "personal_best,session_summary,overtake,position_lost,off_road"
+
+    def enabled_webhook_events(self) -> set[str]:
+        from app.notify import parse_events
+
+        return parse_events(self.webhook_events)
 
 
 @lru_cache

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,13 @@ class Settings(BaseSettings):
     http_host: str = "0.0.0.0"
     http_port: int = 8000
 
+    # When set, the Admin API and all mutating endpoints require this token
+    # (X-API-Key header). Empty = fully open (LAN-trusted, the old behavior).
+    admin_token: str = ""
+    # Comma-separated origins allowed for cross-origin API use. Empty = no
+    # CORS headers at all — the bundled UI is same-origin and needs none.
+    cors_origins: str = ""
+
     # Client stream rate (Hz). Raw capture is ~60 Hz; the UI does not need all of it.
     ws_rate: int = 30
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -76,12 +76,17 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 def create_app() -> FastAPI:
     app = FastAPI(title="GT7 Datalogger", lifespan=lifespan)
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # No CORS middleware by default: both serving modes are same-origin (the
+    # SPA is mounted below; the dev server proxies /api and /ws). Cross-origin
+    # consumers must opt in via GT7_CORS_ORIGINS.
+    origins = [o.strip() for o in get_settings().cors_origins.split(",") if o.strip()]
+    if origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_methods=["*"],
+            allow_headers=["*"],  # includes X-API-Key
+        )
     app.include_router(routes.router)
     app.include_router(admin.router)
     app.include_router(layouts.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -47,10 +47,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         settings.ps_ip = stored["ps_ip"]
     if stored.get("source") in ("udp", "sim"):
         settings.source = stored["source"]
+    if stored.get("packet_format") in ("A", "B", "~", "C"):
+        settings.packet_format = stored["packet_format"]
     if "log_level" in stored:
         logging.getLogger().setLevel(stored["log_level"])
     if "webhook_url" in stored:
         settings.webhook_url = stored["webhook_url"]
+    if "webhook_events" in stored:
+        settings.webhook_events = stored["webhook_events"]
 
     cars = CarDatabase()
     cars.load(settings.cars_csv)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -114,6 +114,24 @@ class TelemetryPacket:
 
     car_id: int
 
+    # --- Extended formats (None when the console sends plain packet A) ------
+    # Packet B (heartbeat "B") and up:
+    wheel_rotation: float | None = None  # steering wheel angle, radians
+    sway: float | None = None  # lateral acceleration
+    heave: float | None = None  # vertical acceleration
+    surge: float | None = None  # longitudinal acceleration
+    # Packet "~" and up:
+    throttle_filtered: int | None = None  # 0..255, after assists
+    brake_filtered: int | None = None  # 0..255, after assists
+    torque_vectors: tuple[float, ...] | None = None  # per wheel; + drive, - brake/regen
+    energy_recovery: float | None = None
+    # Packet C only:
+    surface_types: str | None = None  # per wheel FL FR RL RR: T/C/D/G/S/s
+    lap_time_ms: int | None = None  # live current-lap timer
+    wheel_steering_rad: tuple[float, float] | None = None  # front wheels, left/right
+    wheelbase_m: float | None = None
+    car_category: str | None = None  # e.g. "Gr3", "Gr4"
+
     @property
     def speed_kmh(self) -> float:
         return self.speed_mps * 3.6

--- a/backend/app/notify.py
+++ b/backend/app/notify.py
@@ -39,6 +39,12 @@ class Notifier:
 
     Only events in `enabled` are sent (the admin "test" event always goes
     through so the Test button works regardless of toggles).
+
+    Trust model: the webhook URL is admin-configured and deliberately may
+    point at LAN services (Home Assistant, n8n) — private ranges are NOT
+    blocked. The guard against untrusted configuration is the admin token
+    (GT7_ADMIN_TOKEN), not network filtering, and redirects are never
+    followed so a response can't re-aim the request.
     """
 
     def __init__(self) -> None:
@@ -83,7 +89,9 @@ class Notifier:
             extra = {k.lower().replace(" ", "_"): v for k, v in fields}
             payload = {"event": event, "title": title, **extra}
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
+            # follow_redirects pinned off: a redirecting response must not
+            # re-aim the webhook POST at a URL the admin never configured.
+            async with httpx.AsyncClient(timeout=10, follow_redirects=False) as client:
                 resp = await client.post(self.url, json=payload)
                 resp.raise_for_status()
             log.info("webhook sent: %s", event)

--- a/backend/app/notify.py
+++ b/backend/app/notify.py
@@ -1,4 +1,4 @@
-"""Outbound webhook notifications (personal bests, session summaries).
+"""Outbound webhook notifications (personal bests, race events, summaries).
 
 Discord webhook URLs get a rich embed; any other URL receives plain JSON with
 an `event` field, so generic automations (n8n, Home Assistant, ...) work too.
@@ -14,23 +14,43 @@ import httpx
 
 log = logging.getLogger(__name__)
 
+# Every webhook event type, in display order. Kept in sync with the Admin UI
+# toggle list (frontend AdminView) and the docs.
+ALL_EVENTS = (
+    "personal_best",
+    "session_summary",
+    "overtake",
+    "position_lost",
+    "off_road",
+)
+
+
+def parse_events(spec: str) -> set[str]:
+    """Parse a comma-separated event list, dropping unknown names."""
+    return {e.strip() for e in spec.split(",") if e.strip() in ALL_EVENTS}
+
 
 def format_lap_time(ms: int) -> str:
     return f"{ms // 60000}:{(ms % 60000) // 1000:02d}.{ms % 1000:03d}"
 
 
 class Notifier:
-    """Sends webhook events fire-and-forget; failures only log."""
+    """Sends webhook events fire-and-forget; failures only log.
+
+    Only events in `enabled` are sent (the admin "test" event always goes
+    through so the Test button works regardless of toggles).
+    """
 
     def __init__(self) -> None:
         self.url: str = ""
+        self.enabled: set[str] = set(ALL_EVENTS)
 
     @property
     def _is_discord(self) -> bool:
         return "discord.com/api/webhooks" in self.url or "discordapp.com/api/webhooks" in self.url
 
     def notify(self, event: str, title: str, fields: list[tuple[str, str]]) -> None:
-        if not self.url:
+        if not self.url or (event in ALL_EVENTS and event not in self.enabled):
             return
         asyncio.get_running_loop().create_task(self._send(event, title, fields))
 
@@ -84,6 +104,39 @@ class Notifier:
             [
                 ("Lap", str(lap_number)),
                 ("Improvement", f"-{gain:.3f}s"),
+                ("Car", car),
+                ("Track", track or "unknown"),
+            ],
+        )
+
+    def overtake(self, new_pos: int, old_pos: int, total: int, car: str, track: str) -> None:
+        self.notify(
+            "overtake",
+            f"🟢 Overtake! P{old_pos} → P{new_pos}",
+            [
+                ("Position", f"P{new_pos} of {total}"),
+                ("Car", car),
+                ("Track", track or "unknown"),
+            ],
+        )
+
+    def position_lost(self, new_pos: int, old_pos: int, total: int, car: str, track: str) -> None:
+        self.notify(
+            "position_lost",
+            f"🔻 Position lost: P{old_pos} → P{new_pos}",
+            [
+                ("Position", f"P{new_pos} of {total}"),
+                ("Car", car),
+                ("Track", track or "unknown"),
+            ],
+        )
+
+    def off_road(self, lap: int, car: str, track: str) -> None:
+        self.notify(
+            "off_road",
+            "🌿 Off-road excursion",
+            [
+                ("Lap", str(lap) if lap > 0 else "–"),
                 ("Car", car),
                 ("Track", track or "unknown"),
             ],

--- a/backend/app/processing/laps.py
+++ b/backend/app/processing/laps.py
@@ -16,8 +16,13 @@ FULL_INPUT = 250  # of 255; GT7 rarely reports exactly 255 with analog triggers
 TIRE_SPIN_THRESHOLD = 1.1
 # A "completed lap" with almost no samples is a phantom: GT7's lap counter
 # flickers through old values in menus/replays and re-reports a stale
-# last_lap_time. No real lap is shorter than this many ticks (~10 s).
+# last_lap_time. No real lap is shorter than this many samples (~10 s).
 MIN_LAP_TICKS = 600
+# Time/distance integrate packet_id deltas so dropped datagrams don't shrink
+# the axes. Gaps beyond this (>1 s) are a discontinuity (source restart, pid
+# reset, long outage) — extrapolating a minute of distance at current speed
+# would corrupt the lap worse than under-counting one frame does.
+MAX_FRAME_GAP = 60
 
 # Columnar per-tick series kept for each lap. Column order matters for the
 # frontend; keep in sync with frontend/src/lib/types.ts.
@@ -34,6 +39,19 @@ SAMPLE_COLUMNS = (
 
 def new_sample_store() -> dict[str, list[float]]:
     return {c: [] for c in SAMPLE_COLUMNS}
+
+
+def _time_weights(t: list[float]) -> list[float]:
+    """Per-sample durations from t deltas; uniform when too short to tell.
+
+    Metrics weight samples by how much time each one covered, so a sample
+    recorded after a dropped-frame gap counts for the whole gap instead of
+    skewing percentages toward whatever happened while packets flowed.
+    """
+    if len(t) < 2:
+        return [1.0] * len(t)
+    w = [max(t[i] - t[i - 1], 0.0) for i in range(1, len(t))]
+    return [w[0], *w]  # first sample inherits the first interval
 
 
 @dataclass(slots=True)
@@ -77,19 +95,25 @@ class CompletedLap:
         self.total_ticks = n
         if n == 0:
             return
+        # Percentages are time-weighted: after a dropped-frame gap a sample
+        # covers the whole gap, so drops don't skew the input metrics.
+        w = _time_weights(s["t"])
+        total_w = sum(w) or 1.0
+
+        def pct(flags: list[bool]) -> float:
+            return 100.0 * sum(wi for wi, f in zip(w, flags, strict=True) if f) / total_w
+
         self.fuel_consumed = max(0.0, self.fuel_start - self.fuel_end)
-        self.full_throttle_pct = 100.0 * sum(1 for v in s["throttle"] if v >= 98.0) / n
-        self.full_brake_pct = 100.0 * sum(1 for v in s["brake"] if v >= 98.0) / n
-        self.coasting_pct = 100.0 * sum(1 for v in s["coast"] if v > 0) / n
-        self.tire_spin_pct = 100.0 * sum(
-            1 for v in s["tire_slip"] if v >= TIRE_SPIN_THRESHOLD
-        ) / n
+        self.full_throttle_pct = pct([v >= 98.0 for v in s["throttle"]])
+        self.full_brake_pct = pct([v >= 98.0 for v in s["brake"]])
+        self.coasting_pct = pct([v > 0 for v in s["coast"]])
+        self.tire_spin_pct = pct([v >= TIRE_SPIN_THRESHOLD for v in s["tire_slip"]])
         self.max_speed = max(s["speed"])
         self.min_body_height = min(s["body_height"])
         aids = s.get("aids") or []
-        if aids:
-            self.tcs_active_pct = 100.0 * sum(1 for v in aids if int(v) & AidsBits.TCS) / n
-            self.asm_active_pct = 100.0 * sum(1 for v in aids if int(v) & AidsBits.ASM) / n
+        if len(aids) == n:
+            self.tcs_active_pct = pct([bool(int(v) & AidsBits.TCS) for v in aids])
+            self.asm_active_pct = pct([bool(int(v) & AidsBits.ASM) for v in aids])
         self.events = detect_events(s)
 
 
@@ -121,7 +145,10 @@ class LapProcessor:
     _current_lap: int = -1
     _samples: dict[str, list[float]] = field(default_factory=new_sample_store)
     _distance: float = 0.0
-    _ticks: int = 0
+    _elapsed_s: float = 0.0
+    _last_pid: int = -1
+    _pending_dt: int = 1  # frames covered by the next sample (1 = no drops)
+    _dropped_frames: int = 0
     _fuel_start: float = 0.0
     _last_packet: TelemetryPacket | None = None
     # Engine-health aggregates for the lap in progress (not per-tick columns)
@@ -137,9 +164,24 @@ class LapProcessor:
     def live_lap_samples(self) -> dict[str, list[float]]:
         return self._samples
 
+    @property
+    def dropped_frames(self) -> int:
+        return self._dropped_frames
+
     async def feed(self, p: TelemetryPacket) -> None:
         if p.is_loading:
             return
+
+        # Frames covered since the previous packet, from the console's own
+        # packet counter. Tracked for EVERY non-loading packet (paused ones
+        # too) so unpausing sees a ~1-frame gap and pauses add no lap time.
+        gap = p.packet_id - self._last_pid if self._last_pid >= 0 else 1
+        self._last_pid = p.packet_id
+        if 1 <= gap <= MAX_FRAME_GAP:
+            self._pending_dt = gap
+            self._dropped_frames += gap - 1
+        else:
+            self._pending_dt = 1  # first packet, pid reset, or discontinuity
 
         if self._session is not None and p.car_id != self._session.car_id:
             log.info("car changed (%d -> %d): starting new session", self._session.car_id, p.car_id)
@@ -184,7 +226,7 @@ class LapProcessor:
         self._current_lap = p.current_lap
         self._samples = new_sample_store()
         self._distance = 0.0
-        self._ticks = 0
+        self._elapsed_s = 0.0
         self._fuel_start = p.fuel_level
         self._max_water = 0.0
         self._max_oil = 0.0
@@ -217,11 +259,14 @@ class LapProcessor:
             await self.on_lap(lap)
 
     def _append_sample(self, p: TelemetryPacket) -> None:
-        self._distance += p.speed_mps * TICK_SECONDS
         s = self._samples
+        dt_s = self._pending_dt * TICK_SECONDS
+        if s["t"]:  # the lap's first sample anchors at t=0
+            self._elapsed_s += dt_s
+        self._distance += p.speed_mps * dt_s
         throttle = round(p.throttle_pct, 1)
         brake = round(p.brake_pct, 1)
-        s["t"].append(round(self._ticks * TICK_SECONDS, 4))
+        s["t"].append(round(self._elapsed_s, 4))
         s["dist"].append(round(self._distance, 2))
         s["speed"].append(round(p.speed_kmh, 2))
         s["throttle"].append(throttle)
@@ -257,4 +302,3 @@ class LapProcessor:
                 if self._min_oil_pressure < 0
                 else min(self._min_oil_pressure, p.oil_pressure)
             )
-        self._ticks += 1

--- a/backend/app/processing/live_events.py
+++ b/backend/app/processing/live_events.py
@@ -1,0 +1,116 @@
+"""Race-event detection on the live packet stream (overtakes, off-road).
+
+Distinct from processing/events.py, which finds driving events (lockups,
+wheelspin) inside recorded lap samples — this module watches the live 60 Hz
+stream for things worth an immediate webhook notification.
+
+Detection is deliberately debounced:
+
+- A position change must hold for ~1 s before it counts. Side-by-side racing
+  makes GT7 flip the position field every few frames; without the hold, a
+  single battle would fire dozens of notifications.
+- Off-road needs >= 3 wheels on a loose surface for ~0.5 s, and re-arms only
+  after ~2 s continuously back on tarmac/kerb, so one excursion is one event.
+  This requires packet format C (the only format carrying surface data).
+
+GT7 caveat: the position field is only live in some race types — the game
+reports -1 outside them, in which case position events simply never fire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.models import TelemetryPacket
+
+# Loose surfaces per packet-C surface chars: Dirt, Grass, Sand, snow.
+# "T" (tarmac) and "C" (curb/kerb) count as on-road.
+LOOSE_SURFACES = frozenset("DGSs")
+
+POSITION_HOLD_TICKS = 60  # ~1 s at 60 Hz
+OFFROAD_MIN_TICKS = 30  # ~0.5 s
+OFFROAD_REARM_TICKS = 120  # ~2 s back on road before the next event
+OFFROAD_MIN_SPEED_MPS = 8.0  # ignore crawling/parked excursions
+OFFROAD_MIN_WHEELS = 3  # two wheels on the grass is a normal track-limits nibble
+
+
+@dataclass(slots=True)
+class LiveEvent:
+    kind: str  # "overtake" | "position_lost" | "off_road"
+    position: int = 0
+    previous_position: int = 0
+    total_positions: int = 0
+
+
+@dataclass(slots=True)
+class LiveEventWatcher:
+    """Feed packets, get race events back. Reset on every new session."""
+
+    _committed_pos: int = -1
+    _candidate_pos: int = -1
+    _candidate_ticks: int = 0
+    _offroad_ticks: int = 0
+    _onroad_ticks: int = 0
+    _offroad_armed: bool = True
+    _events: list[LiveEvent] = field(default_factory=list)
+
+    def reset(self) -> None:
+        self._committed_pos = -1
+        self._candidate_pos = -1
+        self._candidate_ticks = 0
+        self._offroad_ticks = 0
+        self._onroad_ticks = 0
+        self._offroad_armed = True
+
+    def feed(self, p: TelemetryPacket) -> list[LiveEvent]:
+        self._events = []
+        if p.is_on_track and not p.is_paused:
+            self._watch_position(p)
+            self._watch_surface(p)
+        return self._events
+
+    def _watch_position(self, p: TelemetryPacket) -> None:
+        pos = p.race_position
+        if pos < 1 or p.total_positions < 2:
+            return
+        if self._committed_pos < 1:
+            # First valid reading of the session: baseline, no event.
+            self._committed_pos = pos
+            self._candidate_pos = pos
+            return
+        if pos != self._candidate_pos:
+            self._candidate_pos = pos
+            self._candidate_ticks = 0
+            return
+        if pos == self._committed_pos:
+            return
+        self._candidate_ticks += 1
+        if self._candidate_ticks < POSITION_HOLD_TICKS:
+            return
+        kind = "overtake" if pos < self._committed_pos else "position_lost"
+        self._events.append(
+            LiveEvent(
+                kind=kind,
+                position=pos,
+                previous_position=self._committed_pos,
+                total_positions=p.total_positions,
+            )
+        )
+        self._committed_pos = pos
+        self._candidate_ticks = 0
+
+    def _watch_surface(self, p: TelemetryPacket) -> None:
+        if p.surface_types is None:
+            return  # not packet C
+        loose = sum(1 for c in p.surface_types if c in LOOSE_SURFACES)
+        if loose >= OFFROAD_MIN_WHEELS and p.speed_mps >= OFFROAD_MIN_SPEED_MPS:
+            self._onroad_ticks = 0
+            self._offroad_ticks += 1
+            if self._offroad_armed and self._offroad_ticks >= OFFROAD_MIN_TICKS:
+                self._offroad_armed = False
+                self._events.append(LiveEvent(kind="off_road"))
+        else:
+            self._offroad_ticks = 0
+            self._onroad_ticks += 1
+            if self._onroad_ticks >= OFFROAD_REARM_TICKS:
+                self._offroad_armed = True

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -305,6 +305,9 @@ class TelemetryService:
             "recording": self.recording,
             "session_id": self.session_id,
             "track_name": self.track_name,
+            # 60 Hz frames the console numbered but we never received
+            # (distinct from packets_dropped: queue overflow on our side).
+            "frames_dropped": self.processor.dropped_frames,
             **self.source.stats,
         }
 

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
 
@@ -23,6 +25,23 @@ from app.telemetry.listener import UdpTelemetrySource
 from app.telemetry.simulator import SimTelemetrySource
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _ClientStream:
+    """Per-client outbound state: a slow reader must never stall capture.
+
+    Two lanes: telemetry frames land in a 1-slot latest-wins mailbox (missing
+    intermediate frames is fine — each is a full state snapshot), while
+    lap/session/status events queue up and are never dropped. A client whose
+    event queue overflows has been unreadable for minutes and is disconnected.
+    """
+
+    ws: WebSocket
+    events: asyncio.Queue[str] = field(default_factory=lambda: asyncio.Queue(maxsize=256))
+    frame: str | None = None
+    wakeup: asyncio.Event = field(default_factory=asyncio.Event)
+    task: asyncio.Task[None] | None = None
 
 
 def _count_events(events: list[dict[str, Any]]) -> dict[str, int]:
@@ -60,7 +79,7 @@ class TelemetryService:
         # live delta. Safe to hold by reference: the processor allocates a
         # fresh sample store at every lap boundary.
         self._best_ref: Samples | None = None
-        self._clients: set[WebSocket] = set()
+        self._clients: dict[WebSocket, _ClientStream] = {}
         self._last_ws_send = 0.0
         self._ws_interval = 1.0 / settings.ws_rate
 
@@ -69,6 +88,11 @@ class TelemetryService:
 
     async def stop(self) -> None:
         await self.source.stop()
+        tasks = [c.task for c in self._clients.values() if c.task]
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._clients.clear()
 
     async def switch_source(self, kind: str) -> None:
         """Swap between the UDP and simulated source at runtime."""
@@ -80,14 +104,14 @@ class TelemetryService:
             self.source = UdpTelemetrySource(self.settings, self._on_packet)
         await self.source.start()
         log.info("telemetry source switched to %s", kind)
-        await self._broadcast({"type": "status", "data": await self.status()})
+        self._publish({"type": "status", "data": await self.status()})
 
     async def set_ps_ip(self, ip: str) -> None:
         self.settings.ps_ip = ip
         if isinstance(self.source, UdpTelemetrySource):
             self.source.reset_discovery()
         log.info("console IP set to %s", ip or "<auto-discover>")
-        await self._broadcast({"type": "status", "data": await self.status()})
+        self._publish({"type": "status", "data": await self.status()})
 
     async def restart_source(self) -> None:
         await self.switch_source(self.settings.source)
@@ -103,7 +127,7 @@ class TelemetryService:
         now = time.monotonic()
         if now - self._last_ws_send >= self._ws_interval:
             self._last_ws_send = now
-            await self._broadcast({"type": "telemetry", "data": self._live_frame(p)})
+            self._publish({"type": "telemetry", "data": self._live_frame(p)})
 
     def _notify_live_event(self, event: LiveEvent, p: TelemetryPacket) -> None:
         car = self.cars.name(p.car_id)
@@ -129,7 +153,7 @@ class TelemetryService:
         self._prev_best_ms = None
         self._best_ref = None
         log.info("new session %s (car %s)", self.session_id, self.cars.name(info.car_id))
-        await self._broadcast({"type": "session", "data": await self.status()})
+        self._publish({"type": "session", "data": await self.status()})
 
     async def _close_previous_session(self) -> None:
         """Summarize a finished session, or drop it if it never got a lap.
@@ -198,7 +222,7 @@ class TelemetryService:
             "asm_active_pct": round(lap.asm_active_pct, 1),
             "event_counts": _count_events(lap.events),
         }
-        await self._broadcast({"type": "lap", "data": summary})
+        self._publish({"type": "lap", "data": summary})
 
     async def _identify_track(self, lap: CompletedLap) -> None:
         sig = signature_from_samples(lap.samples)
@@ -209,7 +233,7 @@ class TelemetryService:
             self.track_name = name
             await self.repo.set_session_track(self.session_id, name)
             log.info("track identified: %s", name)
-            await self._broadcast({"type": "session", "data": await self.status()})
+            self._publish({"type": "session", "data": await self.status()})
 
     async def name_current_track(self, name: str, lap_samples: dict[str, list[float]]) -> None:
         """Save the current circuit under a name and tag the session with it."""
@@ -221,7 +245,7 @@ class TelemetryService:
         if self.session_id is not None:
             await self.repo.set_session_track(self.session_id, name)
         log.info("track saved: %s (%.0f m)", name, sig.length_m)
-        await self._broadcast({"type": "session", "data": await self.status()})
+        self._publish({"type": "session", "data": await self.status()})
 
     # --- live stream --------------------------------------------------------
 
@@ -289,24 +313,66 @@ class TelemetryService:
         return len(self._clients)
 
     async def register(self, ws: WebSocket) -> None:
-        self._clients.add(ws)
-        await ws.send_text(json.dumps({"type": "status", "data": await self.status()}))
+        client = _ClientStream(ws=ws)
+        self._clients[ws] = client
+        # Start the sender before enqueueing so the initial status can't be
+        # orphaned in a task-less queue.
+        client.task = asyncio.create_task(self._client_sender(client))
+        client.events.put_nowait(json.dumps({"type": "status", "data": await self.status()}))
+        client.wakeup.set()
 
-    def unregister(self, ws: WebSocket) -> None:
-        self._clients.discard(ws)
+    async def unregister(self, ws: WebSocket) -> None:
+        client = self._clients.pop(ws, None)
+        if client and client.task:
+            client.task.cancel()
+            await asyncio.gather(client.task, return_exceptions=True)
 
-    async def _broadcast(self, message: dict[str, Any]) -> None:
+    def _publish(self, message: dict[str, Any]) -> None:
+        """Queue a message for every client without awaiting any client I/O.
+
+        The capture pipeline calls this at 60 Hz; a browser that stops reading
+        only loses its own telemetry frames (latest wins) — it can never
+        backpressure lap detection or the other clients.
+        """
         if not self._clients:
             return
         text = json.dumps(message)
-        dead: list[WebSocket] = []
-        for ws in self._clients:
-            try:
-                await ws.send_text(text)
-            except Exception:
-                dead.append(ws)
-        for ws in dead:
-            self._clients.discard(ws)
+        droppable = message["type"] == "telemetry"
+        for client in list(self._clients.values()):
+            if droppable:
+                client.frame = text
+            else:
+                try:
+                    client.events.put_nowait(text)
+                except asyncio.QueueFull:
+                    # Unreadable for minutes — disconnect rather than lose
+                    # a lap/session event silently.
+                    self._drop_client(client)
+                    continue
+            client.wakeup.set()
+
+    def _drop_client(self, client: _ClientStream) -> None:
+        self._clients.pop(client.ws, None)
+        if client.task:
+            client.task.cancel()
+
+    async def _client_sender(self, client: _ClientStream) -> None:
+        """Drain one client's lanes; events always go out before frames."""
+        try:
+            while True:
+                await client.wakeup.wait()
+                client.wakeup.clear()
+                while not client.events.empty():
+                    await client.ws.send_text(client.events.get_nowait())
+                if client.frame is not None:
+                    frame, client.frame = client.frame, None
+                    await client.ws.send_text(frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Send failed — the WS endpoint's finally-unregister cleans up;
+            # also remove eagerly in case the receive side is still alive.
+            self._clients.pop(client.ws, None)
 
     # --- controls -----------------------------------------------------------
 

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -44,6 +44,14 @@ class _ClientStream:
     task: asyncio.Task[None] | None = None
 
 
+async def _close_ws(ws: WebSocket) -> None:
+    """Best-effort close; the socket may already be half-dead."""
+    try:
+        await ws.close(code=1013)  # 1013 = try again later (server overloaded)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _count_events(events: list[dict[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for e in events:
@@ -358,6 +366,9 @@ class TelemetryService:
         self._clients.pop(client.ws, None)
         if client.task:
             client.task.cancel()
+        # Close the socket too, or the /ws/live receive loop keeps an open,
+        # no-longer-tracked connection alive indefinitely.
+        asyncio.get_running_loop().create_task(_close_ws(client.ws))
 
     async def _client_sender(self, client: _ClientStream) -> None:
         """Drain one client's lanes; events always go out before frames."""
@@ -374,8 +385,10 @@ class TelemetryService:
             raise
         except Exception:
             # Send failed — the WS endpoint's finally-unregister cleans up;
-            # also remove eagerly in case the receive side is still alive.
+            # also remove eagerly and close in case the receive side is
+            # still alive on a half-broken connection.
             self._clients.pop(client.ws, None)
+            await _close_ws(client.ws)
 
     # --- controls -----------------------------------------------------------
 

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -16,6 +16,7 @@ from app.notify import Notifier
 from app.processing.analysis import Samples, time_delta_at
 from app.processing.cars import CarDatabase
 from app.processing.laps import CompletedLap, LapProcessor, SessionInfo
+from app.processing.live_events import LiveEvent, LiveEventWatcher
 from app.processing.tracks import signature_from_samples
 from app.storage.repository import Repository, lap_summary  # noqa: F401  (re-export)
 from app.telemetry.listener import UdpTelemetrySource
@@ -51,6 +52,8 @@ class TelemetryService:
         self.latest_packet: TelemetryPacket | None = None
         self.notifier = Notifier()
         self.notifier.url = settings.webhook_url
+        self.notifier.enabled = settings.enabled_webhook_events()
+        self.event_watcher = LiveEventWatcher()
         self._session_best_ms: int | None = None
         self._prev_best_ms: int | None = None
         # (dist, t) trace of the session-best lap — the reference for the
@@ -95,12 +98,30 @@ class TelemetryService:
         self.latest_packet = p
         if self.recording:
             await self.processor.feed(p)
+        for event in self.event_watcher.feed(p):
+            self._notify_live_event(event, p)
         now = time.monotonic()
         if now - self._last_ws_send >= self._ws_interval:
             self._last_ws_send = now
             await self._broadcast({"type": "telemetry", "data": self._live_frame(p)})
 
+    def _notify_live_event(self, event: LiveEvent, p: TelemetryPacket) -> None:
+        car = self.cars.name(p.car_id)
+        if event.kind == "overtake":
+            self.notifier.overtake(
+                event.position, event.previous_position, event.total_positions,
+                car, self.track_name,
+            )
+        elif event.kind == "position_lost":
+            self.notifier.position_lost(
+                event.position, event.previous_position, event.total_positions,
+                car, self.track_name,
+            )
+        elif event.kind == "off_road":
+            self.notifier.off_road(p.current_lap, car, self.track_name)
+
     async def _on_session(self, info: SessionInfo) -> None:
+        self.event_watcher.reset()
         await self._close_previous_session()
         self.session_id = await self.repo.create_session(info, self.cars.name(info.car_id))
         self.track_name = ""

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -100,26 +100,30 @@ class Repository:
             return row.id
 
     async def list_sessions(self) -> list[dict[str, Any]]:
+        # One aggregate query for all sessions; the outer join keeps lap-less
+        # sessions and only touches LapRow ids/times (never samples_json).
         async with self._sf() as db:
-            rows = (await db.execute(select(SessionRow).order_by(SessionRow.id.desc()))).scalars()
-            out = []
-            for s in rows:
-                laps = (
-                    await db.execute(select(LapRow.time_ms).where(LapRow.session_id == s.id))
-                ).scalars().all()
-                out.append(
-                    {
-                        "id": s.id,
-                        "started_at": s.started_at,
-                        "car_id": s.car_id,
-                        "car_name": s.car_name,
-                        "note": s.note,
-                        "track_name": s.track_name,
-                        "lap_count": len(laps),
-                        "best_lap_time_ms": min(laps) if laps else None,
-                    }
+            rows = (
+                await db.execute(
+                    select(SessionRow, func.count(LapRow.id), func.min(LapRow.time_ms))
+                    .outerjoin(LapRow, LapRow.session_id == SessionRow.id)
+                    .group_by(SessionRow.id)
+                    .order_by(SessionRow.id.desc())
                 )
-            return out
+            ).all()
+            return [
+                {
+                    "id": s.id,
+                    "started_at": s.started_at,
+                    "car_id": s.car_id,
+                    "car_name": s.car_name,
+                    "note": s.note,
+                    "track_name": s.track_name,
+                    "lap_count": count,
+                    "best_lap_time_ms": best,
+                }
+                for s, count, best in rows
+            ]
 
     async def session_lap_stats(self, session_id: int) -> dict[str, Any]:
         """Aggregates for a session without materializing lap rows.

--- a/backend/app/telemetry/crypto.py
+++ b/backend/app/telemetry/crypto.py
@@ -3,6 +3,10 @@
 GT7 encrypts every UDP packet with Salsa20. The 32-byte key is fixed and
 publicly known; the 8-byte nonce is derived from a 4-byte IV embedded
 (unencrypted, as part of the keystream quirk) at offset 0x40 of the packet.
+
+The IV XOR constant differs per packet format (A/B/~/C, distinguished by
+size), so decryption picks the constant matching the datagram length and
+falls back to trying the others — the magic check tells us when it worked.
 """
 
 from __future__ import annotations
@@ -11,23 +15,49 @@ import struct
 
 from Crypto.Cipher import Salsa20
 
+from app.telemetry.packet import (
+    PACKET_SIZE_A,
+    PACKET_SIZE_B,
+    PACKET_SIZE_C,
+    PACKET_SIZE_TILDE,
+)
+
 KEY = b"Simulator Interface Packet GT7 ver 0.0"[:32]
 IV_OFFSET = 0x40
-IV_XOR = 0xDEADBEAF
 MAGIC = 0x47375330  # "G7S0" little-endian
+
+# Per-format IV XOR constants (community-documented; B and C share one).
+XOR_A = 0xDEADBEAF
+XOR_B = 0xDEADBEEF
+XOR_TILDE = 0x55FABB4F
+_XOR_BY_SIZE = {
+    PACKET_SIZE_A: XOR_A,
+    PACKET_SIZE_B: XOR_B,
+    PACKET_SIZE_TILDE: XOR_TILDE,
+    PACKET_SIZE_C: XOR_B,
+}
+
+
+def _try_decrypt(data: bytes, xor: int) -> bytes | None:
+    iv1 = struct.unpack_from("<I", data, IV_OFFSET)[0]
+    iv2 = iv1 ^ xor
+    nonce = struct.pack("<II", iv2, iv1)
+    plain = Salsa20.new(key=KEY, nonce=nonce).decrypt(data)
+    if struct.unpack_from("<I", plain, 0)[0] != MAGIC:
+        return None
+    return plain
 
 
 def decrypt_packet(data: bytes) -> bytes | None:
     """Decrypt a raw GT7 UDP packet. Returns None if the result is invalid."""
     if len(data) < IV_OFFSET + 4:
         return None
-    iv1 = struct.unpack_from("<I", data, IV_OFFSET)[0]
-    iv2 = iv1 ^ IV_XOR
-    nonce = struct.pack("<II", iv2, iv1)
-    plain = Salsa20.new(key=KEY, nonce=nonce).decrypt(data)
-    if struct.unpack_from("<I", plain, 0)[0] != MAGIC:
-        return None
-    return plain
+    first = _XOR_BY_SIZE.get(len(data), XOR_A)
+    for xor in (first, *(x for x in (XOR_A, XOR_B, XOR_TILDE) if x != first)):
+        plain = _try_decrypt(data, xor)
+        if plain is not None:
+            return plain
+    return None
 
 
 def encrypt_packet(plain: bytes) -> bytes:
@@ -38,7 +68,7 @@ def encrypt_packet(plain: bytes) -> bytes:
     IV bytes remain readable — mirroring how the real packets carry it.
     """
     iv1 = struct.unpack_from("<I", plain, IV_OFFSET)[0]
-    iv2 = iv1 ^ IV_XOR
+    iv2 = iv1 ^ _XOR_BY_SIZE.get(len(plain), XOR_A)
     nonce = struct.pack("<II", iv2, iv1)
     cipher = Salsa20.new(key=KEY, nonce=nonce).encrypt(plain)
     # Restore the IV bytes in the ciphertext: decrypt_packet reads them raw.

--- a/backend/app/telemetry/listener.py
+++ b/backend/app/telemetry/listener.py
@@ -1,9 +1,11 @@
 """UDP telemetry capture from a PlayStation running GT7.
 
-Sends a heartbeat ("A") to the console every ~1.6 s (GT7 stops sending after
-100 packets without one) and receives ~60 Hz encrypted packets. If no console
-IP is configured, the heartbeat is broadcast so the console is auto-discovered
-from the first packet's source address.
+Sends a heartbeat to the console every ~1.6 s (GT7 stops sending after
+100 packets without one) and receives ~60 Hz encrypted packets. The
+heartbeat character selects the packet format ("A", "B", "~", or "C" —
+richer formats add steering, motion, surface, and lap-timer data). If no
+console IP is configured, the heartbeat is broadcast so the console is
+auto-discovered from the first packet's source address.
 """
 
 from __future__ import annotations
@@ -16,7 +18,7 @@ from collections.abc import Awaitable, Callable
 from app.config import Settings
 from app.models import TelemetryPacket
 from app.telemetry.crypto import decrypt_packet
-from app.telemetry.packet import parse_packet
+from app.telemetry.packet import HEARTBEAT_FORMATS, parse_packet
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +52,11 @@ class UdpTelemetrySource:
         return self._last_packet_at > 0 and (time.monotonic() - self._last_packet_at) < STALE_AFTER
 
     @property
+    def heartbeat_char(self) -> str:
+        fmt = self._settings.packet_format
+        return fmt if fmt in HEARTBEAT_FORMATS else "A"
+
+    @property
     def stats(self) -> dict[str, object]:
         return {
             "connected": self.connected,
@@ -57,6 +64,7 @@ class UdpTelemetrySource:
             "packets_received": self._packet_count,
             "decode_errors": self._decode_errors,
             "packets_dropped": self._dropped,
+            "packet_format": self.heartbeat_char,
         }
 
     def reset_discovery(self) -> None:
@@ -151,4 +159,4 @@ class UdpTelemetrySource:
             target = (self._console_addr[0], self._settings.heartbeat_port)
         else:
             target = ("255.255.255.255", self._settings.heartbeat_port)
-        self._transport.sendto(b"A", target)
+        self._transport.sendto(self.heartbeat_char.encode("ascii"), target)

--- a/backend/app/telemetry/listener.py
+++ b/backend/app/telemetry/listener.py
@@ -98,8 +98,17 @@ class UdpTelemetrySource:
         self._running = False
         for t in self._tasks:
             t.cancel()
+        # Wait for the heartbeat/consume tasks to actually finish before the
+        # socket goes away — a restart rebinds the same port immediately, and
+        # a half-dead consumer racing the new bind corrupts the swap.
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
         if self._transport:
             self._transport.close()
+            self._transport = None
+            # close() only schedules the socket teardown; yield so the loop
+            # actually releases the port before a restart rebinds it.
+            await asyncio.sleep(0)
 
     def _handle_datagram(self, data: bytes, addr: tuple[str, int]) -> None:
         if self._console_addr is None or self._console_addr[0] != addr[0]:

--- a/backend/app/telemetry/packet.py
+++ b/backend/app/telemetry/packet.py
@@ -1,4 +1,11 @@
-"""Binary layout of the 296-byte GT7 "A" telemetry packet."""
+"""Binary layout of the GT7 telemetry packets.
+
+Four formats exist, selected by the heartbeat character sent to the console:
+"A" (296 bytes, base), "B" (316, adds steering/motion floats), "~" (344,
+adds filtered inputs + torque vectors), and "C" (368, since game v1.68,
+adds surface types, a live lap timer, and car geometry). Each format is a
+strict superset of the previous one, so parsing keys off the packet length.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +13,12 @@ import struct
 
 from app.models import TelemetryPacket
 
-PACKET_SIZE = 296
+PACKET_SIZE_A = 296
+PACKET_SIZE_B = 316
+PACKET_SIZE_TILDE = 344
+PACKET_SIZE_C = 368
+PACKET_SIZE = PACKET_SIZE_A  # base layout, kept for existing callers
+HEARTBEAT_FORMATS = ("A", "B", "~", "C")
 MAGIC = 0x47375330
 
 # struct format for the full packet, little-endian.
@@ -58,12 +70,25 @@ _HEAD = struct.Struct(
     "i"  # 0x124 car id
 )
 
-assert _HEAD.size == PACKET_SIZE
+assert _HEAD.size == PACKET_SIZE_A
+
+# Packet "B" extension at 0x128: wheel rotation, filler, sway, heave, surge.
+_EXT_B = struct.Struct("<5f")
+# Packet "~" extension at 0x13C: filtered throttle/brake, 2 unknown bytes,
+# 4 torque-vector floats, energy recovery, 1 unknown float.
+_EXT_TILDE = struct.Struct("<4B4f2f")
+# Packet "C" extension at 0x158: per-wheel surface chars, live lap time,
+# front wheel steering angles, wheelbase, car category string.
+_EXT_C = struct.Struct("<4si2ff4s")
+
+assert PACKET_SIZE_A + _EXT_B.size == PACKET_SIZE_B
+assert PACKET_SIZE_B + _EXT_TILDE.size == PACKET_SIZE_TILDE
+assert PACKET_SIZE_TILDE + _EXT_C.size == PACKET_SIZE_C
 
 
 def parse_packet(plain: bytes) -> TelemetryPacket:
-    """Parse a decrypted 296-byte packet into the typed model."""
-    if len(plain) < PACKET_SIZE:
+    """Parse a decrypted packet (any of the A/B/~/C sizes) into the model."""
+    if len(plain) < PACKET_SIZE_A:
         raise ValueError(f"packet too short: {len(plain)} bytes")
     v = _HEAD.unpack_from(plain)
     (
@@ -104,6 +129,35 @@ def parse_packet(plain: bytes) -> TelemetryPacket:
     gear_ratios = tuple(rest[12:20])
     car_id = rest[20]
 
+    wheel_rotation = sway = heave = surge = None
+    throttle_f: int | None = None
+    brake_f: int | None = None
+    torque_vectors: tuple[float, ...] | None = None
+    energy_recovery: float | None = None
+    surface_types: str | None = None
+    lap_time_ms: int | None = None
+    wheel_steering: tuple[float, float] | None = None
+    wheelbase: float | None = None
+    car_category: str | None = None
+    if len(plain) >= PACKET_SIZE_B:
+        wheel_rotation, _filler, sway, heave, surge = _EXT_B.unpack_from(
+            plain, PACKET_SIZE_A
+        )
+    if len(plain) >= PACKET_SIZE_TILDE:
+        (
+            throttle_f, brake_f, _u1, _u2,
+            tv0, tv1, tv2, tv3,
+            energy_recovery, _u3,
+        ) = _EXT_TILDE.unpack_from(plain, PACKET_SIZE_B)
+        torque_vectors = (tv0, tv1, tv2, tv3)
+    if len(plain) >= PACKET_SIZE_C:
+        surface, lap_time_ms, steer_l, steer_r, wheelbase, category = (
+            _EXT_C.unpack_from(plain, PACKET_SIZE_TILDE)
+        )
+        surface_types = surface.decode("ascii", errors="replace")
+        wheel_steering = (steer_l, steer_r)
+        car_category = category.split(b"\x00", 1)[0].decode("ascii", errors="replace")
+
     return TelemetryPacket(
         packet_id=packet_id,
         position_x=pos_x, position_y=pos_y, position_z=pos_z,
@@ -135,6 +189,12 @@ def parse_packet(plain: bytes) -> TelemetryPacket:
         transmission_top_speed=top_speed,
         gear_ratios=gear_ratios,
         car_id=car_id,
+        wheel_rotation=wheel_rotation, sway=sway, heave=heave, surge=surge,
+        throttle_filtered=throttle_f, brake_filtered=brake_f,
+        torque_vectors=torque_vectors, energy_recovery=energy_recovery,
+        surface_types=surface_types, lap_time_ms=lap_time_ms,
+        wheel_steering_rad=wheel_steering, wheelbase_m=wheelbase,
+        car_category=car_category,
     )
 
 
@@ -173,10 +233,26 @@ def build_packet(
     gear_ratios: tuple[float, ...] = (),
     transmission_top_speed: float = 300.0,
     car_id: int = 0,
+    fmt: str = "A",
+    wheel_rotation: float = 0.0,
+    sway: float = 0.0,
+    heave: float = 0.0,
+    surge: float = 0.0,
+    throttle_filtered: int = 0,
+    brake_filtered: int = 0,
+    torque_vectors: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0),
+    energy_recovery: float = 0.0,
+    surface_types: str = "TTTT",
+    lap_time_ms: int = 0,
+    wheel_steering_rad: tuple[float, float] = (0.0, 0.0),
+    wheelbase_m: float = 2.5,
+    car_category: str = "",
 ) -> bytes:
-    """Build a plaintext packet (simulator / test fixture)."""
+    """Build a plaintext packet (simulator / test fixture) in any format."""
+    if fmt not in HEARTBEAT_FORMATS:
+        raise ValueError(f"unknown packet format {fmt!r}")
     ratios = (tuple(gear_ratios) + (0.0,) * 8)[:8]
-    return _HEAD.pack(
+    head = _HEAD.pack(
         MAGIC,
         *position,
         *velocity,
@@ -209,4 +285,21 @@ def build_packet(
         transmission_top_speed,
         *ratios,
         car_id,
+    )
+    if fmt == "A":
+        return head
+    out = head + _EXT_B.pack(wheel_rotation, 0.0, sway, heave, surge)
+    if fmt == "B":
+        return out
+    out += _EXT_TILDE.pack(
+        throttle_filtered, brake_filtered, 0, 0, *torque_vectors, energy_recovery, 0.0
+    )
+    if fmt == "~":
+        return out
+    return out + _EXT_C.pack(
+        surface_types.encode("ascii")[:4].ljust(4),
+        lap_time_ms,
+        *wheel_steering_rad,
+        wheelbase_m,
+        car_category.encode("ascii")[:4].ljust(4, b"\x00"),
     )

--- a/backend/app/telemetry/simulator.py
+++ b/backend/app/telemetry/simulator.py
@@ -56,6 +56,7 @@ class SimTelemetrySource:
             "console_ip": "simulated",
             "packets_received": self._packet_count,
             "decode_errors": 0,
+            "packet_format": "C",
         }
 
     async def start(self) -> None:
@@ -188,6 +189,18 @@ class SimTelemetrySource:
                 gear_ratios=(3.2, 2.3, 1.8, 1.4, 1.15, 0.95),
                 transmission_top_speed=290.0,
                 car_id=CAR_ID,
+                # Packet C extension: exercises the full parse path in dev.
+                fmt="C",
+                wheel_rotation=lat * 1.2,
+                sway=lat * 6.0,
+                surge=(throttle - brake) / 255 * 5.0,
+                throttle_filtered=throttle,
+                brake_filtered=brake,
+                surface_types="CTTT" if kerb else "TTTT",
+                lap_time_ms=int((tick - lap_start_tick) * TICK * 1000),
+                wheel_steering_rad=(lat * 0.3, lat * 0.3),
+                wheelbase_m=2.7,
+                car_category="GRX",
             )
             self._packet_count += 1
             await self._on_packet(parse_packet(plain))

--- a/backend/app/telemetry/simulator.py
+++ b/backend/app/telemetry/simulator.py
@@ -66,6 +66,8 @@ class SimTelemetrySource:
     async def stop(self) -> None:
         if self._task:
             self._task.cancel()
+            await asyncio.gather(self._task, return_exceptions=True)
+            self._task = None
 
     async def _run(self) -> None:
         rng = random.Random(42)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gt7-datalogger"
-version = "0.2.1"
+version = "0.3.0"
 description = "GT7 telemetry datalogger and analysis dashboard"
 license = "MIT"
 requires-python = ">=3.12"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,125 @@
+"""Opt-in admin token: gated admin/mutating endpoints, open reads, compat."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.main import create_app
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from tests.test_api import drive_laps
+
+TOKEN = "s3cret-token"
+AUTH = {"X-API-Key": TOKEN}
+
+
+async def make_client(tmp_path, admin_token: str):
+    settings = Settings(
+        source="udp",
+        db_path=tmp_path / "test.db",
+        ws_rate=1000,
+        telemetry_port=43744,
+        admin_token=admin_token,
+    )
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), service, engine
+
+
+@pytest.fixture
+async def secured(tmp_path):
+    c, service, engine = await make_client(tmp_path, TOKEN)
+    async with c:
+        yield c, service
+    await service.stop()
+    await engine.dispose()
+
+
+@pytest.fixture
+async def open_client(tmp_path):
+    c, service, engine = await make_client(tmp_path, "")
+    async with c:
+        yield c, service
+    await service.stop()
+    await engine.dispose()
+
+
+async def test_admin_get_requires_token(secured) -> None:
+    c, _ = secured
+    assert (await c.get("/api/admin/settings")).status_code == 401
+    assert (await c.get("/api/admin/settings", headers=AUTH)).status_code == 200
+
+
+async def test_wrong_token_403(secured) -> None:
+    c, _ = secured
+    resp = await c.get("/api/admin/settings", headers={"X-API-Key": "nope"})
+    assert resp.status_code == 403
+
+
+async def test_mutating_routes_require_token(secured) -> None:
+    c, service = secured
+    await drive_laps(service, laps=1)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+
+    checks = [
+        ("DELETE", f"/api/laps/{lap_id}", None),
+        ("DELETE", "/api/sessions/1", None),
+        ("POST", "/api/laps/import", {"format": "x", "version": 2, "lap": {}}),
+        ("POST", "/api/tracks", {"name": "T", "lap_id": lap_id}),
+        ("DELETE", "/api/tracks/1", None),
+        ("POST", "/api/control/recording", {"recording": True}),
+        ("POST", "/api/control/log-lap-now", None),
+        ("POST", "/api/layouts", {"name": "l", "kind": "overlay", "config": {}}),
+        ("PUT", "/api/layouts/1", {"config": {}}),
+        ("DELETE", "/api/layouts/1", None),
+        ("POST", "/api/admin/vacuum", None),
+        ("PUT", "/api/admin/settings", {"log_level": "INFO"}),
+        ("POST", "/api/admin/clear-data", None),
+    ]
+    for method, url, body in checks:
+        bare = await c.request(method, url, json=body)
+        assert bare.status_code == 401, f"{method} {url} not gated"
+        authed = await c.request(method, url, json=body, headers=AUTH)
+        assert authed.status_code != 401, f"{method} {url} rejected valid token"
+        assert authed.status_code != 403, f"{method} {url} rejected valid token"
+
+
+async def test_reads_stay_open_with_token_set(secured) -> None:
+    c, service = secured
+    await drive_laps(service, laps=1)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    for url in (
+        "/api/health",
+        "/api/status",
+        "/api/sessions",
+        "/api/laps",
+        f"/api/laps/{lap_id}/export",
+        f"/api/laps/{lap_id}/export.csv",
+        "/api/tracks",
+        "/api/layouts",
+    ):
+        assert (await c.get(url)).status_code == 200, url
+
+
+async def test_vacuum_with_token(secured) -> None:
+    c, _ = secured
+    resp = await c.post("/api/admin/vacuum", headers=AUTH)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+async def test_no_token_configured_is_fully_open(open_client) -> None:
+    c, service = open_client
+    await drive_laps(service, laps=1)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    assert (await c.get("/api/admin/settings")).status_code == 200
+    assert (await c.post("/api/admin/vacuum")).status_code == 200
+    assert (await c.delete(f"/api/laps/{lap_id}")).status_code == 200

--- a/backend/tests/test_import_validation.py
+++ b/backend/tests/test_import_validation.py
@@ -1,0 +1,120 @@
+"""Lap import validation: malformed files get a 400, never a stored 500-bomb."""
+
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.api import routes
+from app.config import Settings
+from app.main import create_app
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from tests.test_api import drive_laps
+
+
+@pytest.fixture
+async def client(tmp_path):
+    settings = Settings(
+        source="udp", db_path=tmp_path / "test.db", ws_rate=1000, telemetry_port=43743
+    )
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
+
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, service
+    await service.stop()
+    await engine.dispose()
+
+
+async def exported_lap(c, service) -> dict:
+    await drive_laps(service)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    return (await c.get(f"/api/laps/{lap_id}/export")).json()
+
+
+async def test_missing_required_column_400(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    del payload["lap"]["samples"]["dist"]
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 400
+    assert "dist" in resp.json()["detail"]
+
+
+async def test_ragged_column_lengths_400(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    payload["lap"]["samples"]["speed"] = payload["lap"]["samples"]["speed"][:-5]
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 400
+    assert "unequal" in resp.json()["detail"]
+
+
+async def test_string_sample_values_400(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    n = len(payload["lap"]["samples"]["t"])
+    payload["lap"]["samples"]["speed"] = ["fast"] * n
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 400
+
+
+async def test_non_finite_values_400(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    payload["lap"]["samples"]["speed"][0] = float("inf")
+    # json.dumps would refuse Infinity in strict mode; send it the way a
+    # hostile client would (python's default json allows it).
+    body = json.dumps(payload)
+    resp = await c.post(
+        "/api/laps/import", content=body, headers={"content-type": "application/json"}
+    )
+    assert resp.status_code == 400
+    assert "non-finite" in resp.json()["detail"]
+
+
+async def test_oversized_import_400(client, monkeypatch) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    monkeypatch.setattr(routes, "MAX_IMPORT_SAMPLES", 10)
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 400
+    assert "sample count" in resp.json()["detail"]
+
+
+async def test_samples_not_a_dict_400(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    payload["lap"]["samples"] = [1, 2, 3]
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 400
+
+
+async def test_unknown_extra_column_is_dropped(client) -> None:
+    c, service = client
+    payload = await exported_lap(c, service)
+    n = len(payload["lap"]["samples"]["t"])
+    payload["lap"]["samples"]["future_channel"] = [0.0] * n
+    resp = await c.post("/api/laps/import", json=payload)
+    assert resp.status_code == 200
+    lap = (await c.get(f"/api/laps/{resp.json()['id']}")).json()
+    assert "future_channel" not in lap["samples"]
+
+
+async def test_rejected_import_creates_no_session(client) -> None:
+    c, _service = client
+    bad = {"format": "gt7-datalogger-lap", "version": 2, "lap": {"samples": {}}}
+    resp = await c.post("/api/laps/import", json=bad)
+    assert resp.status_code == 400
+    assert (await c.get("/api/sessions")).json() == []

--- a/backend/tests/test_laps.py
+++ b/backend/tests/test_laps.py
@@ -108,9 +108,10 @@ async def test_coasting_and_metrics(setup) -> None:
     await feed_lap(proc, 1, 20, throttle=0, brake=0)
     await proc.feed(make_packet(current_lap=2, last_lap_time_ms=30_000))
     lap = c.laps[0]
-    assert lap.full_throttle_pct == pytest.approx(50.0)
-    assert lap.full_brake_pct == pytest.approx(30.0)
-    assert lap.coasting_pct == pytest.approx(20.0)
+    # abs tolerance: t is stored at 4 decimals, so time weights carry ~0.01%
+    assert lap.full_throttle_pct == pytest.approx(50.0, abs=0.1)
+    assert lap.full_brake_pct == pytest.approx(30.0, abs=0.1)
+    assert lap.coasting_pct == pytest.approx(20.0, abs=0.1)
 
 
 async def test_distance_integration(setup) -> None:
@@ -173,3 +174,64 @@ async def test_no_samples_recorded_after_race_finish(setup) -> None:
     assert len(c.laps) == 1  # final lap still completes
     await feed_lap(proc, 6, 20, total_laps=5, speed_mps=30.0)
     assert len(proc.live_lap_samples["t"]) == 0
+
+
+# --- packet-loss-robust timing ----------------------------------------------
+
+
+async def test_packet_gap_extends_time_axis(setup) -> None:
+    proc, _ = setup
+    for i in range(10):
+        await proc.feed(make_packet(current_lap=1, packet_id=i, speed_mps=60.0))
+    await proc.feed(make_packet(current_lap=1, packet_id=15, speed_mps=60.0))
+    t = proc.live_lap_samples["t"]
+    d = proc.live_lap_samples["dist"]
+    assert t[-1] - t[-2] == pytest.approx(6 / 60)
+    assert d[-1] - d[-2] == pytest.approx(60.0 * 6 / 60)
+    assert proc.dropped_frames == 5
+
+
+async def test_huge_gap_falls_back_to_one_frame(setup) -> None:
+    proc, _ = setup
+    for i in range(10):
+        await proc.feed(make_packet(current_lap=1, packet_id=i, speed_mps=60.0))
+    await proc.feed(make_packet(current_lap=1, packet_id=500, speed_mps=60.0))
+    t = proc.live_lap_samples["t"]
+    assert t[-1] - t[-2] == pytest.approx(1 / 60, abs=1e-3)
+
+
+async def test_non_monotonic_pid_falls_back(setup) -> None:
+    proc, _ = setup
+    await proc.feed(make_packet(current_lap=1, packet_id=100, speed_mps=60.0))
+    await proc.feed(make_packet(current_lap=1, packet_id=40, speed_mps=60.0))
+    t = proc.live_lap_samples["t"]
+    assert t == [0.0, pytest.approx(1 / 60, abs=1e-4)]
+
+
+async def test_pause_does_not_inflate_time(setup) -> None:
+    proc, _ = setup
+    for i in range(10):
+        await proc.feed(make_packet(current_lap=1, packet_id=i, speed_mps=60.0))
+    paused = int(SimulatorFlags.CAR_ON_TRACK | SimulatorFlags.PAUSED)
+    for i in range(10, 30):
+        await proc.feed(make_packet(current_lap=1, packet_id=i, flags=paused))
+    await proc.feed(make_packet(current_lap=1, packet_id=30, speed_mps=60.0))
+    t = proc.live_lap_samples["t"]
+    assert len(t) == 11  # paused packets are not sampled
+    assert t[-1] - t[-2] == pytest.approx(1 / 60, abs=1e-3)  # pause added no time
+
+
+async def test_metrics_time_weighted_under_drops(setup) -> None:
+    proc, c = setup
+    # 10 full-throttle frames (pids 0..9), then 10 coast samples every 3rd
+    # frame (pids 12,15,...,39) -> throttle time 10 frames, coast 30 frames.
+    for pid in range(10):
+        await proc.feed(make_packet(current_lap=1, packet_id=pid, throttle=255, speed_mps=50.0))
+    for pid in range(12, 40, 3):
+        await proc.feed(make_packet(current_lap=1, packet_id=pid, throttle=0, speed_mps=50.0))
+    await proc.feed(
+        make_packet(current_lap=2, packet_id=40, last_lap_time_ms=60_000, speed_mps=50.0)
+    )
+    lap = c.laps[0]
+    assert lap.full_throttle_pct == pytest.approx(100.0 * 10 / 40, abs=0.5)
+    assert lap.coasting_pct == pytest.approx(100.0 * 30 / 40, abs=0.5)

--- a/backend/tests/test_live_events.py
+++ b/backend/tests/test_live_events.py
@@ -1,0 +1,159 @@
+"""Live race-event detection: overtakes, positions lost, off-road excursions."""
+
+from app.models import SimulatorFlags, TelemetryPacket
+from app.notify import ALL_EVENTS, Notifier, parse_events
+from app.processing.live_events import (
+    OFFROAD_MIN_TICKS,
+    OFFROAD_REARM_TICKS,
+    POSITION_HOLD_TICKS,
+    LiveEventWatcher,
+)
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+
+
+def racing_packet(position: int = 3, total: int = 12, **kwargs) -> TelemetryPacket:
+    return parse_packet(
+        build_packet(
+            fmt="C",
+            flags=ON_TRACK,
+            race_position=position,
+            total_positions=total,
+            speed_mps=kwargs.pop("speed_mps", 40.0),
+            **kwargs,
+        )
+    )
+
+
+def feed_n(watcher: LiveEventWatcher, packet: TelemetryPacket, n: int) -> list:
+    events = []
+    for _ in range(n):
+        events.extend(watcher.feed(packet))
+    return events
+
+
+def test_overtake_fires_after_hold() -> None:
+    w = LiveEventWatcher()
+    w.feed(racing_packet(position=3))  # baseline
+    events = feed_n(w, racing_packet(position=2), POSITION_HOLD_TICKS + 2)
+    assert len(events) == 1
+    assert events[0].kind == "overtake"
+    assert events[0].position == 2
+    assert events[0].previous_position == 3
+    # Holding the position produces no further events
+    assert feed_n(w, racing_packet(position=2), 200) == []
+
+
+def test_position_lost_fires_after_hold() -> None:
+    w = LiveEventWatcher()
+    w.feed(racing_packet(position=3))
+    events = feed_n(w, racing_packet(position=4), POSITION_HOLD_TICKS + 2)
+    assert [e.kind for e in events] == ["position_lost"]
+
+
+def test_side_by_side_flapping_does_not_fire() -> None:
+    w = LiveEventWatcher()
+    w.feed(racing_packet(position=3))
+    events = []
+    for _ in range(20):  # P2/P3 swap every 10 ticks — never holds for 1 s
+        events.extend(feed_n(w, racing_packet(position=2), 10))
+        events.extend(feed_n(w, racing_packet(position=3), 10))
+    assert events == []
+
+
+def test_no_position_events_without_live_position() -> None:
+    w = LiveEventWatcher()
+    # GT7 reports -1 outside supported race types, and 1-of-1 in time trials
+    assert feed_n(w, racing_packet(position=-1), 100) == []
+    assert feed_n(w, racing_packet(position=1, total=1), 100) == []
+
+
+def test_no_events_while_paused_or_off_track() -> None:
+    w = LiveEventWatcher()
+    w.feed(racing_packet(position=3))
+    paused = parse_packet(
+        build_packet(
+            fmt="C",
+            flags=int(SimulatorFlags.CAR_ON_TRACK | SimulatorFlags.PAUSED),
+            race_position=2,
+            total_positions=12,
+        )
+    )
+    assert feed_n(w, paused, 200) == []
+
+
+def test_off_road_fires_once_and_rearms() -> None:
+    w = LiveEventWatcher()
+    grass = racing_packet(surface_types="GGGG")
+    tarmac = racing_packet(surface_types="TTTT")
+    events = feed_n(w, grass, OFFROAD_MIN_TICKS + 50)
+    assert [e.kind for e in events] == ["off_road"]
+    # Still off-road: no repeat until re-armed
+    assert feed_n(w, grass, 500) == []
+    # Back on tarmac long enough to re-arm, then a second excursion fires
+    assert feed_n(w, tarmac, OFFROAD_REARM_TICKS + 1) == []
+    events = feed_n(w, grass, OFFROAD_MIN_TICKS + 1)
+    assert [e.kind for e in events] == ["off_road"]
+
+
+def test_track_limits_nibble_is_not_off_road() -> None:
+    w = LiveEventWatcher()
+    two_wheels = racing_packet(surface_types="GGTT")
+    assert feed_n(w, two_wheels, 300) == []
+
+
+def test_kerbs_are_not_off_road() -> None:
+    w = LiveEventWatcher()
+    kerb = racing_packet(surface_types="CCTT")
+    assert feed_n(w, kerb, 300) == []
+
+
+def test_slow_excursion_is_ignored() -> None:
+    w = LiveEventWatcher()
+    crawling = racing_packet(surface_types="GGGG", speed_mps=2.0)
+    assert feed_n(w, crawling, 300) == []
+
+
+def test_packet_a_has_no_surface_so_no_off_road() -> None:
+    w = LiveEventWatcher()
+    p = parse_packet(
+        build_packet(flags=ON_TRACK, race_position=3, total_positions=12, speed_mps=40.0)
+    )
+    assert p.surface_types is None
+    assert feed_n(w, p, 300) == []
+
+
+def test_event_helpers_use_canonical_names(monkeypatch) -> None:
+    sent: list[str] = []
+    monkeypatch.setattr(
+        Notifier, "notify", lambda self, event, title, fields: sent.append(event)
+    )
+    n = Notifier()
+    n.overtake(2, 3, 12, "car", "track")
+    n.position_lost(3, 2, 12, "car", "track")
+    n.off_road(5, "car", "track")
+    assert sent == ["overtake", "position_lost", "off_road"]
+    assert all(e in ALL_EVENTS for e in sent)
+
+
+def test_notify_respects_enabled_set() -> None:
+    # The real notify() drops disabled events before scheduling any send.
+    n = Notifier()
+    n.url = "https://example.invalid/hook"
+    n.enabled = set()
+    # Would raise RuntimeError (no running loop) if it tried to schedule a task
+    n.notify("overtake", "t", [])
+    n.enabled = {"overtake"}
+    try:
+        n.notify("overtake", "t", [])
+    except RuntimeError:
+        pass  # reached task scheduling — the event passed the gate
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected notify to attempt scheduling")
+
+
+def test_parse_events() -> None:
+    assert parse_events("overtake, off_road") == {"overtake", "off_road"}
+    assert parse_events("bogus,overtake") == {"overtake"}
+    assert parse_events("") == set()

--- a/backend/tests/test_packet.py
+++ b/backend/tests/test_packet.py
@@ -1,8 +1,17 @@
 """Packet building, encryption round-trip, and field decoding."""
 
+import pytest
+
 from app.models import SimulatorFlags
 from app.telemetry.crypto import decrypt_packet, encrypt_packet
-from app.telemetry.packet import PACKET_SIZE, build_packet, parse_packet
+from app.telemetry.packet import (
+    PACKET_SIZE,
+    PACKET_SIZE_B,
+    PACKET_SIZE_C,
+    PACKET_SIZE_TILDE,
+    build_packet,
+    parse_packet,
+)
 
 
 def make_plain(**kwargs) -> bytes:
@@ -11,6 +20,9 @@ def make_plain(**kwargs) -> bytes:
 
 def test_packet_size() -> None:
     assert len(make_plain()) == PACKET_SIZE
+    assert len(make_plain(fmt="B")) == PACKET_SIZE_B
+    assert len(make_plain(fmt="~")) == PACKET_SIZE_TILDE
+    assert len(make_plain(fmt="C")) == PACKET_SIZE_C
 
 
 def test_encrypt_decrypt_roundtrip() -> None:
@@ -83,3 +95,67 @@ def test_tire_slip_ratio() -> None:
 def test_tire_slip_ratio_at_standstill() -> None:
     p = parse_packet(make_plain(speed_mps=0.0))
     assert p.tire_slip_ratio == 1.0
+
+
+def test_packet_a_has_no_extended_fields() -> None:
+    p = parse_packet(make_plain())
+    assert p.wheel_rotation is None
+    assert p.torque_vectors is None
+    assert p.surface_types is None
+    assert p.lap_time_ms is None
+
+
+def test_parse_packet_b_extension() -> None:
+    p = parse_packet(make_plain(fmt="B", wheel_rotation=0.5, sway=1.5, heave=-0.2, surge=2.0))
+    assert p.wheel_rotation is not None and abs(p.wheel_rotation - 0.5) < 1e-6
+    assert p.sway is not None and abs(p.sway - 1.5) < 1e-6
+    assert p.heave is not None and abs(p.heave - -0.2) < 1e-6
+    assert p.surge is not None and abs(p.surge - 2.0) < 1e-6
+    assert p.surface_types is None  # tilde/C fields absent in B
+
+
+def test_parse_packet_tilde_extension() -> None:
+    p = parse_packet(
+        make_plain(
+            fmt="~",
+            throttle_filtered=200,
+            brake_filtered=10,
+            torque_vectors=(0.1, 0.2, -0.3, -0.4),
+            energy_recovery=5.5,
+        )
+    )
+    assert p.throttle_filtered == 200
+    assert p.brake_filtered == 10
+    assert p.torque_vectors is not None
+    assert abs(p.torque_vectors[2] - -0.3) < 1e-6
+    assert p.energy_recovery is not None and abs(p.energy_recovery - 5.5) < 1e-6
+    assert p.lap_time_ms is None  # C fields absent in ~
+
+
+def test_parse_packet_c_extension() -> None:
+    p = parse_packet(
+        make_plain(
+            fmt="C",
+            surface_types="CTDG",
+            lap_time_ms=42_123,
+            wheel_steering_rad=(0.12, 0.11),
+            wheelbase_m=2.65,
+            car_category="GR3",
+        )
+    )
+    assert p.surface_types == "CTDG"
+    assert p.lap_time_ms == 42_123
+    assert p.wheel_steering_rad is not None
+    assert abs(p.wheel_steering_rad[0] - 0.12) < 1e-6
+    assert p.wheelbase_m is not None and abs(p.wheelbase_m - 2.65) < 1e-6
+    assert p.car_category == "GR3"
+
+
+@pytest.mark.parametrize("fmt", ["A", "B", "~", "C"])
+def test_encrypt_decrypt_roundtrip_all_formats(fmt: str) -> None:
+    plain = make_plain(fmt=fmt, packet_id=99, speed_mps=33.3)
+    recovered = decrypt_packet(encrypt_packet(plain))
+    assert recovered is not None
+    assert recovered[:0x40] == plain[:0x40]
+    assert recovered[0x44:] == plain[0x44:]
+    assert parse_packet(recovered).packet_id == 99

--- a/backend/tests/test_source_restart.py
+++ b/backend/tests/test_source_restart.py
@@ -1,0 +1,64 @@
+"""Telemetry source lifecycle: restarts and source switches release cleanly."""
+
+import pytest
+
+from app.config import Settings
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.listener import UdpTelemetrySource
+from app.telemetry.simulator import SimTelemetrySource
+
+
+@pytest.fixture
+async def service(tmp_path):
+    # High port so tests never collide with a live server on 33740.
+    settings = Settings(
+        source="udp", db_path=tmp_path / "test.db", ws_rate=1000, telemetry_port=43741
+    )
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    svc = TelemetryService(settings, repo, CarDatabase())
+    yield svc
+    await svc.stop()
+    await engine.dispose()
+
+
+async def test_switch_source_rebinds_udp_port_cleanly(service) -> None:
+    await service.start()
+    # Each switch stops the old source (releasing the UDP port) and binds a
+    # new one on the same port — any lingering task/socket raises OSError.
+    for _ in range(5):
+        await service.switch_source("udp")
+    assert isinstance(service.source, UdpTelemetrySource)
+    assert service.source._transport is not None
+
+
+async def test_switch_between_sim_and_udp_repeatedly(service) -> None:
+    await service.start()
+    for _ in range(3):
+        await service.switch_source("sim")
+        assert isinstance(service.source, SimTelemetrySource)
+        assert service.source.stats["console_ip"] == "simulated"
+        await service.switch_source("udp")
+        assert isinstance(service.source, UdpTelemetrySource)
+        assert "packet_format" in service.source.stats
+
+
+async def test_stop_clears_source_tasks(service) -> None:
+    await service.start()
+    assert service.source._tasks
+    await service.source.stop()
+    assert service.source._tasks == []
+    assert service.source._transport is None
+
+    await service.switch_source("sim")
+    await service.source.stop()
+    assert service.source._task is None
+
+
+async def test_stop_without_start_is_safe(service) -> None:
+    # test fixtures routinely stop never-started services
+    await service.stop()

--- a/backend/tests/test_tier3.py
+++ b/backend/tests/test_tier3.py
@@ -208,3 +208,26 @@ async def test_session_summary_on_new_session(client, monkeypatch) -> None:
         parse_packet(build_packet(current_lap=1, flags=ON_TRACK, car_id=99))
     )
     assert "session_summary" in events
+
+
+async def test_csv_export_escapes_hostile_metadata(client) -> None:
+    """Imported text (finished_at) must not corrupt the CSV or reach a
+    spreadsheet as a live formula."""
+    import csv as csv_mod
+    import io
+
+    c, service = client
+    await drive_laps(service, laps=1)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    exported = (await c.get(f"/api/laps/{lap_id}/export")).json()
+    exported["lap"]["finished_at"] = '=cmd(),"x'
+    imported = (await c.post("/api/laps/import", json=exported)).json()
+
+    resp = await c.get(f"/api/laps/{imported['id']}/export.csv")
+    assert resp.status_code == 200
+    date_line = next(
+        line for line in resp.text.splitlines() if line.startswith('"Log Date"')
+    )
+    row = next(csv_mod.reader(io.StringIO(date_line)))
+    assert len(row) == 2  # embedded comma/quote didn't split the row
+    assert row[1].startswith("'=")  # formula neutralized

--- a/backend/tests/test_ws_broadcast.py
+++ b/backend/tests/test_ws_broadcast.py
@@ -1,0 +1,131 @@
+"""Per-client WebSocket queues: slow viewers can't stall telemetry capture."""
+
+import asyncio
+import json
+
+import pytest
+
+from app.config import Settings
+from app.models import SimulatorFlags
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+
+
+class FakeWS:
+    """Stands in for a WebSocket; optionally blocks until released."""
+
+    def __init__(self, block: asyncio.Event | None = None) -> None:
+        self.sent: list[str] = []
+        self.block = block
+
+    async def send_text(self, text: str) -> None:
+        if self.block is not None:
+            await self.block.wait()
+        self.sent.append(text)
+
+    def messages(self, kind: str) -> list[dict]:
+        return [m for m in map(json.loads, self.sent) if m["type"] == kind]
+
+
+@pytest.fixture
+async def service(tmp_path):
+    settings = Settings(
+        source="udp", db_path=tmp_path / "test.db", ws_rate=1000, telemetry_port=43742
+    )
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    svc = TelemetryService(settings, repo, CarDatabase())
+    svc.processor.min_lap_ticks = 1
+    yield svc
+    await svc.stop()
+    await engine.dispose()
+
+
+def packet(i: int, lap: int = 1) -> object:
+    return parse_packet(
+        build_packet(packet_id=i, current_lap=lap, speed_mps=40.0, flags=ON_TRACK)
+    )
+
+
+async def test_slow_client_does_not_block_ingestion(service) -> None:
+    release = asyncio.Event()
+    slow, fast = FakeWS(block=release), FakeWS()
+    await service.register(slow)  # type: ignore[arg-type]
+    await service.register(fast)  # type: ignore[arg-type]
+
+    async def feed() -> None:
+        for i in range(50):
+            await service._on_packet(packet(i))
+            await asyncio.sleep(0)
+
+    # The whole feed must complete while one client is fully stalled.
+    await asyncio.wait_for(feed(), timeout=1.0)
+    await asyncio.sleep(0.01)
+    assert fast.messages("telemetry")
+    assert service.client_count == 2  # slow frames never evict a client
+    release.set()
+
+
+async def test_slow_client_drops_frames_but_keeps_events(service) -> None:
+    release = asyncio.Event()
+    slow = FakeWS(block=release)
+    await service.register(slow)  # type: ignore[arg-type]
+    await asyncio.sleep(0.01)  # let the initial status flush attempt start
+
+    for i in range(20):
+        service._publish({"type": "telemetry", "data": {"i": i}})
+    service._publish({"type": "lap", "data": {"number": 1}})
+    service._publish({"type": "status", "data": {"ok": True}})
+
+    release.set()
+    await asyncio.sleep(0.05)
+    frames = slow.messages("telemetry")
+    assert len(frames) <= 1  # latest wins; intermediates dropped
+    if frames:
+        assert frames[0]["data"] == {"i": 19}
+    assert len(slow.messages("lap")) == 1
+    assert len(slow.messages("status")) >= 2  # initial status + published one
+
+
+async def test_lap_event_delivered_exactly_once(service) -> None:
+    ws = FakeWS()
+    await service.register(ws)  # type: ignore[arg-type]
+    # Lap 1 for a few ticks, then lap 2 with a valid last-lap time -> one lap
+    for i in range(10):
+        await service._on_packet(packet(i, lap=1))
+    await service._on_packet(
+        parse_packet(
+            build_packet(
+                packet_id=10, current_lap=2, last_lap_time_ms=61_000,
+                speed_mps=40.0, flags=ON_TRACK,
+            )
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert len(ws.messages("lap")) == 1
+
+
+async def test_unregister_cancels_sender(service) -> None:
+    ws = FakeWS()
+    await service.register(ws)  # type: ignore[arg-type]
+    client = service._clients[ws]  # type: ignore[index]
+    await service.unregister(ws)  # type: ignore[arg-type]
+    assert service.client_count == 0
+    assert client.task is not None and client.task.done()
+
+
+async def test_event_queue_overflow_disconnects_client(service) -> None:
+    release = asyncio.Event()
+    slow = FakeWS(block=release)
+    await service.register(slow)  # type: ignore[arg-type]
+    await asyncio.sleep(0.01)
+    for _ in range(300):  # events queue maxsize is 256
+        service._publish({"type": "status", "data": {}})
+    assert service.client_count == 0
+    release.set()

--- a/backend/tests/test_ws_broadcast.py
+++ b/backend/tests/test_ws_broadcast.py
@@ -22,11 +22,15 @@ class FakeWS:
     def __init__(self, block: asyncio.Event | None = None) -> None:
         self.sent: list[str] = []
         self.block = block
+        self.closed = False
 
     async def send_text(self, text: str) -> None:
         if self.block is not None:
             await self.block.wait()
         self.sent.append(text)
+
+    async def close(self, code: int = 1000) -> None:
+        self.closed = True
 
     def messages(self, kind: str) -> list[dict]:
         return [m for m in map(json.loads, self.sent) if m["type"] == kind]
@@ -129,3 +133,7 @@ async def test_event_queue_overflow_disconnects_client(service) -> None:
         service._publish({"type": "status", "data": {}})
     assert service.client_count == 0
     release.set()
+    await asyncio.sleep(0.01)
+    # The socket itself must be closed too, or /ws/live keeps an open,
+    # untracked connection alive.
+    assert slow.closed

--- a/dev.sh
+++ b/dev.sh
@@ -19,6 +19,11 @@ if [[ ! -d node_modules ]]; then
   npm install --no-fund --no-audit
 fi
 
+# Refresh the built frontend so :8000 serves current code, not a stale dist
+# (dist/ is gitignored and only updated by this build).
+echo "building frontend..."
+npm --prefix frontend run build
+
 echo
 echo "  backend  → http://localhost:8000  (API + built frontend)"
 echo "  frontend → http://localhost:5173  (hot reload — use this one)"

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -13,10 +13,12 @@ working directory.
 | --- | --- | --- |
 | `GT7_SOURCE` | `udp` | `udp` (PlayStation) or `sim` (simulated laps) |
 | `GT7_PS_IP` | *(empty)* | Console IP; empty = broadcast auto-discovery |
+| `GT7_PACKET_FORMAT` | `C` | Telemetry format requested from the console: `A`, `B`, `~`, or `C` (richest, needs GT7 v1.68+; also settable in Admin) |
 | `GT7_DB_PATH` | `data/gt7.db` | SQLite database path — also accepts a full SQLAlchemy async URL (e.g. Postgres) |
 | `GT7_CARS_CSV` | `data/cars.csv` | Car ID → name lookup table |
 | `GT7_WS_RATE` | `30` | Live stream rate to the browser (Hz); capture stays at ~60 Hz |
-| `GT7_WEBHOOK_URL` | *(empty)* | Webhook for PB / session notifications (also settable in Admin) |
+| `GT7_WEBHOOK_URL` | *(empty)* | Webhook for race notifications (also settable in Admin) |
+| `GT7_WEBHOOK_EVENTS` | *(all)* | Comma-separated events to send: `personal_best`, `session_summary`, `overtake`, `position_lost`, `off_road` (toggles in Admin) |
 | `GT7_LOG_LEVEL` | `INFO` | Root log level (also settable in Admin) |
 | `GT7_HTTP_HOST` | `0.0.0.0` | HTTP bind host |
 | `GT7_HTTP_PORT` | `8000` | HTTP port |
@@ -51,6 +53,9 @@ Set a webhook URL (environment variable or **Admin** view) to get:
 
 - **New personal best** notifications as they happen
 - **End-of-session summaries**
+- **Overtakes** and **positions lost** (in race types where GT7 reports live positions)
+- **Off-road excursions** (requires packet format C)
 
+Every event type has its own toggle in the Admin view (`GT7_WEBHOOK_EVENTS` via env).
 Discord webhook URLs receive a rich embed; any other URL receives plain JSON.
 See [Admin view](../guide/admin.md) for details.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -20,6 +20,8 @@ working directory.
 | `GT7_WEBHOOK_URL` | *(empty)* | Webhook for race notifications (also settable in Admin) |
 | `GT7_WEBHOOK_EVENTS` | *(all)* | Comma-separated events to send: `personal_best`, `session_summary`, `overtake`, `position_lost`, `off_road` (toggles in Admin) |
 | `GT7_LOG_LEVEL` | `INFO` | Root log level (also settable in Admin) |
+| `GT7_ADMIN_TOKEN` | *(empty)* | When set, the Admin pages and all destructive/mutating API calls require this token via the `X-API-Key` header; overlay/dash/read endpoints stay open. Empty = fully open (LAN-trusted) |
+| `GT7_CORS_ORIGINS` | *(empty)* | Comma-separated origins allowed for cross-origin API use. Empty (default) sends no CORS headers — the bundled UI is same-origin and needs none |
 | `GT7_HTTP_HOST` | `0.0.0.0` | HTTP bind host |
 | `GT7_HTTP_PORT` | `8000` | HTTP port |
 | `GT7_TELEMETRY_PORT` | `33740` | Inbound telemetry UDP port |

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -4,7 +4,8 @@
 
 From the repo root, one command starts everything — backend with auto-reload on `:8000`,
 frontend with hot reload on `:5173` — and bootstraps the virtualenv and `node_modules`
-on first run. ++ctrl+c++ stops both:
+on first run. It also rebuilds `frontend/dist` on every start, so `:8000` always serves
+the current UI (not a stale build). ++ctrl+c++ stops both:
 
 ```bash
 ./dev.sh

--- a/docs/guide/admin.md
+++ b/docs/guide/admin.md
@@ -19,6 +19,11 @@ database, and override environment variables on the next start.
   default). Applied on the next heartbeat, within ~2 s. Use **A** if an older game
   version stops sending data.
 - **Log level** — DEBUG / INFO / WARNING / ERROR, applied server-side immediately.
+- **Admin token** — only relevant when the server sets `GT7_ADMIN_TOKEN`. Enter the
+  token here once per browser (it's stored in that browser's localStorage and sent as
+  `X-API-Key`). Without it, the Admin pages, the recording toggle, session/lap
+  deletes, imports, and layout saves return 401; the Live view, overlays, and the
+  driver dash never need it.
 
 ## Diagnostics
 
@@ -60,6 +65,10 @@ Notes on the race events:
 automations work out of the box. The **Test** button sends a test event so you can
 verify delivery — it ignores the toggles. Notifications are fire-and-forget — a
 failed delivery logs a warning and never blocks capture.
+
+Trust model: the webhook URL may deliberately point at LAN services (Home
+Assistant, n8n) — private addresses are not blocked. Redirects are never followed,
+and setting `GT7_ADMIN_TOKEN` ensures only you can change the URL.
 
 ## Overlay & dashboard builder
 

--- a/docs/guide/admin.md
+++ b/docs/guide/admin.md
@@ -13,6 +13,11 @@ database, and override environment variables on the next start.
   (the built-in synthetic 60 Hz source) live. This is the in-app equivalent of
   `GT7_SOURCE=sim` — everything (live view, recording, analysis, overlay) works against
   the simulator.
+- **Packet format** — which telemetry format to request from the console: **A**
+  (base, 296 B), **B** (adds steering/motion), **~** (adds filtered inputs, torque
+  vectors), or **C** (adds surface type, live lap timer — needs GT7 v1.68+, the
+  default). Applied on the next heartbeat, within ~2 s. Use **A** if an older game
+  version stops sending data.
 - **Log level** — DEBUG / INFO / WARNING / ERROR, applied server-side immediately.
 
 ## Diagnostics
@@ -30,17 +35,31 @@ session/lap counts, database size, and loaded car names. Two actions:
 
 ## Notifications
 
-Set a **webhook URL** to get notified about:
+Set a **webhook URL** and pick which events to be notified about — each has its own
+toggle in the panel:
 
-- **New personal bests** — fired the moment a session best is beaten (never on the
-  first lap of a session), with lap, improvement, car, and track.
-- **Session summaries** — when a session ends, with car, track, lap count, best lap,
-  and fuel used.
+| Event | Fires when | JSON `event` |
+| --- | --- | --- |
+| **Personal bests** | a session best is beaten (never on the first lap), with lap, improvement, car, track | `personal_best` |
+| **Session summaries** | a session ends, with car, track, lap count, best lap, fuel used | `session_summary` |
+| **Overtakes** | your race position improves (e.g. P3 → P2) | `overtake` |
+| **Positions lost** | your race position drops | `position_lost` |
+| **Off-road excursions** | 3+ wheels are on grass/dirt/sand/snow at speed | `off_road` |
+
+Notes on the race events:
+
+- **Position events** need GT7 to report a live race position — it only does in some
+  race types (elsewhere the field reads −1 and nothing fires). A change must **hold
+  for ~1 s** before it counts, so side-by-side battles don't spam your channel.
+- **Off-road** needs **packet format C** (the default), the only format carrying
+  per-wheel surface data. Kerbs and two-wheels-over-the-line don't count; one
+  excursion sends one event, re-arming after ~2 s back on tarmac.
 
 **Discord** webhook URLs get a rich embed; **any other URL** receives plain JSON
-(snake-cased fields), so n8n / Home Assistant–style automations work out of the box.
-The **Test** button sends a test event so you can verify delivery. Notifications are
-fire-and-forget — a failed delivery logs a warning and never blocks capture.
+(snake-cased fields plus the `event` name above), so n8n / Home Assistant–style
+automations work out of the box. The **Test** button sends a test event so you can
+verify delivery — it ignores the toggles. Notifications are fire-and-forget — a
+failed delivery logs a warning and never blocks capture.
 
 ## Overlay & dashboard builder
 

--- a/docs/internals/lap-detection.md
+++ b/docs/internals/lap-detection.md
@@ -17,13 +17,22 @@ hold**:
 
 Packets with the `LOADING` flag set are dropped entirely before any processing.
 
-**Time and distance** are synthesized, not taken from packet timestamps:
+**Time and distance** are synthesized from the console's own **packet counter**, not
+from wall clocks or a fixed tick assumption:
 
-- `t = tick_index × 1/60` seconds
-- `dist += speed_mps × 1/60` meters, accumulated per recorded tick
+- each sample covers `Δpacket_id` frames (clamped to 1–60; a pid reset,
+  non-monotonic value, or a gap over 1 s falls back to a single frame);
+- `t += Δframes × 1/60` seconds, `dist += speed_mps × Δframes × 1/60` meters.
 
-Because distance only accumulates on recorded ticks, paused or off-track time adds no
-distance and the distance axis stays clean.
+Dropped datagrams therefore widen the time/distance steps instead of silently
+compressing the axes. The pid tracker also advances on paused/off-track packets, so
+unpausing sees a ~1-frame gap — pauses still add no lap time or distance. Frames
+lost in transit are counted and reported as `frames_dropped` in `/api/status` and
+the Admin diagnostics.
+
+Input metrics (full-throttle %, braking %, coasting %, tire spin, TCS/ASM activity)
+are **time-weighted** using the `t` deltas, so a sample recorded after a gap counts
+for the whole gap it covers.
 
 ## When a lap completes
 
@@ -33,7 +42,7 @@ conditions hold:
 1. the previous lap number was `> 0` (a real lap, not the out-lap);
 2. the counter moved **exactly +1** (monotonic step);
 3. the game reported a positive `last_lap_time_ms`;
-4. the lap collected at least **600 samples** (~10 s at 60 Hz).
+4. the lap collected at least **600 samples** (~10 s of received packets at 60 Hz).
 
 Condition 4 is the **phantom-lap guard**: in menus and replays GT7's lap counter
 flickers through stale values and re-reports an old `last_lap_time`. Requiring 10

--- a/docs/internals/telemetry-capture.md
+++ b/docs/internals/telemetry-capture.md
@@ -7,9 +7,11 @@ screen. This page describes exactly how the datalogger captures and decodes it.
 
 The console only streams to a client that keeps asking for data:
 
-1. The datalogger binds UDP port **33740** and sends a **heartbeat** — a single byte
-   `A` — to the console's port **33739** every **1.6 s**. (GT7 stops sending after
-   ~100 packets without a heartbeat.)
+1. The datalogger binds UDP port **33740** and sends a **heartbeat** — a single
+   character — to the console's port **33739** every **1.6 s**. (GT7 stops sending
+   after ~100 packets without a heartbeat.) The character selects the packet format:
+   `A`, `B`, `~`, or `C` (see [packet formats](#packet-formats) below); the
+   datalogger sends `C` by default (`GT7_PACKET_FORMAT`, changeable live in Admin).
 2. The heartbeat is addressed to `GT7_PS_IP` if configured. If not, it is
    **broadcast** (`255.255.255.255`), and the console's address is learned from the
    source address of the first telemetry packet that arrives — that's the
@@ -17,23 +19,37 @@ The console only streams to a client that keeps asking for data:
 3. If no packet arrives for **5 s** the connection is considered stale and the status
    indicator drops to "waiting for telemetry" while heartbeats continue.
 
+## Packet formats
+
+Four packet formats exist, each a strict superset of the previous. Parsing keys off
+the datagram length, so whatever the console answers is decoded correctly:
+
+| Heartbeat | Size | Adds |
+| --- | --- | --- |
+| `A` | 296 B | base telemetry (everything in the table below) |
+| `B` | 316 B | steering wheel rotation, sway / heave / surge accelerations |
+| `~` | 344 B | filtered throttle & brake, per-wheel torque vectors, energy recovery |
+| `C` | 368 B | per-wheel surface type, live lap timer, front-wheel steering angles, wheelbase, car category (needs GT7 **v1.68+**) |
+
+The extended fields are parsed into the typed packet model (as `None` when the
+console sends a smaller format). Older game versions only answer the `A` heartbeat —
+set **Packet format** to `A` in the Admin view if no data arrives.
+
 ## Decryption
 
-Each 296-byte datagram is encrypted with **Salsa20**:
+Each datagram is encrypted with **Salsa20**:
 
 - **Key** — the first 32 bytes of the ASCII string
   `Simulator Interface Packet GT7 ver 0.0` (i.e. `Simulator Interface Packet GT7 v`).
 - **Nonce** — a 4-byte little-endian seed `iv1` is read *unencrypted* at offset `0x40`
-  of the datagram. A second value is derived as `iv2 = iv1 XOR 0xDEADBEAF` (yes,
-  `BEAF` — that is the real GT7 constant), and the 8-byte Salsa20 nonce is `iv2`
-  followed by `iv1` (both little-endian).
+  of the datagram. A second value is derived as `iv2 = iv1 XOR <constant>`, and the
+  8-byte Salsa20 nonce is `iv2` followed by `iv1` (both little-endian). The XOR
+  constant depends on the packet format: `0xDEADBEAF` for `A` (yes, `BEAF` — that is
+  the real GT7 constant), `0xDEADBEEF` for `B` and `C`, `0x55FABB4F` for `~`. The
+  decoder picks the constant matching the datagram size and falls back to trying the
+  others.
 - **Validation** — after decryption, the first four bytes must equal the magic
   `0x47375330` (`"G7S0"`). Anything else is counted as a decode error and dropped.
-
-!!! note "Packet format support"
-    The datalogger implements the classic **296-byte format-A packet** with the `A`
-    heartbeat. The extended formats introduced in later GT7 patches (the "B" / `~`
-    variants) are not used — format A carries everything the dashboard needs.
 
 ## Decoded fields
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -53,6 +53,18 @@ filter for apps without alpha support. See [Overlay & streaming](../guide/overla
   also must hold for ~1 s before they count.
 - **Off-road** needs **packet format C** — check Admin → Connection.
 
+## 401 / 403 "admin token" errors
+
+The server has `GT7_ADMIN_TOKEN` set. Enter the same token under **Admin →
+Connection → Admin token** (once per browser). 403 means the entered token doesn't
+match the server's. Read-only pages (Live, overlays, `/dash`) never need the token.
+
+## Cross-origin (CORS) errors after upgrading
+
+Wildcard CORS was removed — the bundled UI is same-origin and unaffected, but if you
+built a separate app that calls this API from another origin, set
+`GT7_CORS_ORIGINS=http://your-app-host:port` (comma-separated for several).
+
 ## Getting more detail
 
 - **Admin → Logs** shows the live backend log with level filtering.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -13,6 +13,9 @@ The backend is running but no packets are arriving from the console.
   `network_mode: host` (Linux only).
 - You must be **in a race, time trial, or replay** — GT7 only streams telemetry while
   driving is on screen, not in menus.
+- The default **packet format C** needs GT7 **v1.68+** (and the `~` format doesn't
+  stream during replays). On an older game version, set **Packet format** to `A` in
+  the Admin view.
 
 ## Wrong or garbled data (decode errors in `/api/status`)
 
@@ -39,6 +42,16 @@ page from.
 Use a **Browser source** in OBS and make sure the overlay layout is set to the
 transparent strip; alternatively use the green-screen page mode and add a chroma-key
 filter for apps without alpha support. See [Overlay & streaming](../guide/overlay.md).
+
+## Webhook notifications not arriving
+
+- Check the URL with the **Test** button in Admin → Notifications (the test ignores
+  the per-event toggles).
+- Each event type has its own toggle — make sure the one you expect is enabled.
+- **Overtake / position lost** need GT7 to report a live race position; it only does
+  so in some race types (the field reads −1 elsewhere, and nothing fires). Changes
+  also must hold for ~1 s before they count.
+- **Off-road** needs **packet format C** — check Admin → Connection.
 
 ## Getting more detail
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gt7-datalogger-frontend",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gt7-datalogger-frontend",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-select": "^2.3.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gt7-datalogger-frontend",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,19 +12,51 @@ import type {
   Track,
 } from "./types";
 
+// Admin token (only needed when the server sets GT7_ADMIN_TOKEN). Stored per
+// device; sent on every request — open endpoints simply ignore it.
+const TOKEN_KEY = "gt7.adminToken";
+
+export function getAdminToken(): string {
+  return localStorage.getItem(TOKEN_KEY) ?? "";
+}
+
+export function setAdminToken(token: string): void {
+  if (token) localStorage.setItem(TOKEN_KEY, token);
+  else localStorage.removeItem(TOKEN_KEY);
+}
+
+function authHeaders(): Record<string, string> {
+  const t = getAdminToken();
+  return t ? { "X-API-Key": t } : {};
+}
+
+async function fail(url: string, resp: Response): Promise<never> {
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error(
+      resp.status === 401
+        ? "admin token required — set it in Admin → Connection"
+        : "admin token rejected — check it in Admin → Connection",
+    );
+  }
+  throw new Error(`${url}: ${resp.status} ${await resp.text()}`);
+}
+
 async function get<T>(url: string): Promise<T> {
-  const resp = await fetch(url);
-  if (!resp.ok) throw new Error(`${url}: ${resp.status} ${await resp.text()}`);
+  const resp = await fetch(url, { headers: authHeaders() });
+  if (!resp.ok) await fail(url, resp);
   return resp.json() as Promise<T>;
 }
 
 async function send<T>(url: string, method: string, body?: unknown): Promise<T> {
   const resp = await fetch(url, {
     method,
-    headers: body ? { "Content-Type": "application/json" } : undefined,
+    headers: {
+      ...authHeaders(),
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
     body: body ? JSON.stringify(body) : undefined,
   });
-  if (!resp.ok) throw new Error(`${url}: ${resp.status} ${await resp.text()}`);
+  if (!resp.ok) await fail(url, resp);
   return resp.json() as Promise<T>;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -71,7 +71,12 @@ export const api = {
   admin: {
     settings: () => get<AdminSettings>("/api/admin/settings"),
     updateSettings: (
-      patch: Partial<Pick<AdminSettings, "ps_ip" | "source" | "log_level" | "webhook_url">>,
+      patch: Partial<
+        Pick<
+          AdminSettings,
+          "ps_ip" | "source" | "log_level" | "webhook_url" | "webhook_events" | "packet_format"
+        >
+      >,
     ) => send<AdminSettings>("/api/admin/settings", "PUT", patch),
     testWebhook: () => send<{ status: string }>("/api/admin/test-webhook", "POST"),
     logs: (limit = 300, level?: string) =>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -49,6 +49,7 @@ export interface ConnectionStatus {
   packets_received: number;
   decode_errors: number;
   packet_format?: string;
+  frames_dropped?: number; // console frames lost in transit (packet-id gaps)
 }
 
 export interface LapSummary {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface ConnectionStatus {
   console_ip: string;
   packets_received: number;
   decode_errors: number;
+  packet_format?: string;
 }
 
 export interface LapSummary {
@@ -169,7 +170,16 @@ export interface AdminSettings {
   heartbeat_port: number;
   telemetry_port: number;
   webhook_url: string;
+  webhook_events: WebhookEvent[];
+  packet_format: "A" | "B" | "~" | "C";
 }
+
+export type WebhookEvent =
+  | "personal_best"
+  | "session_summary"
+  | "overtake"
+  | "position_lost"
+  | "off_road";
 
 export interface LogRecord {
   ts: string;

--- a/frontend/src/store/telemetry.ts
+++ b/frontend/src/store/telemetry.ts
@@ -65,8 +65,19 @@ export const useTelemetry = create<TelemetryState>((set) => {
           }));
           break;
         case "status":
-        case "session":
           set({ status: msg.data });
+          break;
+        case "session":
+          // Drop laps that belong to another session: a car change or race
+          // restart must not leave old laps in the feed, or the fuel-strategy
+          // average mixes consumption from the previous car/track. Track
+          // identification re-broadcasts the same session_id, so mid-session
+          // laps survive this filter.
+          set((st) => ({
+            status: msg.data,
+            recentLaps: st.recentLaps.filter((l) => l.session_id === msg.data.session_id),
+            lapEpoch: st.lapEpoch + 1,
+          }));
           break;
       }
     };

--- a/frontend/src/views/AdminView.tsx
+++ b/frontend/src/views/AdminView.tsx
@@ -107,6 +107,8 @@ export function AdminView() {
               <Stat k="Decode errors" v={String(stats.source.decode_errors)}
                 cls={stats.source.decode_errors > 0 ? "text-warn" : undefined} />
               <Stat k="Packet format" v={stats.source.packet_format ?? "A"} />
+              <Stat k="Frames dropped" v={String(stats.source.frames_dropped ?? 0)}
+                cls={(stats.source.frames_dropped ?? 0) > 0 ? "text-warn" : undefined} />
               <Stat k="Server uptime" v={formatDuration(stats.uptime_s * 1000)} />
               <Stat k="Live clients" v={String(stats.clients)} />
               <Stat k="Sessions / laps" v={`${stats.db.sessions} / ${stats.db.laps}`} />

--- a/frontend/src/views/AdminView.tsx
+++ b/frontend/src/views/AdminView.tsx
@@ -6,7 +6,7 @@ import { LayoutBuilder } from "@/components/LayoutBuilder";
 import { ConfirmDialog } from "@/components/ui/Dialog";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { Select } from "@/components/ui/Select";
-import { api } from "@/lib/api";
+import { api, getAdminToken, setAdminToken } from "@/lib/api";
 import { formatDuration } from "@/lib/format";
 import type { AdminSettings, AdminStats, LogRecord, WebhookEvent } from "@/lib/types";
 import { useTelemetry } from "@/store/telemetry";
@@ -34,6 +34,7 @@ const LEVEL_COLORS: Record<string, string> = {
 export function AdminView() {
   const setStatus = useTelemetry((s) => s.setStatus);
   const [settings, setSettings] = useState<AdminSettings | null>(null);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [confirmingClear, setConfirmingClear] = useState(false);
@@ -50,7 +51,16 @@ export function AdminView() {
   }, [setStatus]);
 
   useEffect(() => {
-    api.admin.settings().then(setSettings).catch(() => flash("Could not load settings", true));
+    api.admin
+      .settings()
+      .then((s) => {
+        setSettings(s);
+        setSettingsError(null);
+      })
+      .catch((e) => {
+        setSettingsError(e instanceof Error ? e.message : "Could not load settings");
+        flash("Could not load settings", true);
+      });
     refreshStats();
     const t = window.setInterval(refreshStats, 5000);
     return () => window.clearInterval(t);
@@ -91,6 +101,8 @@ export function AdminView() {
         <Panel title="Connection" subtitle="how telemetry reaches the datalogger">
           {settings ? (
             <ConnectionForm settings={settings} busy={busy} onApply={apply} />
+          ) : settingsError ? (
+            <TokenForm error={settingsError} />
           ) : (
             <div className="p-4 text-sm text-ink-dim">Loading…</div>
           )}
@@ -205,6 +217,39 @@ export function AdminView() {
   );
 }
 
+function TokenForm({ error }: { error: string }) {
+  const [token, setToken] = useState(getAdminToken());
+  return (
+    <div className="space-y-2 p-4">
+      <p className="text-sm text-warn">{error}</p>
+      <label className="block text-xs text-ink-dim" htmlFor="admin-token">
+        Admin token (the server&apos;s GT7_ADMIN_TOKEN)
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="admin-token"
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          className="w-full rounded-md border border-edge bg-panel-2 px-3 py-1.5 font-tabular text-sm focus:border-accent focus:outline-none"
+        />
+        <button
+          className="btn shrink-0"
+          onClick={() => {
+            setAdminToken(token.trim());
+            window.location.reload();
+          }}
+        >
+          Save
+        </button>
+      </div>
+      <p className="text-[11px] text-ink-dim">
+        Stored in this browser only. Live/overlay pages work without it.
+      </p>
+    </div>
+  );
+}
+
 function ConnectionForm({
   settings,
   busy,
@@ -215,6 +260,7 @@ function ConnectionForm({
   onApply: (patch: Parameters<typeof api.admin.updateSettings>[0], label: string) => void;
 }) {
   const [ip, setIp] = useState(settings.ps_ip);
+  const [token, setToken] = useState(getAdminToken());
   useEffect(() => setIp(settings.ps_ip), [settings.ps_ip]);
 
   return (
@@ -295,6 +341,35 @@ function ConnectionForm({
             className="px-2 py-1.5 text-xs"
           />
         </div>
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs text-ink-dim" htmlFor="admin-token-field">
+          Admin token — only needed if the server sets GT7_ADMIN_TOKEN
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="admin-token-field"
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="empty = server is open"
+            className="w-full rounded-md border border-edge bg-panel-2 px-3 py-1.5 font-tabular text-sm placeholder:text-ink-dim/60 focus:border-accent focus:outline-none"
+          />
+          <button
+            className="btn shrink-0"
+            disabled={busy !== null || token === getAdminToken()}
+            onClick={() => {
+              setAdminToken(token.trim());
+              window.location.reload();
+            }}
+          >
+            Save
+          </button>
+        </div>
+        <p className="mt-1 text-[11px] text-ink-dim">
+          Stored in this browser only; sent as X-API-Key. Live/overlay pages never need it.
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/views/AdminView.tsx
+++ b/frontend/src/views/AdminView.tsx
@@ -8,11 +8,20 @@ import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { Select } from "@/components/ui/Select";
 import { api } from "@/lib/api";
 import { formatDuration } from "@/lib/format";
-import type { AdminSettings, AdminStats, LogRecord } from "@/lib/types";
+import type { AdminSettings, AdminStats, LogRecord, WebhookEvent } from "@/lib/types";
 import { useTelemetry } from "@/store/telemetry";
 import { toast } from "@/store/toasts";
 
 const LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR"] as const;
+
+// Order matches the backend's ALL_EVENTS.
+const WEBHOOK_EVENTS: { value: WebhookEvent; label: string; hint: string }[] = [
+  { value: "personal_best", label: "Personal bests", hint: "a lap beats your session best" },
+  { value: "session_summary", label: "Session summaries", hint: "car, laps, best time, fuel used" },
+  { value: "overtake", label: "Overtakes", hint: "you gain a race position" },
+  { value: "position_lost", label: "Positions lost", hint: "you drop a race position" },
+  { value: "off_road", label: "Off-road excursions", hint: "3+ wheels on grass/dirt — needs packet format C" },
+];
 
 const LEVEL_COLORS: Record<string, string> = {
   DEBUG: "text-ink-dim",
@@ -79,7 +88,7 @@ export function AdminView() {
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         {/* Connection settings */}
-        <Panel title="Connection">
+        <Panel title="Connection" subtitle="how telemetry reaches the datalogger">
           {settings ? (
             <ConnectionForm settings={settings} busy={busy} onApply={apply} />
           ) : (
@@ -88,7 +97,7 @@ export function AdminView() {
         </Panel>
 
         {/* Diagnostics */}
-        <Panel title="Diagnostics">
+        <Panel title="Diagnostics" subtitle="live health — refreshes every 5 s">
           {stats ? (
             <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 p-4 font-tabular text-sm">
               <Stat k="Telemetry" v={stats.source.connected ? "connected" : "no data"}
@@ -97,6 +106,7 @@ export function AdminView() {
               <Stat k="Packets received" v={stats.source.packets_received.toLocaleString()} />
               <Stat k="Decode errors" v={String(stats.source.decode_errors)}
                 cls={stats.source.decode_errors > 0 ? "text-warn" : undefined} />
+              <Stat k="Packet format" v={stats.source.packet_format ?? "A"} />
               <Stat k="Server uptime" v={formatDuration(stats.uptime_s * 1000)} />
               <Stat k="Live clients" v={String(stats.clients)} />
               <Stat k="Sessions / laps" v={`${stats.db.sessions} / ${stats.db.laps}`} />
@@ -131,7 +141,7 @@ export function AdminView() {
 
       <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         {/* Webhook notifications */}
-        <Panel title="Notifications">
+        <Panel title="Notifications" subtitle="webhook pings for race events">
           {settings ? (
             <WebhookForm settings={settings} busy={busy} onApply={apply} flash={flash} setBusy={setBusy} />
           ) : (
@@ -142,17 +152,20 @@ export function AdminView() {
       </div>
 
       {/* Overlay & dashboard layout builder */}
-      <Panel title="Overlay & dashboard builder">
+      <Panel
+        title="Overlay & dashboard builder"
+        subtitle="design OBS overlays and driver dashboards"
+      >
         <LayoutBuilder flash={flash} />
       </Panel>
 
       {/* Logs */}
-      <Panel title="Logs">
+      <Panel title="Logs" subtitle="live server log">
         <LogViewer />
       </Panel>
 
       {/* Data management */}
-      <Panel title="Data management">
+      <Panel title="Data management" subtitle="recorded sessions and laps">
         <div className="flex flex-wrap items-center gap-2 p-3">
           <button
             className="btn"
@@ -248,6 +261,27 @@ function ConnectionForm({
           />
         </div>
         <div>
+          <span className="mb-1 block text-xs text-ink-dim">Packet format</span>
+          <SegmentedControl
+            ariaLabel="Packet format"
+            value={settings.packet_format}
+            disabled={busy !== null}
+            onValueChange={(f) =>
+              f !== settings.packet_format &&
+              onApply({ packet_format: f as AdminSettings["packet_format"] }, "Packet format")
+            }
+            options={[
+              { value: "A", label: "A" },
+              { value: "B", label: "B" },
+              { value: "~", label: "~" },
+              { value: "C", label: "C" },
+            ]}
+          />
+          <p className="mt-1 text-[11px] text-ink-dim">
+            C is richest (needs GT7 v1.68+); use A for older game versions.
+          </p>
+        </div>
+        <div>
           <span className="mb-1 block text-xs text-ink-dim">Log level</span>
           <Select
             ariaLabel="Log level"
@@ -280,48 +314,83 @@ function WebhookForm({
   const [url, setUrl] = useState(settings.webhook_url);
   useEffect(() => setUrl(settings.webhook_url), [settings.webhook_url]);
 
+  function toggleEvent(ev: WebhookEvent, on: boolean) {
+    const next = WEBHOOK_EVENTS.map((e) => e.value).filter((e) =>
+      e === ev ? on : settings.webhook_events.includes(e),
+    );
+    onApply({ webhook_events: next }, "Notification events");
+  }
+
   return (
-    <div className="space-y-2 p-4">
-      <label className="block text-xs text-ink-dim" htmlFor="webhook-url">
-        Webhook URL — notified on new personal bests and session summaries
-      </label>
-      <div className="flex gap-2">
-        <input
-          id="webhook-url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://discord.com/api/webhooks/… (or any HTTP endpoint)"
-          className="w-full rounded-md border border-edge bg-panel-2 px-3 py-1.5 font-tabular text-sm placeholder:text-ink-dim/60 focus:border-accent focus:outline-none"
-        />
-        <button
-          className="btn shrink-0"
-          disabled={busy !== null || url === settings.webhook_url}
-          onClick={() => onApply({ webhook_url: url }, "Webhook")}
-        >
-          Apply
-        </button>
-        <button
-          className="btn shrink-0"
-          disabled={busy !== null || !settings.webhook_url}
-          onClick={async () => {
-            setBusy("test-webhook");
-            try {
-              await api.admin.testWebhook();
-              flash("Test notification sent");
-            } catch (e) {
-              flash(e instanceof Error ? e.message : "Webhook test failed", true);
-            } finally {
-              setBusy(null);
-            }
-          }}
-        >
-          Test
-        </button>
+    <div className="space-y-3 p-4">
+      <div>
+        <label className="mb-1 block text-xs text-ink-dim" htmlFor="webhook-url">
+          Webhook URL — where notifications are sent
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="webhook-url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://discord.com/api/webhooks/… (or any HTTP endpoint)"
+            className="w-full rounded-md border border-edge bg-panel-2 px-3 py-1.5 font-tabular text-sm placeholder:text-ink-dim/60 focus:border-accent focus:outline-none"
+          />
+          <button
+            className="btn shrink-0"
+            disabled={busy !== null || url === settings.webhook_url}
+            onClick={() => onApply({ webhook_url: url }, "Webhook")}
+          >
+            Apply
+          </button>
+          <button
+            className="btn shrink-0"
+            disabled={busy !== null || !settings.webhook_url}
+            onClick={async () => {
+              setBusy("test-webhook");
+              try {
+                await api.admin.testWebhook();
+                flash("Test notification sent");
+              } catch (e) {
+                flash(e instanceof Error ? e.message : "Webhook test failed", true);
+              } finally {
+                setBusy(null);
+              }
+            }}
+          >
+            Test
+          </button>
+        </div>
+        <p className="mt-1 text-[11px] text-ink-dim">
+          Discord webhook URLs get a rich embed; any other URL receives plain JSON. Leave
+          empty to disable all notifications.
+        </p>
       </div>
-      <p className="text-[11px] text-ink-dim">
-        Discord webhook URLs get a rich embed; any other URL receives plain JSON. Leave empty
-        to disable.
-      </p>
+
+      <div>
+        <span className="mb-1 block text-xs text-ink-dim">Notify me when…</span>
+        <div className="space-y-1">
+          {WEBHOOK_EVENTS.map((ev) => (
+            <label
+              key={ev.value}
+              className="flex cursor-pointer items-baseline gap-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                className="translate-y-px accent-sky-400"
+                checked={settings.webhook_events.includes(ev.value)}
+                disabled={busy !== null || !settings.webhook_url}
+                onChange={(e) => toggleEvent(ev.value, e.target.checked)}
+              />
+              <span>{ev.label}</span>
+              <span className="text-[11px] text-ink-dim">— {ev.hint}</span>
+            </label>
+          ))}
+        </div>
+        <p className="mt-1.5 text-[11px] text-ink-dim">
+          Overtake / position events only fire in races where GT7 reports live positions;
+          changes must hold for ~1 s so side-by-side battles don't spam.
+        </p>
+      </div>
     </div>
   );
 }
@@ -394,11 +463,26 @@ function LogViewer() {
   );
 }
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+function Panel({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="rounded-xl bg-panel">
-      <div className="border-b border-edge px-3 py-2 text-[10px] font-semibold uppercase tracking-widest text-ink-dim">
-        {title}
+      <div className="flex items-baseline gap-2 border-b border-edge px-3 py-2">
+        <span className="text-[10px] font-semibold uppercase tracking-widest text-ink-dim">
+          {title}
+        </span>
+        {subtitle && (
+          <span className="text-[11px] normal-case tracking-normal text-ink-dim/80">
+            {subtitle}
+          </span>
+        )}
       </div>
       {children}
     </div>


### PR DESCRIPTION
## What's in this release

Three streams of work, ending with the 0.3.0 release commit (changelog + version bumps).

### Features

- **GT7 extended packet support (B / `~` / C)** — the heartbeat character now selects the format, each format's distinct Salsa20 IV XOR constant is handled, and the new fields (steering, sway/heave/surge, filtered inputs, torque vectors, energy recovery, per-wheel surface type, live lap timer, wheelbase, car category) are parsed into the model. Default is packet **C** (needs GT7 v1.68+); `GT7_PACKET_FORMAT` or the new Admin control switch it live — older game versions can drop back to `A`. The simulator emits packet C so the whole path runs in dev.
- **Race-event webhooks** — overtakes, positions lost, and off-road excursions (3+ wheels on a loose surface, via packet C surface data) join the existing PB/session notifications. Position changes must hold ~1 s so side-by-side battles don't spam; one off-road excursion = one event with re-arm. Every event has an Admin toggle (`GT7_WEBHOOK_EVENTS`). Caveat, documented: GT7 only reports a live race position in some race types — elsewhere position events simply never fire.

### Fixes from an adversarial review (all 8 findings)

- **Opt-in admin auth** (`GT7_ADMIN_TOKEN` → `X-API-Key`) gating the Admin API and every mutating endpoint; reads/overlay/dash/WS stay open. Unset = previous fully-open behavior.
- **Lap timing robust to packet loss** — t/dist integrate the console's packet counter instead of assuming perfect 60 Hz; input metrics are time-weighted; new `frames_dropped` diagnostic.
- **Per-client WebSocket queues** — a stalled viewer can no longer backpressure telemetry capture (frames latest-wins; lap/session events never dropped).
- **Source restart race** — `stop()` awaits task teardown and socket release before the port is rebound (the new test caught a second asyncio scheduling race here).
- **Lap import validation** — required columns, equal lengths, finite numbers, 120k-sample cap; clear 400s instead of stored laps that 500 during analysis; rejected imports no longer leak an empty session.
- **CSV export** via `csv.writer` with a formula-injection guard (byte-identical output for clean data).
- **Webhook hardening** — redirects pinned off; trust model documented (LAN targets intentional; the admin token guards configuration).
- **Sessions list** is one aggregate query instead of N+1.

Also fixed along the way: fuel-strategy widgets mixing laps from a previous session/car, and `dev.sh` now rebuilds the frontend so `:8000` never serves a stale build.

### ⚠️ Breaking change

Wildcard CORS is removed. The bundled UI is unaffected (same-origin in dev via the vite proxy and in prod via the SPA mount); separate cross-origin consumers must set `GT7_CORS_ORIGINS`.

## Verification

- **124 backend tests** (95 → 124: new suites for auth, WS backpressure, import validation, source restarts, packet-drop timing, live events, extended packets), ruff + strict mypy clean, frontend tsc/eslint/build clean.
- Live e2e in sim mode: packet C end-to-end with 0 decode errors; token mode verified (401 bare / 403 wrong / 200 with token, reads stay open, Admin UI prompts for the token instead of hanging); no CORS headers on cross-origin probes; webhook delivery verified against a local endpoint.

## Reviewer notes

- Packet layouts and per-format IV constants were cross-checked against Nenkai/PDTools and MacManley/gt7-udp.
- Docs updated throughout (admin guide, configuration, troubleshooting, telemetry-capture and lap-detection internals, README, changelog).
- Suggest tagging `v0.3.0` on main after merge.