### PR TITLE
fix: LAN/second-screen fixes — voice client id, mobile nav, lap colours, chrome-less views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Notable changes to GT7 Datalogger. The format follows
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-07
+
+### Fixed
+
+- **Race Engineer voice now works from other devices on the LAN.** Opening the
+  dashboard from a plain-HTTP address (`http://<pi-ip>:8000` — the normal way to
+  reach a Raspberry Pi) broke voice output: the browser only provides
+  `crypto.randomUUID` on HTTPS or localhost, so registering the device and claiming
+  **Use this device for voice output** failed silently. The client id now falls back
+  to `crypto.getRandomValues`, which works everywhere.
+- **Phone navigation.** The header nav drops to its own row on narrow screens
+  instead of clipping tab names — Sessions and Admin are reachable on a phone again.
+- **Lap colours no longer collide in Analysis.** Colours are keyed to the lap id
+  six-wise, so laps 6 apart — routinely the "latest vs best" pair — rendered
+  identically in the charts, map and chips. Laps compared together now always get
+  distinct colours; a lap only changes colour when it collides, and keeps its
+  canonical colour everywhere else.
+- **`/dash` and `/engineer` have a way back** to the main app (a small home link);
+  the OBS overlay stays chrome-less.
+- **`#/overlay` now routes to the overlay** like its `#/dash` and `#/engineer`
+  siblings, alongside the existing `/overlay` and `#overlay` forms.
+- Cross-view links into Analysis keep the chart channel selection (`ch=` was
+  declared but never written), and the S1/S2/S3 zoom buttons' hover style renders
+  (its colour token was never defined).
+
 ## [0.4.0] - 2026-08-06
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gt7-datalogger"
-version = "0.4.0"
+version = "0.4.1"
 description = "GT7 telemetry datalogger and analysis dashboard"
 license = "MIT"
 requires-python = ">=3.12"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gt7-datalogger-frontend",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gt7-datalogger-frontend",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-select": "^2.3.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gt7-datalogger-frontend",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -29,13 +29,16 @@ export function StatusBar({ view }: { view: View }) {
       : "Disconnected from server";
 
   return (
-    <header className="flex items-center gap-4 border-b border-edge bg-panel px-4 py-2">
+    // Below sm the nav drops to its own full-width row (order-last) — a single
+    // non-wrapping row clips tab names on phones and leaves Sessions/Admin
+    // unreachable.
+    <header className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-edge bg-panel px-4 py-2">
       <div className="flex items-center gap-2" title={dotTitle}>
         <span className={`h-2.5 w-2.5 rounded-full ${dotColor} ${telemetryUp ? "animate-pulse" : ""}`} />
-        <h1 className="text-sm font-semibold tracking-wide">GT7 Datalogger</h1>
+        <h1 className="whitespace-nowrap text-sm font-semibold tracking-wide">GT7 Datalogger</h1>
       </div>
 
-      <nav className="flex gap-1 overflow-x-auto">
+      <nav className="order-last flex w-full gap-1 overflow-x-auto sm:order-none sm:w-auto">
         {TABS.map((t) => (
           <button
             key={t.id}

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -76,6 +76,7 @@ const REPLACE_SERIES = ["series"];
 export function StackedCharts({
   data,
   lapLabels,
+  lapColors,
   units,
   channels,
   onCursorDist,
@@ -84,6 +85,8 @@ export function StackedCharts({
 }: {
   data: CompareResult;
   lapLabels: Record<string, string>;
+  /** Collision-resolved per-set colors (see lapColorMap); lapColor fallback. */
+  lapColors?: Record<string, string>;
   units: Units;
   channels: ChannelDef[]; // ordered, from the channel picker
   onCursorDist?: (dist: number | null) => void;
@@ -283,7 +286,7 @@ export function StackedCharts({
           showSymbol: false,
           step: panel.step ? "end" : undefined,
           lineStyle: { width: 1.4 },
-          color: lapColor(Number(lapId)),
+          color: lapColors?.[lapId] ?? lapColor(Number(lapId)),
           ...(isDelta
             ? {
                 markLine: {
@@ -299,7 +302,10 @@ export function StackedCharts({
             ? {
                 markArea: {
                   silent: true,
-                  itemStyle: { color: lapColor(Number(lapId)), opacity: 0.14 },
+                  itemStyle: {
+                    color: lapColors?.[lapId] ?? lapColor(Number(lapId)),
+                    opacity: 0.14,
+                  },
                   data: bands,
                 },
               }
@@ -447,7 +453,7 @@ export function StackedCharts({
         },
       },
     };
-  }, [data, lapLabels, units, panels]);
+  }, [data, lapLabels, lapColors, units, panels]);
 
   return (
     <div className="flex flex-col">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,7 @@
   --color-panel: #14171c;
   --color-panel-2: #1b1f26;
   --color-edge: #262b33;
+  --color-edge-bright: #3d4552; /* hover state for edge-bordered controls */
   --color-ink: #e6e9ee;
   --color-ink-dim: #8b93a1;
   --color-accent: #38bdf8;

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -33,16 +33,29 @@ export function lapColor(lapId: number): string {
 }
 
 /**
- * Collision-free colors for a set of laps shown together. Ids are processed in
- * ascending order, so the older lap keeps its canonical lapColor() and only the
- * newer one shifts — and the same set always yields the same assignment. Past
- * six laps the palette is exhausted and slots repeat (labels disambiguate).
+ * Collision-free colors for a set of laps shown together. Two passes: every
+ * lap that can hold its canonical lapColor() slot keeps it (oldest lap wins a
+ * contested slot), and only the losers move to the next free slot — a
+ * displaced lap must never steal a slot another lap holds canonically. The
+ * same set always yields the same assignment. Past six laps the palette is
+ * exhausted and slots repeat (labels disambiguate).
  */
 export function lapColorMap(lapIds: Iterable<number>): Map<number, string> {
   const n = SERIES_COLORS.length;
+  const ids = [...new Set(lapIds)].sort((a, b) => a - b);
   const assigned = new Map<number, string>();
   const used = new Set<number>();
-  for (const id of [...new Set(lapIds)].sort((a, b) => a - b)) {
+  const displaced: number[] = [];
+  for (const id of ids) {
+    const slot = Math.abs(id) % n;
+    if (used.has(slot)) {
+      displaced.push(id);
+    } else {
+      assigned.set(id, SERIES_COLORS[slot]);
+      used.add(slot);
+    }
+  }
+  for (const id of displaced) {
     let slot = Math.abs(id) % n;
     for (let i = 0; i < n && used.has(slot); i++) slot = (slot + 1) % n;
     assigned.set(id, SERIES_COLORS[slot]);

--- a/frontend/src/lib/colors.ts
+++ b/frontend/src/lib/colors.ts
@@ -13,6 +13,11 @@
 // CVD-safe (amber↔orange is the weakest here) — which is why every colored
 // mark ships with a text label (lap number / legend entry) beside it; color is
 // never the only identity channel.
+//
+// Id-keying also means laps 6 apart share a slot — and "latest vs best" pairs
+// them routinely. Views that show a *set* of laps side by side use
+// lapColorMap(), which keeps each lap's id-keyed color unless it collides
+// within that set; the colliding lap (larger id) moves to the next free slot.
 
 export const SERIES_COLORS = [
   "#0284c7", // sky
@@ -25,4 +30,23 @@ export const SERIES_COLORS = [
 
 export function lapColor(lapId: number): string {
   return SERIES_COLORS[Math.abs(lapId) % SERIES_COLORS.length];
+}
+
+/**
+ * Collision-free colors for a set of laps shown together. Ids are processed in
+ * ascending order, so the older lap keeps its canonical lapColor() and only the
+ * newer one shifts — and the same set always yields the same assignment. Past
+ * six laps the palette is exhausted and slots repeat (labels disambiguate).
+ */
+export function lapColorMap(lapIds: Iterable<number>): Map<number, string> {
+  const n = SERIES_COLORS.length;
+  const assigned = new Map<number, string>();
+  const used = new Set<number>();
+  for (const id of [...new Set(lapIds)].sort((a, b) => a - b)) {
+    let slot = Math.abs(id) % n;
+    for (let i = 0; i < n && used.has(slot); i++) slot = (slot + 1) % n;
+    assigned.set(id, SERIES_COLORS[slot]);
+    used.add(slot);
+  }
+  return assigned;
 }

--- a/frontend/src/lib/overlay.ts
+++ b/frontend/src/lib/overlay.ts
@@ -108,15 +108,15 @@ export const PHONE_PRESET: OverlayConfig = {
 
 // Preferred URL form is the plain path /overlay?w=… — hash-fragment URLs
 // (/#overlay?…) still work but are rejected by some apps' URL validators
-// (e.g. TikTok LIVE Studio web sources).
+// (e.g. TikTok LIVE Studio web sources). #/overlay is accepted too so the
+// hash form matches its siblings (#/dash, #/engineer).
 export function isOverlayLocation(loc: {
   pathname: string;
   hash: string;
 }): boolean {
   return (
     loc.pathname === "/overlay" ||
-    loc.hash === "#overlay" ||
-    loc.hash.startsWith("#overlay?")
+    /^#\/?overlay(\?|$)/.test(loc.hash)
   );
 }
 

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -43,6 +43,7 @@ export function openInAnalysis(req: AnalysisRequest): void {
   if (req.session != null) params.session = String(req.session);
   if (req.laps && req.laps.length > 0) params.laps = req.laps.join(",");
   if (req.ref != null) params.ref = String(req.ref);
+  if (req.channels && req.channels.length > 0) params.ch = req.channels.join(",");
   navigate("analysis", params);
 }
 

--- a/frontend/src/store/engineer.ts
+++ b/frontend/src/store/engineer.ts
@@ -33,10 +33,28 @@ export const TEST_PHRASE = "Race engineer enabled.";
 export function clientId(): string {
   let id = localStorage.getItem(CLIENT_ID_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = randomId();
     localStorage.setItem(CLIENT_ID_KEY, id);
   }
   return id;
+}
+
+/**
+ * `crypto.randomUUID` exists only in secure contexts, and this dashboard is
+ * typically served plain-HTTP from a Pi on the LAN — where it is undefined and
+ * the call throws, taking claimSpeaker/sendCapabilities down with it.
+ * `getRandomValues` has no such restriction.
+ */
+function randomId(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // UUID v4 version/variant bits, so the
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // id looks the same either way
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return (
+    `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-` +
+    `${hex.slice(16, 20)}-${hex.slice(20)}`
+  );
 }
 
 export type VoicePage = "dash" | "engineer";

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -21,7 +21,7 @@ import {
   loadChannelKeys,
   saveChannelKeys,
 } from "@/lib/channels";
-import { lapColor } from "@/lib/colors";
+import { lapColor, lapColorMap } from "@/lib/colors";
 import { formatLapTime, formatSpeed } from "@/lib/format";
 import { reflectAnalysisSelection, type AnalysisRequest } from "@/lib/router";
 import type { CompareResult, DeviationResult, LapSummary, SessionSummary } from "@/lib/types";
@@ -201,17 +201,31 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
   const refEntry = compare?.laps[String(refLap)];
   const refSummary = laps.find((l) => l.id === refLap);
 
-  // Laps for the track map, colored by lap id exactly like the chart series.
+  // One color assignment for everything that shows the compared laps together
+  // (chips, chart series, map, corner detail): id-keyed, but two selected laps
+  // never share a color (laps 6 apart otherwise would — latest vs best hits it).
+  const lapColors = useMemo<Record<string, string>>(() => {
+    const ids = new Set<number>(selected);
+    if (refLap != null) ids.add(refLap);
+    for (const id of Object.keys(compare?.laps ?? {})) ids.add(Number(id));
+    return Object.fromEntries(
+      [...lapColorMap(ids)].map(([id, color]) => [String(id), color]),
+    );
+  }, [selected, refLap, compare]);
+  const colorOf = (id: string | number) =>
+    lapColors[String(id)] ?? lapColor(Number(id));
+
+  // Laps for the track map, colored exactly like the chart series.
   const mapLaps = useMemo<MapLap[]>(() => {
     if (!compare) return [];
     return Object.keys(compare.laps).map((id) => ({
       id,
       entry: compare.laps[id],
-      color: lapColor(Number(id)),
+      color: lapColors[id] ?? lapColor(Number(id)),
       label: lapLabels[id] ?? `Lap ${id}`,
       isRef: id === String(refLap),
     }));
-  }, [compare, lapLabels, refLap]);
+  }, [compare, lapLabels, refLap, lapColors]);
 
   // Same laps, shaped for the Corner Detail widget (cursor-synced with the
   // charts and the map dot).
@@ -220,11 +234,11 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
     return Object.keys(compare.laps).map((id) => ({
       id,
       label: lapLabels[id] ?? `Lap ${id}`,
-      color: lapColor(Number(id)),
+      color: lapColors[id] ?? lapColor(Number(id)),
       isRef: id === String(refLap),
       series: compare.laps[id].series,
     }));
-  }, [compare, lapLabels, refLap]);
+  }, [compare, lapLabels, refLap, lapColors]);
 
   if (sessions == null) {
     // Failed fetch would otherwise leave the skeleton up forever.
@@ -306,7 +320,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
                     {active && (
                       <span
                         className="h-2 w-2 rounded-full"
-                        style={{ backgroundColor: lapColor(lap.id) }}
+                        style={{ backgroundColor: colorOf(lap.id) }}
                       />
                     )}
                     L{lap.number} {formatLapTime(lap.time_ms)}
@@ -342,6 +356,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
             <StackedCharts
               data={compare}
               lapLabels={lapLabels}
+              lapColors={lapColors}
               units={units}
               channels={channelDefs}
               onCursorDist={onCursorDist}

--- a/frontend/src/views/DashView.tsx
+++ b/frontend/src/views/DashView.tsx
@@ -129,6 +129,15 @@ export function DashView({ params }: { params: DashParams }) {
         >
           ⛶
         </button>
+        {/* /#/live (not #/live): /dash may be a path, where a bare hash change
+            would still match isDashLocation and go nowhere. */}
+        <a
+          href="/#/live"
+          className="rounded border border-white/10 bg-black/40 px-1.5 py-0.5 text-[10px] text-ink-dim hover:text-ink"
+          title="Back to the main app"
+        >
+          ⌂
+        </a>
       </div>
     </div>
   );

--- a/frontend/src/views/EngineerView.tsx
+++ b/frontend/src/views/EngineerView.tsx
@@ -23,13 +23,19 @@ export function EngineerView() {
     <div className="mx-auto max-w-xl space-y-3 p-3">
       <div className="flex items-baseline justify-between">
         <h1 className="text-lg font-semibold">Race Engineer</h1>
-        <span className="flex items-center gap-1.5 text-[11px] text-ink-dim">
-          <span
-            className={`h-2 w-2 rounded-full ${
-              !wsConnected ? "bg-brake" : isSpeaker ? "bg-throttle" : "bg-warn"
-            }`}
-          />
-          {!wsConnected ? "offline" : isSpeaker ? "speaking here" : "connected"}
+        <span className="flex items-center gap-3 text-[11px] text-ink-dim">
+          <span className="flex items-center gap-1.5">
+            <span
+              className={`h-2 w-2 rounded-full ${
+                !wsConnected ? "bg-brake" : isSpeaker ? "bg-throttle" : "bg-warn"
+              }`}
+            />
+            {!wsConnected ? "offline" : isSpeaker ? "speaking here" : "connected"}
+          </span>
+          {/* /#/live: this page has no other way back (no header, no nav). */}
+          <a href="/#/live" className="hover:text-ink" title="Back to the main app">
+            ⌂ home
+          </a>
         </span>
       </div>
 


### PR DESCRIPTION
Bug fixes for using the datalogger from a second device on the LAN, plus small verified defects from the 2026-08 review.

## Voice client on plain-HTTP origins
`clientId()` used `crypto.randomUUID()`, which only exists in secure contexts (HTTPS/localhost). Served plain-HTTP from a Pi, every call threw — capabilities never registered and **Use this device for voice output** silently failed. Now falls back to a UUID built from `crypto.getRandomValues()`. Verified end-to-end on a real insecure LAN origin (claim round-trip, active speaker, spoken test utterance).

## Review fixes
- **Mobile nav** (#27): header nav drops to its own full-width row below `sm`; all four tabs reachable at 390px.
- **Lap colour collisions** (#28): one `lapColorMap()` assignment shared by chips, chart series, map and corner detail — id-keyed colours, collisions within the compared set resolved to the next free slot (older lap keeps its canonical colour). Verified with laps 450/456 (both ≡ 0 mod 6): now sky vs amber.
- **Chrome-less views** (#30): small home link on `/dash` (corner controls) and `/engineer` (title row); `/overlay` untouched for OBS.
- **Paper cuts** (#31): `--color-edge-bright` token defined (hover rule now in built CSS), `#/overlay` accepted alongside `#overlay`, `openInAnalysis()` serializes `ch=` as its type declares.

`npm run lint` (tsc + eslint) clean; all fixes verified in the running app.

Fixes #27
Fixes #28
Fixes #30
Fixes #31