### PR TITLE
Fix pit out-laps poisoning session best, live delta, and fuel projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Notable changes to GT7 Datalogger. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Pit out-laps no longer poison the session best / live delta**: a short out-lap
+  (GT7 reports a time for it, but it covers only part of the track with a
+  pit-exit-anchored distance axis) could become the delta reference — the live
+  delta then glitched for the first fraction of the next lap and froze on a bogus
+  ~lap-sized fallback value. Laps now only count for best when their distance span
+  matches the session's longest lap (85 %), and a full lap invalidates a partial
+  "best" retroactively.
+- **Fuel projection survives race restarts**: recent laps are filtered by car
+  (not recording session), so a restart keeps the previous stint's consumption
+  data — you get a range estimate from the first meters instead of after a full
+  lap, which matters in races with aggressive fuel multipliers. Partial-lap
+  outliers (a lap consuming < 50 % of the window max, i.e. pit out-laps) are
+  excluded from the average.
+
 ## [0.3.0] - 2026-08-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Notable changes to GT7 Datalogger. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-numbered corners on the track map**: corners are detected from the
+  reference lap's racing-line signed curvature (hysteresis segmentation,
+  direction-aware split/merge, start/finish wrap stitching, apex at the
+  curvature-weighted centroid) and numbered from the start line, GT7 Data
+  Logger-style. Numbered circles while ≤ 30 corners are in view, dots beyond;
+  the Corner Detail widget shows the current corner (e.g. `T5 R`) while
+  scrubbing. Detection parameters were tuned against real GT7 laps for
+  identical counts and < 30 m apex drift across laps of the same track.
+
 ### Fixed
 
 - **Pit out-laps no longer poison the session best / live delta**: a short out-lap

--- a/TODO.md
+++ b/TODO.md
@@ -203,15 +203,16 @@ Change who would use the tool.
   centerline. Fictional GT7 tracks still need edge tracing. Their own backend
   (api.gt-telemetry.com/tracks) is auth-gated and its data unlicensed — don't scrape it;
   ask via GitHub issue if we ever want their fictional-track layouts.
-- [ ] **Auto-numbered corners on the track map** *(tabled 2026-07-26 — prototyped, then
-  reverted; the naive version was wrong)*. Detect corners from racing-line curvature and
-  number them from the start line, GT7-Data-Logger style. Lesson from the failed attempt:
-  UNSIGNED curvature is not enough — a long hairpin splits into two corners where curvature
-  dips mid-arc, and an S-section merges into one. A correct detector needs **signed**
-  curvature (split regions when turn direction flips, merge only same-direction arcs),
-  hysteresis on the threshold, and probably apex-at-minimum-speed rather than
-  apex-at-max-curvature. Display rule that worked: dots on the full map, numbered circles
-  only when the zoomed section shows ≤ ~30 corners.
+- [x] **Auto-numbered corners on the track map** *(shipped 2026-08-05; tabled
+  2026-07-26 after a failed unsigned-curvature prototype)*. Signed curvature with
+  hysteresis (enter 0.0030, stay 0.0022 rad/m), noise arcs dropped before same-direction
+  merging (90 m gap), 25°–300° significance band, start/finish wrap stitching, apex at
+  the curvature-weighted centroid (min-speed apexes wander ~100 m between laps —
+  the spec's own assumption proved wrong when validated against real laps). Parameters
+  tuned for identical counts + <30 m apex drift across 5 real GT7 sessions. Numbered
+  circles ≤30 in view, dots beyond; detection on the reference lap only. Follow-up
+  idea: per-track canonical corner store (median of clean laps) so numbering survives
+  reference-lap switches.
 
 ---
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -357,7 +357,11 @@ async def compare(
             "peaks_valleys": analysis.speed_peaks_valleys(samples),
             "events": events_by_id.get(lap_id, []),
         }
-        if lap_id != ref:
+        if lap_id == ref:
+            # Corner numbering comes from the reference lap only, so every
+            # overlaid lap shares one consistent set of map markers.
+            entry["corners"] = analysis.detect_corners(samples)
+        else:
             entry["delta"] = analysis.time_delta_series(samples, samples_by_id[ref], step)
         out["laps"][str(lap_id)] = entry
     return out

--- a/backend/app/processing/analysis.py
+++ b/backend/app/processing/analysis.py
@@ -6,6 +6,7 @@ LapProcessor (see SAMPLE_COLUMNS in laps.py).
 
 from __future__ import annotations
 
+import math
 from bisect import bisect_left
 from dataclasses import dataclass
 
@@ -147,6 +148,213 @@ def speed_peaks_valleys(
             i += w
         i += 1
     return {"peaks": peaks, "valleys": valleys}
+
+
+# --- Corner detection -------------------------------------------------------
+
+# Parameters empirically tuned against real GT7 laps (5 sessions, road courses
+# + a banked oval): the goal is IDENTICAL corner counts and <30 m apex drift
+# across laps of the same track — numbered corners that renumber between laps
+# are useless. The hysteresis band is deliberately narrow: K_HI above ~0.0035
+# loses banked/high-speed corners entirely, K_LO below ~0.002 sinks into the
+# road-noise floor and bleeds adjacent corners together.
+CORNER_STEP_M = 2.0  # uniform resample grid for curvature
+CORNER_HALF_WIN_M = 16.0  # heading measured over ±this many meters
+CORNER_K_HI = 0.0030  # rad/m — |curvature| to enter a corner (~330 m radius)
+CORNER_K_LO = 0.0022  # rad/m — |curvature| to stay in one
+CORNER_END_GAP_M = 40.0  # below K_LO for this long ends the segment
+CORNER_MERGE_GAP_M = 90.0  # same-direction arcs closer than this merge
+CORNER_NOISE_ANGLE_DEG = 12.0  # arcs below this are noise, dropped pre-merge
+CORNER_MIN_ANGLE_DEG = 25.0  # final significance threshold
+CORNER_MAX_ANGLE_DEG = 300.0  # beyond this it's a spin, not a corner
+
+
+def _wrap_angle(a: float) -> float:
+    """Wrap to (-pi, pi]."""
+    while a <= -math.pi:
+        a += 2 * math.pi
+    while a > math.pi:
+        a -= 2 * math.pi
+    return a
+
+
+@dataclass(slots=True)
+class _Arc:
+    start: int  # indices into the resampled grid
+    end: int  # inclusive
+    sign: int
+    angle: float  # total heading change, radians (signed)
+
+
+def detect_corners(samples: Samples) -> list[dict[str, float | int | str]]:
+    """Auto-numbered corners from the racing line's signed curvature.
+
+    Pipeline (each stage exists because the naive version failed on real
+    laps — see docs/internals/analysis-math.md):
+    resample to a uniform grid → signed curvature from wrapped chord-heading
+    deltas → hysteresis segmentation that splits on direction flips → drop
+    sub-noise arcs BEFORE merging (a surviving opposite blip would block
+    merges on some laps only) → merge same-direction arcs across short gaps
+    (a hairpin whose curvature dips mid-arc is one corner) → keep significant
+    arcs → apex at the curvature-weighted centroid (min speed sits at the
+    segment edge and wanders ~100 m between laps).
+    """
+    dist = samples.get("dist") or []
+    xs = samples.get("pos_x") or []
+    zs = samples.get("pos_z") or []
+    speed = samples.get("speed") or []
+    n = min(len(dist), len(xs), len(zs), len(speed) or len(dist))
+    if n < 8:
+        return []
+    speed = speed[:n] if speed else [0.0] * n
+
+    # Strictly increasing distance only — duplicates/backwards points (pause
+    # edges, imports) break interpolation.
+    keep = [0]
+    for i in range(1, n):
+        if dist[i] > dist[keep[-1]]:
+            keep.append(i)
+    if len(keep) < 8 or dist[keep[-1]] - dist[keep[0]] < 8 * CORNER_STEP_M:
+        return []
+    d = [dist[i] for i in keep]
+    px = [xs[i] for i in keep]
+    pz = [zs[i] for i in keep]
+    sp = [speed[i] for i in keep]
+
+    # Uniform 2 m grid decouples curvature from the 60 Hz speed-dependent
+    # sample spacing.
+    total = d[-1] - d[0]
+    m = int(total / CORNER_STEP_M) + 1
+    grid = [d[0] + i * CORNER_STEP_M for i in range(m)]
+    gx = [_interp(d, px, g) for g in grid]
+    gz = [_interp(d, pz, g) for g in grid]
+    gs = [_interp(d, sp, g) for g in grid]
+
+    # Signed curvature: wrapped delta between the chord headings of the two
+    # half-windows either side of each point, divided by the half-span.
+    w = max(1, int(CORNER_HALF_WIN_M / CORNER_STEP_M))
+    curv = [0.0] * m
+    for i in range(w, m - w):
+        dx0, dz0 = gx[i] - gx[i - w], gz[i] - gz[i - w]
+        dx1, dz1 = gx[i + w] - gx[i], gz[i + w] - gz[i]
+        if (dx0 == 0 and dz0 == 0) or (dx1 == 0 and dz1 == 0):
+            continue
+        dh = _wrap_angle(math.atan2(dz1, dx1) - math.atan2(dz0, dx0))
+        curv[i] = dh / (w * CORNER_STEP_M)
+
+    arcs = _segment_arcs(curv)
+    # Noise arcs are discarded BEFORE merging so they cannot block a merge.
+    arcs = [a for a in arcs if abs(math.degrees(a.angle)) >= CORNER_NOISE_ANGLE_DEG]
+    arcs = _merge_arcs(arcs)
+    # Stitch BEFORE the significance filter: a corner split by the start line
+    # must be judged on its combined angle, not per half (a 40° corner split
+    # 20/20 would otherwise vanish). The spin cap also applies post-stitch.
+    arcs = _stitch_wraparound(arcs, m)
+    arcs = [
+        a
+        for a in arcs
+        if CORNER_MIN_ANGLE_DEG <= abs(math.degrees(a.angle)) <= CORNER_MAX_ANGLE_DEG
+    ]
+
+    corners: list[dict[str, float | int | str]] = []
+    for a in sorted(arcs, key=lambda a: _apex_index(a, curv)):
+        i = _apex_index(a, curv)
+        corners.append(
+            {
+                "n": len(corners) + 1,
+                "apex_dist": round(grid[i], 1),
+                "apex_x": round(gx[i], 1),
+                "apex_z": round(gz[i], 1),
+                "entry_dist": round(grid[a.start], 1),
+                "exit_dist": round(grid[a.end], 1),
+                # Positive heading delta is CCW in raw x/z, but the map (and
+                # GT7's own view) renders z inverted — that's a right-hander.
+                "direction": "R" if a.sign > 0 else "L",
+                "min_speed": round(min(gs[a.start : a.end + 1]), 1),
+                "angle_deg": round(abs(math.degrees(a.angle)), 1),
+            }
+        )
+    return corners
+
+
+def _segment_arcs(curv: list[float]) -> list[_Arc]:
+    """Hysteresis segmentation of the curvature series, split on sign flips."""
+    end_gap = int(CORNER_END_GAP_M / CORNER_STEP_M)
+    arcs: list[_Arc] = []
+    i = 0
+    m = len(curv)
+    while i < m:
+        if abs(curv[i]) <= CORNER_K_HI:
+            i += 1
+            continue
+        sign = 1 if curv[i] > 0 else -1
+        start = i
+        last_active = i
+        angle = 0.0
+        while i < m:
+            k = curv[i]
+            if k * sign > 0 and abs(k) >= CORNER_K_LO:
+                last_active = i
+                angle += k * CORNER_STEP_M
+                i += 1
+            elif k * -sign > CORNER_K_HI:
+                break  # strong opposite curvature: an S — new corner
+            elif i - last_active >= end_gap:
+                break  # faded out for long enough
+            else:
+                i += 1
+        arcs.append(_Arc(start=start, end=last_active, sign=sign, angle=angle))
+    return arcs
+
+
+def _merge_arcs(arcs: list[_Arc]) -> list[_Arc]:
+    """Merge same-direction arcs across short gaps (double-apex complexes)."""
+    gap = int(CORNER_MERGE_GAP_M / CORNER_STEP_M)
+    out: list[_Arc] = []
+    for a in arcs:
+        prev = out[-1] if out else None
+        if prev is not None and prev.sign == a.sign and a.start - prev.end <= gap:
+            prev.end = a.end
+            prev.angle += a.angle
+        else:
+            out.append(_Arc(a.start, a.end, a.sign, a.angle))
+    return out
+
+
+def _stitch_wraparound(arcs: list[_Arc], m: int) -> list[_Arc]:
+    """A lap that starts mid-corner shows one physical corner split across
+    the start/finish line; merge the two halves into one corner.
+
+    Each half may sit at most half the merge gap from its lap edge, so the
+    combined tolerance matches the mid-lap merge distance. The larger half
+    keeps the corner's extent/apex (a wrapped extent isn't representable);
+    min_speed therefore covers only that half — a known approximation.
+    """
+    edge = int(CORNER_MERGE_GAP_M / 2 / CORNER_STEP_M)
+    if len(arcs) < 2:
+        return arcs
+    first, last = arcs[0], arcs[-1]
+    if (
+        first.sign == last.sign
+        and first.start <= edge
+        and m - 1 - last.end <= edge
+    ):
+        keep, other = (first, last) if abs(first.angle) >= abs(last.angle) else (last, first)
+        keep.angle += other.angle
+        return [keep, *arcs[1:-1]] if keep is first else arcs[1:]
+    return arcs
+
+
+def _apex_index(a: _Arc, curv: list[float]) -> int:
+    """Curvature-weighted centroid: stable within ~25 m across laps, where
+    the min-speed point wanders with braking for the NEXT corner."""
+    total = 0.0
+    weighted = 0.0
+    for i in range(a.start, a.end + 1):
+        w = abs(curv[i])
+        total += w
+        weighted += w * i
+    return round(weighted / total) if total > 0 else (a.start + a.end) // 2
 
 
 # --- Fuel map ---------------------------------------------------------------

--- a/backend/app/processing/laps.py
+++ b/backend/app/processing/laps.py
@@ -23,6 +23,13 @@ MIN_LAP_TICKS = 600
 # reset, long outage) — extrapolating a minute of distance at current speed
 # would corrupt the lap worse than under-counting one frame does.
 MAX_FRAME_GAP = 60
+# Partial-lap guard: an out-lap from the pits covers only part of the track
+# (and its distance axis starts at the pit exit, not the line), so it must
+# never become the session best or the live-delta reference. A lap "counts"
+# only when its distance span is within this fraction of the longest counted
+# lap; a lap longer than the counted span by the inverse margin proves the
+# earlier "best" was partial and invalidates it.
+FULL_LAP_SPAN_RATIO = 0.85
 
 # Columnar per-tick series kept for each lap. Column order matters for the
 # frontend; keep in sync with frontend/src/lib/types.ts.
@@ -83,6 +90,10 @@ class CompletedLap:
     # Static per lap: {"ratios": [...], "top_speed": float, "rpm_alert": float}
     gearing: dict[str, object] | None = None
     events: list[dict[str, object]] = field(default_factory=list)
+    # Partial-lap flags (see FULL_LAP_SPAN_RATIO): whether this lap may set
+    # the session best, and whether it proved the previous best was partial.
+    counts_for_best: bool = True
+    invalidated_best: bool = False
 
     def compute_metrics(self) -> None:
         # Imported laps from older export versions may lack the newer columns;
@@ -149,6 +160,7 @@ class LapProcessor:
     _last_pid: int = -1
     _pending_dt: int = 1  # frames covered by the next sample (1 = no drops)
     _dropped_frames: int = 0
+    _best_span: float = 0.0  # distance span of the longest counted lap
     _fuel_start: float = 0.0
     _last_packet: TelemetryPacket | None = None
     # Engine-health aggregates for the lap in progress (not per-tick columns)
@@ -196,6 +208,7 @@ class LapProcessor:
                 started_at=datetime.now(UTC).isoformat(),
             )
             self._current_lap = -1
+            self._best_span = 0.0
             await self.on_session(self._session)
 
         if p.current_lap != self._current_lap:
@@ -254,8 +267,25 @@ class LapProcessor:
             lap.compute_metrics()
             assert self._session is not None
             self._session.lap_count += 1
-            if self._session.best_lap_time_ms < 0 or lap.time_ms < self._session.best_lap_time_ms:
-                self._session.best_lap_time_ms = lap.time_ms
+
+            # Partial-lap guard: only laps spanning (roughly) the full track
+            # may set the session best; a clearly longer lap proves earlier
+            # "bests" were partial out-laps and voids them.
+            span = finished_samples["dist"][-1] if finished_samples["dist"] else 0.0
+            if self._best_span > 0 and span * FULL_LAP_SPAN_RATIO > self._best_span:
+                lap.invalidated_best = True
+                self._session.best_lap_time_ms = -1
+                self._best_span = 0.0
+            lap.counts_for_best = (
+                self._best_span == 0.0 or span >= self._best_span * FULL_LAP_SPAN_RATIO
+            )
+            if lap.counts_for_best:
+                self._best_span = max(self._best_span, span)
+                if (
+                    self._session.best_lap_time_ms < 0
+                    or lap.time_ms < self._session.best_lap_time_ms
+                ):
+                    self._session.best_lap_time_ms = lap.time_ms
             await self.on_lap(lap)
 
     def _append_sample(self, p: TelemetryPacket) -> None:

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -192,23 +192,32 @@ class TelemetryService:
         lap_id = await self.repo.save_lap(self.session_id, lap)
         log.info("lap %d saved (%d ms, id=%d)", lap.number, lap.time_ms, lap_id)
 
+        # A longer lap just proved the stored "best" was a partial out-lap:
+        # forget it — comparing deltas against a fraction of the track (with
+        # a pit-exit-anchored distance axis) produces garbage.
+        if lap.invalidated_best:
+            self._session_best_ms = None
+            self._prev_best_ms = None
+            self._best_ref = None
+
         # Remember the best BEFORE this lap: the live "Δ best" compares the
         # latest lap against it (comparing against a best that already
         # includes the latest lap can never show an improvement).
         self._prev_best_ms = self._session_best_ms
 
-        # Personal best (only when beating an existing best, not on the first lap)
-        if self._session_best_ms is not None and lap.time_ms < self._session_best_ms:
-            self.notifier.personal_best(
-                lap.time_ms,
-                self._session_best_ms,
-                lap.number,
-                self.cars.name(lap.car_id),
-                self.track_name,
-            )
-        if self._session_best_ms is None or lap.time_ms < self._session_best_ms:
-            self._session_best_ms = lap.time_ms
-            self._best_ref = {"dist": lap.samples["dist"], "t": lap.samples["t"]}
+        if lap.counts_for_best:
+            # Personal best (only when beating an existing best, not on the first lap)
+            if self._session_best_ms is not None and lap.time_ms < self._session_best_ms:
+                self.notifier.personal_best(
+                    lap.time_ms,
+                    self._session_best_ms,
+                    lap.number,
+                    self.cars.name(lap.car_id),
+                    self.track_name,
+                )
+            if self._session_best_ms is None or lap.time_ms < self._session_best_ms:
+                self._session_best_ms = lap.time_ms
+                self._best_ref = {"dist": lap.samples["dist"], "t": lap.samples["t"]}
 
         # Track auto-identification from the first completed lap's geometry
         if not self.track_name:

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -194,11 +194,14 @@ class TelemetryService:
 
         # A longer lap just proved the stored "best" was a partial out-lap:
         # forget it — comparing deltas against a fraction of the track (with
-        # a pit-exit-anchored distance axis) produces garbage.
+        # a pit-exit-anchored distance axis) produces garbage. The saved rows
+        # are re-flagged too, so DB best-lap aggregates (Sessions view,
+        # session-summary webhook) drop them as well.
         if lap.invalidated_best:
             self._session_best_ms = None
             self._prev_best_ms = None
             self._best_ref = None
+            await self.repo.mark_session_laps_partial(self.session_id, lap_id)
 
         # Remember the best BEFORE this lap: the live "Δ best" compares the
         # latest lap against it (comparing against a best that already
@@ -227,6 +230,8 @@ class TelemetryService:
             "session_id": self.session_id,
             "number": lap.number,
             "time_ms": lap.time_ms,
+            "car_id": lap.car_id,
+            "counts_for_best": lap.counts_for_best,
             "car_name": self.cars.name(lap.car_id),
             "fuel_consumed": round(lap.fuel_consumed, 3),
             "full_throttle_pct": round(lap.full_throttle_pct, 1),

--- a/backend/app/storage/db.py
+++ b/backend/app/storage/db.py
@@ -96,6 +96,8 @@ class LapRow(Base):
     max_water_temp: Mapped[float] = mapped_column(default=0.0)
     max_oil_temp: Mapped[float] = mapped_column(default=0.0)
     min_oil_pressure: Mapped[float] = mapped_column(default=-1.0)
+    # False for partial laps (pit out-laps): excluded from best-lap aggregates
+    counts_for_best: Mapped[bool] = mapped_column(default=True)
     events_json: Mapped[str] = mapped_column(Text, default="[]")
     gearing_json: Mapped[str] = mapped_column(Text, default="")
     samples_json: Mapped[str] = mapped_column(Text)
@@ -124,6 +126,11 @@ _SQLITE_MIGRATIONS = (
         "ALTER TABLE sessions ADD COLUMN track_name VARCHAR NOT NULL DEFAULT ''",
     ),
     ("laps", "tod_ms", "ALTER TABLE laps ADD COLUMN tod_ms INTEGER NOT NULL DEFAULT -1"),
+    (
+        "laps",
+        "counts_for_best",
+        "ALTER TABLE laps ADD COLUMN counts_for_best BOOLEAN NOT NULL DEFAULT 1",
+    ),
 ) + tuple(
     ("laps", column, f"ALTER TABLE laps ADD COLUMN {column} {ddl}")
     for column, ddl in (

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -6,7 +6,7 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import case, delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.processing.laps import CompletedLap, SessionInfo
@@ -42,6 +42,7 @@ def lap_summary(row: LapRow) -> dict[str, Any]:
         "max_water_temp": row.max_water_temp,
         "max_oil_temp": row.max_oil_temp,
         "min_oil_pressure": row.min_oil_pressure,
+        "counts_for_best": row.counts_for_best,
         "event_counts": _event_counts(row.events_json),
     }
 
@@ -88,6 +89,7 @@ class Repository:
                 tod_ms=lap.tod_ms,
                 tcs_active_pct=lap.tcs_active_pct,
                 asm_active_pct=lap.asm_active_pct,
+                counts_for_best=lap.counts_for_best,
                 max_water_temp=lap.max_water_temp,
                 max_oil_temp=lap.max_oil_temp,
                 min_oil_pressure=lap.min_oil_pressure,
@@ -103,9 +105,12 @@ class Repository:
         # One aggregate query for all sessions; the outer join keeps lap-less
         # sessions and only touches LapRow ids/times (never samples_json).
         async with self._sf() as db:
+            # Best excludes partial laps (pit out-laps, counts_for_best=0):
+            # their GT7-reported "times" aren't full-lap times.
+            best_expr = func.min(case((LapRow.counts_for_best, LapRow.time_ms)))
             rows = (
                 await db.execute(
-                    select(SessionRow, func.count(LapRow.id), func.min(LapRow.time_ms))
+                    select(SessionRow, func.count(LapRow.id), best_expr)
                     .outerjoin(LapRow, LapRow.session_id == SessionRow.id)
                     .group_by(SessionRow.id)
                     .order_by(SessionRow.id.desc())
@@ -136,7 +141,8 @@ class Repository:
                 await db.execute(
                     select(
                         func.count(LapRow.id),
-                        func.min(LapRow.time_ms),
+                        # partial out-laps don't own the session best
+                        func.min(case((LapRow.counts_for_best, LapRow.time_ms))),
                         func.coalesce(func.sum(LapRow.fuel_consumed), 0.0),
                         func.min(LapRow.car_id),
                     ).where(LapRow.session_id == session_id)
@@ -148,6 +154,21 @@ class Repository:
                 "fuel_used": fuel_used,
                 "car_id": car_id if car_id is not None else 0,
             }
+
+    async def mark_session_laps_partial(self, session_id: int, keep_lap_id: int) -> None:
+        """Flag every lap of the session except `keep_lap_id` as partial.
+
+        Called when a newly completed lap's distance span proves the earlier
+        laps were partial (out-laps): by the span invariant, every prior lap
+        of the session is shorter than 85 % of the new baseline.
+        """
+        async with self._sf() as db:
+            await db.execute(
+                update(LapRow)
+                .where(LapRow.session_id == session_id, LapRow.id != keep_lap_id)
+                .values(counts_for_best=False)
+            )
+            await db.commit()
 
     async def list_laps(self, session_id: int | None = None) -> list[dict[str, Any]]:
         async with self._sf() as db:

--- a/backend/tests/test_analysis.py
+++ b/backend/tests/test_analysis.py
@@ -100,3 +100,225 @@ def test_interp_edges() -> None:
     assert analysis._interp(xs, ys, -5.0) == 0.0
     assert analysis._interp(xs, ys, 15.0) == 100.0
     assert analysis._interp(xs, ys, 5.0) == pytest.approx(50.0)
+
+
+# --- corner detection --------------------------------------------------------
+
+
+def track_lap(segments, step: float = 2.0, speed_kmh: float = 180.0) -> dict:
+    """Build a lap from ('straight', length_m) / ('arc', radius_m, angle_deg)
+    segments. Positive angle turns left (CCW in x/z), negative right."""
+    import math
+
+    s = new_sample_store()
+    x, z, heading, dist = 0.0, 0.0, 0.0, 0.0
+
+    def emit() -> None:
+        s["dist"].append(round(dist, 2))
+        s["pos_x"].append(round(x, 3))
+        s["pos_z"].append(round(z, 3))
+        s["speed"].append(speed_kmh)
+        s["t"].append(dist / (speed_kmh / 3.6))
+
+    emit()
+    for seg in segments:
+        if seg[0] == "straight":
+            length = seg[1]
+            n = max(1, int(length / step))
+            for _ in range(n):
+                x += step * math.cos(heading)
+                z += step * math.sin(heading)
+                dist += step
+                emit()
+        else:
+            _, radius, angle_deg = seg
+            arc_len = abs(math.radians(angle_deg)) * radius
+            n = max(2, int(arc_len / step))
+            dh = math.radians(angle_deg) / n
+            for _ in range(n):
+                heading += dh
+                x += step * math.cos(heading)
+                z += step * math.sin(heading)
+                dist += step
+                emit()
+    return s
+
+
+def test_corners_straight_line_has_none() -> None:
+    lap = track_lap([("straight", 2000)])
+    assert analysis.detect_corners(lap) == []
+
+
+def test_corners_single_90_degree_turn() -> None:
+    lap = track_lap([("straight", 400), ("arc", 100, 90), ("straight", 400)])
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 1
+    c = corners[0]
+    assert c["n"] == 1
+    assert c["direction"] == "R"  # positive heading delta renders as a right-hander
+    assert 60 <= c["angle_deg"] <= 120
+    # apex roughly mid-arc: arc spans 400..557
+    assert 400 <= c["apex_dist"] <= 560
+
+
+def test_corners_s_section_is_two_corners() -> None:
+    lap = track_lap(
+        [("straight", 300), ("arc", 90, 80), ("arc", 90, -80), ("straight", 300)]
+    )
+    corners = analysis.detect_corners(lap)
+    assert [c["direction"] for c in corners] == ["R", "L"]
+    assert [c["n"] for c in corners] == [1, 2]
+
+
+def test_corners_hairpin_with_mid_dip_is_one_corner() -> None:
+    # 180° hairpin whose curvature briefly relaxes mid-arc (double-apex):
+    # two 85° arcs joined by a ~42 m near-straight interlude (real GT7
+    # double-apex complexes contain 50-80 m low-curvature interludes).
+    lap = track_lap(
+        [
+            ("straight", 400),
+            ("arc", 60, 85),
+            ("arc", 1200, 2),  # low-curvature interlude, same direction
+            ("arc", 60, 85),
+            ("straight", 400),
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 1
+    assert corners[0]["angle_deg"] > 120
+
+
+def test_corners_numbered_in_track_order() -> None:
+    lap = track_lap(
+        [
+            ("straight", 300),
+            ("arc", 80, 90),
+            ("straight", 500),
+            ("arc", 70, -120),
+            ("straight", 500),
+            ("arc", 90, 60),
+            ("straight", 300),
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert [c["n"] for c in corners] == [1, 2, 3]
+    dists = [c["apex_dist"] for c in corners]
+    assert dists == sorted(dists)
+    assert [c["direction"] for c in corners] == ["R", "L", "R"]
+
+
+def test_corners_shallow_kink_ignored() -> None:
+    # 10° bend at huge radius: a kink, not a corner
+    lap = track_lap([("straight", 500), ("arc", 500, 10), ("straight", 500)])
+    assert analysis.detect_corners(lap) == []
+
+
+def test_corners_spin_arc_dropped() -> None:
+    # A 420° loop (spin) must not be numbered
+    lap = track_lap(
+        [("straight", 400), ("arc", 80, 90), ("straight", 200), ("arc", 20, 420),
+         ("straight", 200), ("arc", 80, -90), ("straight", 400)]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 2
+    assert all(c["angle_deg"] <= 300 for c in corners)
+
+
+def test_corners_wraparound_stitch() -> None:
+    # Lap starts mid-corner: the same physical corner appears at the very
+    # start and very end; it must be counted once.
+    lap = track_lap(
+        [
+            ("arc", 80, 45),  # second half of the start/finish corner
+            ("straight", 600),
+            ("arc", 80, 90),
+            ("straight", 600),
+            ("arc", 80, 45),  # first half of the start/finish corner
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 2
+
+
+def test_corners_degenerate_inputs() -> None:
+    assert analysis.detect_corners({}) == []
+    assert analysis.detect_corners({"dist": [], "pos_x": [], "pos_z": [], "speed": []}) == []
+    short = track_lap([("straight", 10)])
+    assert analysis.detect_corners(short) == []
+    # non-monotonic dist must not crash
+    lap = track_lap([("straight", 300), ("arc", 80, 90), ("straight", 300)])
+    lap["dist"][50] = lap["dist"][49]  # duplicate
+    lap["dist"][120] = lap["dist"][119] - 5  # backwards
+    assert isinstance(analysis.detect_corners(lap), list)
+    # unequal lengths must not crash
+    lap2 = track_lap([("straight", 300), ("arc", 80, 90), ("straight", 300)])
+    lap2["speed"] = lap2["speed"][:-30]
+    assert isinstance(analysis.detect_corners(lap2), list)
+
+
+def test_corners_min_speed_reported() -> None:
+    lap = track_lap([("straight", 400), ("arc", 100, 90), ("straight", 400)])
+    # dip the speed inside the corner
+    for i, d in enumerate(lap["dist"]):
+        if 420 <= d <= 540:
+            lap["speed"][i] = 90.0
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 1
+    assert corners[0]["min_speed"] == pytest.approx(90.0, abs=1.0)
+
+
+def test_corners_merge_across_long_interlude() -> None:
+    """A ~73 m low-curvature interlude (real double-apex complexes contain
+    50-80 m ones) is long enough that segmentation splits the arc — the
+    merge stage must recombine it. Guards _merge_arcs against regressions."""
+    lap = track_lap(
+        [
+            ("straight", 400),
+            ("arc", 60, 85),
+            ("arc", 1200, 3.5),  # ~73 m near-straight, same direction
+            ("arc", 60, 85),
+            ("straight", 400),
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 1
+    assert corners[0]["angle_deg"] > 120
+
+
+def test_corners_split_by_start_line_survives_significance_filter() -> None:
+    """A 40° corner split 20/20 across the start/finish line: each half is
+    below the 25° significance threshold, so stitching must happen first."""
+    lap = track_lap(
+        [
+            ("arc", 150, 20),  # second half of the start/finish corner
+            ("straight", 700),
+            ("arc", 80, 90),
+            ("straight", 700),
+            ("arc", 150, 20),  # first half of the start/finish corner
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 2
+    # The ±16 m curvature window is blind at the lap edges, so the stitched
+    # angle reads low (~27° of the true 40°) — surviving the 25° filter is
+    # the behavior under test.
+    angles = sorted(c["angle_deg"] for c in corners)
+    assert 25.0 <= angles[0] <= 45.0
+
+
+def test_corners_two_distinct_corners_near_line_not_stitched() -> None:
+    """Two separate corners ~120 m apart across the start line must stay two
+    (the stitch tolerance matches the mid-lap 90 m merge gap, not double)."""
+    lap = track_lap(
+        [
+            ("straight", 60),
+            ("arc", 80, 60),
+            ("straight", 700),
+            ("arc", 80, 90),
+            ("straight", 700),
+            ("arc", 80, 60),
+            ("straight", 60),
+        ]
+    )
+    corners = analysis.detect_corners(lap)
+    assert len(corners) == 3

--- a/backend/tests/test_live_delta.py
+++ b/backend/tests/test_live_delta.py
@@ -144,6 +144,17 @@ async def test_partial_outlap_never_stays_the_reference(service) -> None:
     # out-lap (~+58 s, frozen for the rest of the lap).
     assert frame["prev_best_ms"] == -1
 
+    # The persisted aggregates must drop the partial lap too: the Sessions
+    # view and the session-summary webhook read best from the DB, not from
+    # the live service state.
+    sessions = await service.repo.list_sessions()
+    assert sessions[0]["best_lap_time_ms"] == 118_900
+    stats = await service.repo.session_lap_stats(service.session_id)
+    assert stats["best_ms"] == 118_900
+    laps = await service.repo.list_laps(service.session_id)
+    flags = {lap["number"]: lap["counts_for_best"] for lap in laps}
+    assert flags == {1: False, 2: True}
+
 
 async def test_later_pit_outlap_does_not_steal_best(service) -> None:
     await drive(service, lap=1, speed=40.0, ticks=300)

--- a/backend/tests/test_live_delta.py
+++ b/backend/tests/test_live_delta.py
@@ -116,3 +116,47 @@ async def test_live_delta_reference_resets_with_session(service) -> None:
         parse_packet(build_packet(current_lap=1, speed_mps=40.0, flags=ON_TRACK, car_id=42))
     )
     assert service._best_ref is None
+
+
+async def test_partial_outlap_never_stays_the_reference(service) -> None:
+    """A short pit out-lap gets a GT7 lap time but covers a fraction of the
+    track with a pit-exit-anchored distance axis — the first full lap must
+    replace it as session best / delta reference even though it's slower."""
+    await drive(service, lap=1, speed=40.0, ticks=30)  # out-lap: ~20 m span
+    await service._on_packet(packet(lap=2, speed=40.0, last_ms=60_500))
+    assert service._best_ref is not None  # baseline until proven partial
+
+    await drive(service, lap=2, speed=40.0, ticks=300)  # full lap: ~200 m
+    await service._on_packet(packet(lap=3, speed=40.0, last_ms=118_900))
+
+    assert service._session_best_ms == 118_900  # slower but real
+    assert service.processor.session is not None
+    assert service.processor.session.best_lap_time_ms == 118_900
+    ref = service._best_ref
+    assert ref is not None
+    assert ref["dist"][-1] == pytest.approx(300 * 40 / 60, rel=0.05)
+
+    p = await drive(service, lap=3, speed=40.0, ticks=5)
+    frame = service._live_frame(p)
+    assert frame["session_best_ms"] == 118_900
+    # prev_best must not point at the phantom out-lap time — the delta
+    # widget's end-of-lap fallback would otherwise show last-lap minus
+    # out-lap (~+58 s, frozen for the rest of the lap).
+    assert frame["prev_best_ms"] == -1
+
+
+async def test_later_pit_outlap_does_not_steal_best(service) -> None:
+    await drive(service, lap=1, speed=40.0, ticks=300)
+    await service._on_packet(packet(lap=2, speed=40.0, last_ms=118_900))
+    assert service._session_best_ms == 118_900
+
+    # Mid-race pit stop: short lap with a meaninglessly low reported time
+    await drive(service, lap=2, speed=40.0, ticks=30)
+    await service._on_packet(packet(lap=3, speed=40.0, last_ms=45_000))
+
+    assert service._session_best_ms == 118_900
+    assert service.processor.session is not None
+    assert service.processor.session.best_lap_time_ms == 118_900
+    ref = service._best_ref
+    assert ref is not None
+    assert ref["dist"][-1] == pytest.approx(300 * 40 / 60, rel=0.05)

--- a/docs/internals/analysis-math.md
+++ b/docs/internals/analysis-math.md
@@ -67,12 +67,47 @@ The ▲/▼ markers on the map are local speed extrema, found with a sliding win
 Valleys approximate apexes (minimum corner speed) and peaks approximate the end of
 acceleration zones — without needing full corner detection.
 
-!!! note "Why no numbered corners?"
-    Curvature-based corner numbering was prototyped and removed: unsigned curvature
-    splits hairpins into two "corners" and merges S-sections into one. Doing it right
-    needs signed curvature with hysteresis — it's on the roadmap; until then the
-    peaks/valleys markers plus the **S1/S2/S3** section-zoom buttons (fixed thirds of
-    the lap distance) cover the workflow.
+## Auto-numbered corners
+
+The numbered circles on the map are corners detected from the **reference lap's**
+racing-line geometry (one canonical set, so every overlaid lap shares the same
+numbering). The detector was tuned empirically against real GT7 laps — 5 sessions
+across road courses and a banked oval — with one acceptance criterion: **identical
+corner counts and < 30 m apex drift across laps of the same track**. Pipeline:
+
+1. Resample positions onto a uniform **2 m** distance grid (strictly-increasing
+   distances only), decoupling curvature from the 60 Hz speed-dependent spacing.
+2. **Signed curvature** at each point: the wrapped angle between the chord headings
+   of the 16 m windows before and after, divided by the span.
+3. **Hysteresis segmentation**: enter a corner when |κ| > 0.0030 rad/m (~330 m
+   radius), stay while same-signed |κ| > 0.0022, end after 40 m below that. Strong
+   opposite curvature splits immediately — an S-section is two corners even when
+   the magnitude never dips.
+4. Arcs turning less than **12°** are noise and are dropped *before* merging —
+   a surviving opposite blip would block a merge on some laps only, which was the
+   dominant instability in early tuning.
+5. Same-direction arcs within **90 m** merge: a hairpin or double-apex complex
+   whose curvature relaxes mid-arc stays one corner (real complexes contain
+   50–80 m low-curvature interludes).
+6. A lap that starts mid-corner has that corner split across the start/finish
+   line — the two edge arcs are stitched back into one (each half within 45 m
+   of its lap edge, matching the mid-lap merge distance; the larger half keeps
+   the corner's extent and apex). Stitching runs *before* the significance
+   filter so a split corner is judged on its combined angle.
+7. Keep arcs turning **25°–300°**. Below is a kink; above is a spin, not a corner.
+8. **Apex = the curvature-weighted centroid** of the segment, *not* the
+   minimum-speed point: min speed sits at the segment edge (braking for the next
+   corner) and wanders 60–110 m between laps, while the centroid stays within
+   ~25 m. Minimum corner speed is still reported per corner as a stat.
+
+The thresholds are deliberately a narrow band: raising the entry threshold above
+~0.0035 loses banked/high-speed corners entirely (a 300 m-radius banked turn peaks
+at |κ| ≈ 0.004), and dropping the stay threshold below ~0.002 sinks into the
+road-noise floor and bleeds adjacent corners together.
+
+Display rule: numbered circles while ≤ 30 corners are in view (the zoomed section
+or the whole lap); beyond that they collapse to small dots. The Corner Detail
+widget shows the current corner (`T5 R`) while the cursor is inside one.
 
 ## Cursor synchronization
 

--- a/docs/internals/fuel-strategy.md
+++ b/docs/internals/fuel-strategy.md
@@ -9,9 +9,10 @@ view).
 Computed in the browser from your most recent completed laps:
 
 ```
-recent        = last 3 completed laps that consumed > 0.01 L
-avgFuelPerLap = mean(recent.fuel_consumed)        # L
-avgLapMs      = mean(recent.time_ms)              # ms
+recent        = last 3 completed laps for the CURRENT CAR that consumed > 0.01 L
+usable        = recent minus partial-lap outliers (consumed < 50 % of the window max)
+avgFuelPerLap = mean(usable.fuel_consumed)        # L
+avgLapMs      = mean(usable.time_ms)              # ms
 
 lapsToEmpty   = current_fuel_level / avgFuelPerLap
 timeToEmpty   = lapsToEmpty × avgLapMs
@@ -22,6 +23,13 @@ Details that matter:
 
 - The window is the **last 3 laps**, so the projection adapts quickly to a fuel-map
   change or a different stint pace.
+- Laps **survive a race restart**: a restart opens a new recording session, but the
+  previous stint's laps (same car) keep feeding the projection so you have a fuel
+  estimate from the first meters — important in races with aggressive fuel
+  multipliers. Switching cars drops the old car's laps from the calculation.
+- **Partial laps are excluded**: a pit out-lap burns a fraction of a normal lap; if a
+  lap in the window consumed less than half of the window's maximum, it is dropped
+  rather than allowed to inflate the projected range.
 - Laps that consumed ≤ 0.01 L (fuel-consumption off, time trials) are excluded — until
   a lap actually burns fuel, no projection is shown at all rather than a misleading one.
 - **Warning colors**: the laps-to-empty readout turns amber below **4 laps** and red

--- a/docs/internals/lap-detection.md
+++ b/docs/internals/lap-detection.md
@@ -98,6 +98,16 @@ just-completed lap (`prev_best_ms`). The live "Δ best" readout compares against
 The `personal_best` webhook fires only when an existing session best is actually beaten —
 never on the first lap of a session.
 
+**Partial-lap guard.** A pit out-lap can pass the structural checks (GT7 reports a
+time for it, and it lasts more than 10 s) while covering only part of the track —
+with a distance axis anchored at the pit exit, not the line. Such a lap must never
+become the session best or the live-delta reference: comparing positions against it
+produces garbage deltas that then freeze into a bogus end-of-lap fallback. So a lap
+only *counts for best* when its distance span is within **85 %** of the longest
+counted lap of the session, and when a clearly longer lap arrives it **invalidates**
+an earlier partial "best" (the first full lap takes over even if slower). The guard
+is span-relative, so it needs no knowledge of the track's true length.
+
 ## What "invalid lap" means here
 
 There is no track-limits detection (GT7 doesn't expose it). Laps are excluded only by

--- a/frontend/src/components/analysis/CornerDetail.tsx
+++ b/frontend/src/components/analysis/CornerDetail.tsx
@@ -5,7 +5,7 @@
 // numbers + hollow bars), so focus-vs-ref stays visible without switching.
 
 import { useMemo, useState } from "react";
-import type { Samples } from "@/lib/types";
+import type { Corner as TrackCorner, Samples } from "@/lib/types";
 
 export interface CornerLap {
   id: string;
@@ -36,10 +36,12 @@ export function CornerDetail({
   laps,
   cursorDist,
   step,
+  trackCorners,
 }: {
   laps: CornerLap[];
   cursorDist: number | null;
   step: number;
+  trackCorners?: TrackCorner[];
 }) {
   const candidates = laps.filter((l) => !l.isRef);
   const [focusId, setFocusId] = useState<string | null>(null);
@@ -145,6 +147,12 @@ export function CornerDetail({
   const ravg = ((at(focus.series, "tt_rl", i) ?? 0) + (at(focus.series, "tt_rr", i) ?? 0)) / 2;
   const balance = favg - ravg;
 
+  // Which auto-numbered corner (if any) the cursor is currently inside
+  const inCorner =
+    cursorDist != null
+      ? trackCorners?.find((c) => cursorDist >= c.entry_dist && cursorDist <= c.exit_dist)
+      : undefined;
+
   return (
     <div className="p-3">
       {/* Focus chips — hidden in the common 2-lap case (focus is the non-ref) */}
@@ -173,6 +181,11 @@ export function CornerDetail({
         {cell("rr")}
       </div>
       <div className="mt-2 text-center font-tabular text-xs text-ink-dim">
+        {inCorner && (
+          <span className="mr-2 rounded border border-edge px-1 py-0.5 text-[10px] text-ink">
+            T{inCorner.n} {inCorner.direction}
+          </span>
+        )}
         F/R balance{" "}
         <span className={balance > 3 ? "text-brake" : balance < -3 ? "text-coast" : "text-ink"}>
           {balance >= 0 ? "F +" : "R +"}

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -12,6 +12,10 @@ import type { CompareLapEntry } from "@/lib/types";
 
 const ZONE_COLORS = [CHART_COLORS.brake, CHART_COLORS.coast, CHART_COLORS.throttle];
 
+// Numbered circles are readable up to about this many corners in view;
+// beyond that (or fully zoomed out on a long track) they collapse to dots.
+const MAX_NUMBERED_CORNERS = 30;
+
 function zoneOf(throttle: number, brake: number): number {
   if (brake >= 1) return 0;
   if (throttle >= 1) return 2;
@@ -159,6 +163,39 @@ export function RaceLineMap({
           z: 5,
         },
       );
+
+      // Auto-numbered corners (detected on the reference lap). Numbered
+      // circles while the view shows a readable amount; plain dots otherwise.
+      const corners = ref.entry.corners ?? [];
+      const cornersInView = corners.filter(
+        (c) => !zoomRange || (c.apex_dist >= zoomRange[0] && c.apex_dist <= zoomRange[1]),
+      );
+      const numbered =
+        cornersInView.length > 0 && cornersInView.length <= MAX_NUMBERED_CORNERS;
+      if (cornersInView.length > 0) {
+        series.push({
+          id: "corners",
+          type: "scatter",
+          data: cornersInView.map((c) => ({
+            value: [c.apex_x, c.apex_z],
+            name: String(c.n),
+          })),
+          symbolSize: numbered ? 15 : 5,
+          itemStyle: numbered
+            ? { color: "#14171c", borderColor: CHART_COLORS.label, borderWidth: 1 }
+            : { color: CHART_COLORS.label, opacity: 0.85 },
+          label: {
+            show: numbered,
+            position: "inside",
+            formatter: "{b}",
+            color: "#e5e7eb",
+            fontSize: 9,
+            fontWeight: "bold",
+          },
+          silent: true,
+          z: 4, // above the race line dots, below peak/valley markers & cursors
+        });
+      }
     }
 
     // One synced cursor dot per lap, in the lap's color (reference white).
@@ -241,6 +278,14 @@ export function RaceLineMap({
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-coast" />coast</span>
         <span className="text-warn">▲ peak</span>
         <span className="text-[#c084fc]">▼ valley</span>
+        {(ref?.entry.corners?.length ?? 0) > 0 && (
+          <span>
+            <i className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-ink-dim text-center align-middle text-[7px] leading-[9px]">
+              1
+            </i>
+            corner
+          </span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/lib/strategy.ts
+++ b/frontend/src/lib/strategy.ts
@@ -13,10 +13,23 @@ export function projectStrategy(
   frame: LiveFrame,
   laps: LapSummary[],
 ): StrategyProjection | null {
-  const recent = laps.slice(0, 3).filter((lap) => lap.fuel_consumed > 0.01);
+  // Same car only (a race restart keeps the stint's laps; a car swap must
+  // not inherit another car's consumption), and only laps that actually
+  // burned fuel.
+  const recent = laps
+    .filter(
+      (lap) =>
+        lap.fuel_consumed > 0.01 &&
+        (!lap.car_name || !frame.car_name || lap.car_name === frame.car_name),
+    )
+    .slice(0, 3);
   if (recent.length === 0) return null;
-  const avgFuelPerLap = recent.reduce((a, lap) => a + lap.fuel_consumed, 0) / recent.length;
-  const avgLapMs = recent.reduce((a, lap) => a + lap.time_ms, 0) / recent.length;
+  // Drop partial laps (pit out-laps burn a fraction of a normal lap and
+  // would inflate the projected range — dangerous with aggressive fuel use).
+  const maxFuel = Math.max(...recent.map((lap) => lap.fuel_consumed));
+  const usable = recent.filter((lap) => lap.fuel_consumed >= 0.5 * maxFuel);
+  const avgFuelPerLap = usable.reduce((a, lap) => a + lap.fuel_consumed, 0) / usable.length;
+  const avgLapMs = usable.reduce((a, lap) => a + lap.time_ms, 0) / usable.length;
   const lapsToEmpty = frame.fuel_level / avgFuelPerLap;
   return {
     avgFuelPerLap,

--- a/frontend/src/lib/strategy.ts
+++ b/frontend/src/lib/strategy.ts
@@ -15,13 +15,15 @@ export function projectStrategy(
 ): StrategyProjection | null {
   // Same car only (a race restart keeps the stint's laps; a car swap must
   // not inherit another car's consumption), and only laps that actually
-  // burned fuel.
+  // burned fuel. Prefer car_id (exact); fall back to car_name; only when a
+  // lap carries neither (demo data, legacy rows) is it accepted as-is.
+  const sameCar = (lap: LapSummary): boolean => {
+    if (lap.car_id != null && frame.car_id != null) return lap.car_id === frame.car_id;
+    if (lap.car_name && frame.car_name) return lap.car_name === frame.car_name;
+    return true;
+  };
   const recent = laps
-    .filter(
-      (lap) =>
-        lap.fuel_consumed > 0.01 &&
-        (!lap.car_name || !frame.car_name || lap.car_name === frame.car_name),
-    )
+    .filter((lap) => lap.fuel_consumed > 0.01 && sameCar(lap))
     .slice(0, 3);
   if (recent.length === 0) return null;
   // Drop partial laps (pit out-laps burn a fraction of a normal lap and

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface LapSummary {
   max_water_temp?: number;
   max_oil_temp?: number;
   min_oil_pressure?: number; // -1 = unknown
+  counts_for_best?: boolean; // false = partial lap (pit out-lap)
   event_counts?: Record<string, number>;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -128,11 +128,25 @@ export interface PeakValley {
   z: number;
 }
 
+// Auto-detected corner on the reference lap (numbered from the start line)
+export interface Corner {
+  n: number;
+  apex_dist: number;
+  apex_x: number;
+  apex_z: number;
+  entry_dist: number;
+  exit_dist: number;
+  direction: "L" | "R";
+  min_speed: number;
+  angle_deg: number;
+}
+
 export interface CompareLapEntry {
   series: Samples & { dist: number[] };
   peaks_valleys: { peaks: PeakValley[]; valleys: PeakValley[] };
   events?: LapEvent[];
   delta?: { dist: number[]; delta_ms: number[] };
+  corners?: Corner[]; // reference lap only
 }
 
 export interface CompareResult {

--- a/frontend/src/store/telemetry.ts
+++ b/frontend/src/store/telemetry.ts
@@ -65,19 +65,12 @@ export const useTelemetry = create<TelemetryState>((set) => {
           }));
           break;
         case "status":
-          set({ status: msg.data });
-          break;
         case "session":
-          // Drop laps that belong to another session: a car change or race
-          // restart must not leave old laps in the feed, or the fuel-strategy
-          // average mixes consumption from the previous car/track. Track
-          // identification re-broadcasts the same session_id, so mid-session
-          // laps survive this filter.
-          set((st) => ({
-            status: msg.data,
-            recentLaps: st.recentLaps.filter((l) => l.session_id === msg.data.session_id),
-            lapEpoch: st.lapEpoch + 1,
-          }));
+          // Laps deliberately survive session boundaries: a race restart
+          // opens a new session, and losing the previous stint's laps would
+          // blank the fuel projection exactly when it matters (aggressive
+          // fuel-use races). projectStrategy filters by car instead.
+          set({ status: msg.data });
           break;
       }
     };

--- a/frontend/src/store/telemetry.ts
+++ b/frontend/src/store/telemetry.ts
@@ -65,12 +65,15 @@ export const useTelemetry = create<TelemetryState>((set) => {
           }));
           break;
         case "status":
+          set({ status: msg.data });
+          break;
         case "session":
           // Laps deliberately survive session boundaries: a race restart
           // opens a new session, and losing the previous stint's laps would
           // blank the fuel projection exactly when it matters (aggressive
-          // fuel-use races). projectStrategy filters by car instead.
-          set({ status: msg.data });
+          // fuel-use races). projectStrategy filters by car instead. The
+          // epoch still bumps so session/lap lists refresh promptly.
+          set((st) => ({ status: msg.data, lapEpoch: st.lapEpoch + 1 }));
           break;
       }
     };

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -368,7 +368,12 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
         )}
         {cornerLaps.length > 0 && (
           <SidePanel title="Corner detail — cursor synced">
-            <CornerDetail laps={cornerLaps} cursorDist={cursorDist} step={compare!.step} />
+            <CornerDetail
+              laps={cornerLaps}
+              cursorDist={cursorDist}
+              step={compare!.step}
+              trackCorners={refEntry?.corners}
+            />
           </SidePanel>
         )}
         {refLap != null && (


### PR DESCRIPTION
## The bug (as reported from real driving)

After the first lap time is set, the live delta glitches for the first fraction of the next lap, then jumps to a ~lap-sized value (e.g. +58.444) and freezes until the next lap.

**Root cause:** a short pit **out-lap** passes the structural lap checks — GT7 reports a time for it and it lasts more than 10 s — but covers only part of the track, with its distance axis anchored at the pit exit rather than the line. Once it becomes the session best:

1. the live delta compares positions against the wrong part of the track (the glitching), then runs past the short reference's end → null;
2. the widget falls back to "Δ best (last lap)" = full lap time − out-lap "best" ≈ +58 s, frozen for the rest of the lap;
3. the out-lap's tiny `fuel_consumed` also drags down the fuel-per-lap average.

## The fix

- **Span gating** (`laps.py` + `service.py`): a lap only counts for session best when its distance span is within **85%** of the session's longest counted lap. When a clearly longer lap arrives, it retroactively **invalidates** a partial "best" — the first full lap takes over even if slower. Span-relative, so no knowledge of true track length is needed.
- **Fuel projection** (`strategy.ts` + `telemetry.ts`): recent laps are now filtered **by car** instead of by recording session — a race restart keeps the previous stint's consumption data, so the estimate is available from the first meters (important with aggressive fuel multipliers; the previous session-prune blanked it for a full lap). Partial-lap outliers (< 50% of the window's max consumption) are excluded from the average.

## Verification

- 126 backend tests pass (2 new: out-lap never stays the reference + frame `prev_best_ms` cleared so the frozen fallback can't occur; later pit laps can't steal the best with a bogus low time). ruff + strict mypy + frontend tsc/eslint/build clean.
- Live sim run: normal full laps behave exactly as before (delta live mid-lap, fuel projection populated, screenshot in session).

Docs updated: `internals/lap-detection.md` (partial-lap guard), `internals/fuel-strategy.md` (car filter, restart survival, outlier rule), changelog under `[Unreleased]`.