### PR TITLE
feat: GT7 track metadata from official data (41 tracks, 85 layouts, 121 configs) + builder

### DIFF
--- a/backend/data/tracks.json
+++ b/backend/data/tracks.json
@@ -1,0 +1,1400 @@
+{
+  "meta": {
+    "generated": "2026-08-08",
+    "source": "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List (CC BY-SA; upstream: https://www.gran-turismo.com/gb/gt7/tracklist/)",
+    "tracks": 41,
+    "layouts": 84,
+    "configurations_including_reverse": 121,
+    "note": "Per-layout template data is authoritative; the list page's prose may state a different configuration total. page_describes_layout=false flags layouts whose wiki page infobox measures a different variant; their length_m (from the list) is still per-layout."
+  },
+  "tracks": [
+    {
+      "name": "24 Heures du Mans Racing Circuit",
+      "country": "FRA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Circuit de la Sarthe",
+          "type": "real",
+          "length_m": 13629,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 38,
+          "elevation_m": 37.3,
+          "longest_straight_m": 1679.0,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        },
+        {
+          "name": "No Chicane",
+          "wiki_page": "Circuit de la Sarthe",
+          "type": "real",
+          "length_m": 13567,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 38,
+          "elevation_m": 37.3,
+          "longest_straight_m": 1679.0,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        }
+      ],
+      "country_name": "France"
+    },
+    {
+      "name": "Alsace",
+      "country": "FRA",
+      "layouts": [
+        {
+          "name": "Village",
+          "wiki_page": "Alsace - Village",
+          "type": "original",
+          "length_m": 5423,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 17,
+          "elevation_m": 57.3,
+          "longest_straight_m": 450.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Test Course",
+          "wiki_page": "Alsace - Test Course",
+          "type": "original",
+          "length_m": 2118,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 7,
+          "elevation_m": 35.3,
+          "longest_straight_m": 432.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "France"
+    },
+    {
+      "name": "Autodrome Lago Maggiore",
+      "country": "ITA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Autodrome Lago Maggiore - GP",
+          "type": "original",
+          "length_m": 5809,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 17,
+          "elevation_m": 74.0,
+          "longest_straight_m": 800.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Centre",
+          "wiki_page": "Autodrome Lago Maggiore - Center",
+          "type": "original",
+          "length_m": 1706,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 8,
+          "elevation_m": 12.0,
+          "longest_straight_m": 550.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "East End",
+          "wiki_page": "Autodrome Lago Maggiore - East End",
+          "type": "original",
+          "length_m": 2010,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 8,
+          "elevation_m": 42.0,
+          "longest_straight_m": 500.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "West End",
+          "wiki_page": "Autodrome Lago Maggiore - West End",
+          "type": "original",
+          "length_m": 2444,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 10,
+          "elevation_m": 48.0,
+          "longest_straight_m": 373.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "East",
+          "wiki_page": "Autodrome Lago Maggiore - East",
+          "type": "original",
+          "length_m": 3643,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 43.0,
+          "longest_straight_m": 550.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "West",
+          "wiki_page": "Autodrome Lago Maggiore - West",
+          "type": "original",
+          "length_m": 4168,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 13,
+          "elevation_m": 49.0,
+          "longest_straight_m": 800.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Italy"
+    },
+    {
+      "name": "Autódromo de Interlagos",
+      "country": "BRA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Autódromo de Interlagos",
+          "type": "real",
+          "length_m": 4309,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 15,
+          "elevation_m": 43.0,
+          "longest_straight_m": 650.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Brazil"
+    },
+    {
+      "name": "Autodromo Nazionale Monza",
+      "country": "ITA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Autodromo Nazionale Monza",
+          "type": "real",
+          "length_m": 5793,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 10,
+          "elevation_m": null,
+          "longest_straight_m": null,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "No Chicane",
+          "wiki_page": "Autodromo Nazionale Monza (No Chicane)",
+          "type": "real",
+          "length_m": 5755,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 8,
+          "elevation_m": 14.3,
+          "longest_straight_m": 1248.7,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Italy"
+    },
+    {
+      "name": "Autopolis International Racing Course",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Autopolis International Racing Course",
+          "type": "real",
+          "length_m": 4674,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 18,
+          "elevation_m": 52.0,
+          "longest_straight_m": 902.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Shortcut Course",
+          "wiki_page": "Autopolis International Racing Course - Shortcut Course",
+          "type": "real",
+          "length_m": 3022,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 30.0,
+          "longest_straight_m": 902.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Blue Moon Bay Speedway",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Blue Moon Bay Speedway",
+          "type": "original",
+          "length_m": 3200,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 3,
+          "elevation_m": 0.0,
+          "longest_straight_m": 1060.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Infield A",
+          "wiki_page": "Blue Moon Bay Speedway - Infield A",
+          "type": "original",
+          "length_m": 3350,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 10,
+          "elevation_m": 0.0,
+          "longest_straight_m": 890.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Infield B",
+          "wiki_page": "Blue Moon Bay Speedway - Infield B",
+          "type": "original",
+          "length_m": 2860,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 5,
+          "elevation_m": 0.0,
+          "longest_straight_m": 890.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Brands Hatch",
+      "country": "GBR",
+      "layouts": [
+        {
+          "name": "Grand Prix Circuit",
+          "wiki_page": "Brands Hatch GP",
+          "type": "real",
+          "length_m": 3946,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 9,
+          "elevation_m": 35.0,
+          "longest_straight_m": 475.0,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        },
+        {
+          "name": "Indy Circuit",
+          "wiki_page": "Brands Hatch Indy",
+          "type": "real",
+          "length_m": 1944,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 5,
+          "elevation_m": 24.0,
+          "longest_straight_m": 400.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "United Kingdom"
+    },
+    {
+      "name": "Broad Bean Raceway",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Broad Bean Raceway",
+          "type": "original",
+          "length_m": 1665,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 5,
+          "elevation_m": 0.0,
+          "longest_straight_m": 386.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Circuit de Barcelona-Catalunya",
+      "country": "ESP",
+      "layouts": [
+        {
+          "name": "Grand Prix Layout",
+          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
+          "type": "real",
+          "length_m": 4655,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 16,
+          "elevation_m": 30.0,
+          "longest_straight_m": 1047.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Grand Prix Layout No Chicane",
+          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
+          "type": "real",
+          "length_m": 4730,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 16,
+          "elevation_m": 30.0,
+          "longest_straight_m": 1047.0,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        },
+        {
+          "name": "National Layout",
+          "wiki_page": "Circuit de Barcelona-Catalunya National Layout",
+          "type": "real",
+          "length_m": 2977,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 28.0,
+          "longest_straight_m": 862.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Rallycross Layout",
+          "wiki_page": "Circuit de Barcelona-Catalunya Rallycross Layout",
+          "type": "original",
+          "length_m": 1133,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 11.0,
+          "longest_straight_m": 148.0,
+          "roadway": "Tarmac & Dirt"
+        }
+      ],
+      "country_name": "Spain"
+    },
+    {
+      "name": "Circuit de Sainte-Croix",
+      "country": "FRA",
+      "layouts": [
+        {
+          "name": "Layout A",
+          "wiki_page": "Circuit de Sainte-Croix - A",
+          "type": "original",
+          "length_m": 9477,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 19,
+          "elevation_m": 44.0,
+          "longest_straight_m": 915.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Layout B",
+          "wiki_page": "Circuit de Sainte-Croix - B",
+          "type": "original",
+          "length_m": 7062,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": 44.0,
+          "longest_straight_m": 915.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Layout C",
+          "wiki_page": "Circuit de Sainte-Croix - C",
+          "type": "original",
+          "length_m": 10825,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 24,
+          "elevation_m": 44.0,
+          "longest_straight_m": 1807.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "France"
+    },
+    {
+      "name": "Circuit de Spa-Francorchamps",
+      "country": "BEL",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Circuit de Spa-Francorchamps",
+          "type": "real",
+          "length_m": 7044,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 21,
+          "elevation_m": 104.0,
+          "longest_straight_m": 751.8,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        },
+        {
+          "name": "24h Layout",
+          "wiki_page": "Circuit de Spa-Francorchamps",
+          "type": "real",
+          "length_m": 7044,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 21,
+          "elevation_m": 104.0,
+          "longest_straight_m": 751.8,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        }
+      ],
+      "country_name": "Belgium"
+    },
+    {
+      "name": "Circuit Gilles-Villeneuve",
+      "country": "CAN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Circuit Gilles-Villeneuve",
+          "type": "real",
+          "length_m": 4361,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": null,
+          "longest_straight_m": null,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Canada"
+    },
+    {
+      "name": "Colorado Springs",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Lake",
+          "wiki_page": "Colorado Springs - Lake",
+          "type": "original",
+          "length_m": 2990,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 15,
+          "elevation_m": 15.0,
+          "longest_straight_m": 177.0,
+          "roadway": "Dirt"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Daytona International Speedway",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Tri-Oval",
+          "wiki_page": "Daytona Superspeedway",
+          "type": "real",
+          "length_m": 4023,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 3,
+          "elevation_m": 0.0,
+          "longest_straight_m": 914.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Road Course",
+          "wiki_page": "Daytona Road Course",
+          "type": "real",
+          "length_m": 5729,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 12,
+          "elevation_m": 8.4,
+          "longest_straight_m": 575.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Deep Forest Raceway",
+      "country": "Switzerland",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Deep Forest Raceway",
+          "type": "original",
+          "length_m": 4253,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 15,
+          "elevation_m": 45.2,
+          "longest_straight_m": 779.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "PDI"
+    },
+    {
+      "name": "Dragon Trail",
+      "country": "CRO",
+      "layouts": [
+        {
+          "name": "Seaside",
+          "wiki_page": "Dragon Trail - Seaside",
+          "type": "original",
+          "length_m": 5209,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 18,
+          "elevation_m": 38.0,
+          "longest_straight_m": 653.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Gardens",
+          "wiki_page": "Dragon Trail - Gardens",
+          "type": "original",
+          "length_m": 4352,
+          "reversible": true,
+          "rain": true,
+          "sophy": "no",
+          "turns": 17,
+          "elevation_m": 27.0,
+          "longest_straight_m": 781.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Croatia"
+    },
+    {
+      "name": "Eiger Nordwand",
+      "country": "Switzerland",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Eiger Nordwand Short Track",
+          "type": "original",
+          "length_m": 2436,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 75.0,
+          "longest_straight_m": 250.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Switzerland"
+    },
+    {
+      "name": "Fishermans Ranch",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Fisherman's Ranch",
+          "type": "original",
+          "length_m": 6893,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 40,
+          "elevation_m": 145.0,
+          "longest_straight_m": 434.0,
+          "roadway": "Dirt"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Fuji International Speedway",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Fuji International Speedway",
+          "type": "real",
+          "length_m": 4563,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 16,
+          "elevation_m": 37.0,
+          "longest_straight_m": 1475.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Short Course",
+          "wiki_page": "Fuji International Speedway (Short)",
+          "type": "real",
+          "length_m": 4526,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": 37.0,
+          "longest_straight_m": 1475.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Goodwood Motor Circuit",
+      "country": "GBR",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Goodwood Motor Circuit",
+          "type": "real",
+          "length_m": 3809,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 7,
+          "elevation_m": 10.0,
+          "longest_straight_m": 514.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "United Kingdom"
+    },
+    {
+      "name": "Grand Valley",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Highway 1",
+          "wiki_page": "Grand Valley Highway 1",
+          "type": "original",
+          "length_m": 5099,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 18,
+          "elevation_m": 97.0,
+          "longest_straight_m": 995.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "South",
+          "wiki_page": "Grand Valley South",
+          "type": "original",
+          "length_m": 3076,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 10,
+          "elevation_m": 85.0,
+          "longest_straight_m": 995.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "High Speed Ring",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "High Speed Ring",
+          "type": "original",
+          "length_m": 4345,
+          "reversible": true,
+          "rain": true,
+          "sophy": "forwards_only",
+          "turns": 6,
+          "elevation_m": 8.5,
+          "longest_straight_m": 752.0,
+          "roadway": "Tarmac",
+          "page_describes_layout": false
+        }
+      ],
+      "country_name": "PDI"
+    },
+    {
+      "name": "Kyoto Driving Park",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Yamagiwa",
+          "wiki_page": "Kyoto Driving Park - Yamagiwa",
+          "type": "original",
+          "length_m": 4912,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 15,
+          "elevation_m": 38.6,
+          "longest_straight_m": 743.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Miyabi",
+          "wiki_page": "Kyoto Driving Park - Miyabi",
+          "type": "original",
+          "length_m": 1953,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 7,
+          "elevation_m": 17.5,
+          "longest_straight_m": 442.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Yamagiwa + Miyabi",
+          "wiki_page": "Kyoto Driving Park - Yamagiwa + Miyabi",
+          "type": "original",
+          "length_m": 6846,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 19,
+          "elevation_m": 38.6,
+          "longest_straight_m": 743.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Lake Louise",
+      "country": "CAN",
+      "layouts": [
+        {
+          "name": "Tri-Oval",
+          "wiki_page": "Lake Louise Tri-Oval",
+          "type": "original",
+          "length_m": 3068,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 3,
+          "elevation_m": 78.0,
+          "longest_straight_m": 1184.0,
+          "roadway": "Snow"
+        },
+        {
+          "name": "Short Track",
+          "wiki_page": "Lake Louise Short Track",
+          "type": "original",
+          "length_m": 2577,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 7,
+          "elevation_m": 63.0,
+          "longest_straight_m": 1024.0,
+          "roadway": "Snow"
+        },
+        {
+          "name": "Long Track",
+          "wiki_page": "Lake Louise Long Track",
+          "type": "original",
+          "length_m": 3694,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 78.0,
+          "longest_straight_m": 765.0,
+          "roadway": "Snow"
+        }
+      ],
+      "country_name": "Canada"
+    },
+    {
+      "name": "Michelin Raceway Road Atlanta",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Michelin Raceway Road Atlanta",
+          "type": "real",
+          "length_m": 4088,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 12,
+          "elevation_m": 38.0,
+          "longest_straight_m": 1275.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Mount Panorama Circuit",
+      "country": "AUS",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Mount Panorama",
+          "type": "real",
+          "length_m": 6213,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 23,
+          "elevation_m": 174.0,
+          "longest_straight_m": 1916.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Australia"
+    },
+    {
+      "name": "Northern Isle Speedway",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Northern Isle Speedway",
+          "type": "original",
+          "length_m": 900,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 4,
+          "elevation_m": 0.0,
+          "longest_straight_m": 134.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Nürburgring",
+      "country": "GER",
+      "layouts": [
+        {
+          "name": "Nordschleife",
+          "wiki_page": "Nürburgring Nordschleife",
+          "type": "real",
+          "length_m": 20832,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 73,
+          "elevation_m": 300.0,
+          "longest_straight_m": 2135.0,
+          "roadway": "Tarmac & Concrete"
+        },
+        {
+          "name": "Nordschleife Tourist",
+          "wiki_page": "Nürburgring Nordschleife",
+          "type": "real",
+          "length_m": 20832,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 73,
+          "elevation_m": 300.0,
+          "longest_straight_m": 2135.0,
+          "roadway": "Tarmac & Concrete"
+        },
+        {
+          "name": "24h",
+          "wiki_page": "Nürburgring 24h",
+          "type": "real",
+          "length_m": 25378,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 89,
+          "elevation_m": 300.0,
+          "longest_straight_m": 2135.0,
+          "roadway": "Tarmac & Concrete",
+          "page_describes_layout": false
+        },
+        {
+          "name": "Grand Prix",
+          "wiki_page": "Nürburgring GP/F",
+          "type": "real",
+          "length_m": 5148,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 17,
+          "elevation_m": 57.0,
+          "longest_straight_m": 620.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Endurance",
+          "wiki_page": "Nürburgring Endurance",
+          "type": "real",
+          "length_m": 23864,
+          "reversible": true,
+          "rain": true,
+          "sophy": "no",
+          "turns": 84,
+          "elevation_m": 300.0,
+          "longest_straight_m": 2135.0,
+          "roadway": "Tarmac & Concrete",
+          "page_describes_layout": false
+        },
+        {
+          "name": "Sprint",
+          "wiki_page": "Nürburgring Sprint",
+          "type": "real",
+          "length_m": 3629,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 12,
+          "elevation_m": 33.0,
+          "longest_straight_m": 620.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Germany"
+    },
+    {
+      "name": "Red Bull Ring",
+      "country": "AUT",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Red Bull Ring",
+          "type": "real",
+          "length_m": 4318,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 9,
+          "elevation_m": 65.5,
+          "longest_straight_m": 939.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Short Track",
+          "wiki_page": "Red Bull Ring Short Track",
+          "type": "real",
+          "length_m": 2336,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 6,
+          "elevation_m": 32.4,
+          "longest_straight_m": 939.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Austria"
+    },
+    {
+      "name": "Sardegna - Road Track",
+      "country": "ITA",
+      "layouts": [
+        {
+          "name": "Layout A",
+          "wiki_page": "Sardegna - Road Track - A",
+          "type": "original",
+          "length_m": 5113,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 15,
+          "elevation_m": 38.0,
+          "longest_straight_m": 915.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Layout B",
+          "wiki_page": "Sardegna - Road Track - B",
+          "type": "original",
+          "length_m": 3893,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 13,
+          "elevation_m": 56.0,
+          "longest_straight_m": 915.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Layout C",
+          "wiki_page": "Sardegna - Road Track - C",
+          "type": "original",
+          "length_m": 2661,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 10,
+          "elevation_m": 54.0,
+          "longest_straight_m": 915.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Italy"
+    },
+    {
+      "name": "Sardegna - Windmills",
+      "country": "ITA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Sardegna - Windmills",
+          "type": "original",
+          "length_m": 3310,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": 75.0,
+          "longest_straight_m": 298.0,
+          "roadway": "Dirt"
+        }
+      ],
+      "country_name": "Italy"
+    },
+    {
+      "name": "Special Stage Route X",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Special Stage Route X",
+          "type": "original",
+          "length_m": 30283,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 2,
+          "elevation_m": 65.0,
+          "longest_straight_m": 12000.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "PDI"
+    },
+    {
+      "name": "Suzuka Circuit",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Suzuka Circuit",
+          "type": "real",
+          "length_m": 5807,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 20,
+          "elevation_m": 40.0,
+          "longest_straight_m": 1200.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "East Course",
+          "wiki_page": "Suzuka Circuit East",
+          "type": "real",
+          "length_m": 2243,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 9,
+          "elevation_m": 33.6,
+          "longest_straight_m": 800.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Tokyo Expressway",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Central Clockwise",
+          "wiki_page": "Tokyo Expressway - Central Clockwise",
+          "type": "original",
+          "length_m": 4405,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 13,
+          "elevation_m": 8.0,
+          "longest_straight_m": 600.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "East Clockwise",
+          "wiki_page": "Tokyo Expressway - East Clockwise",
+          "type": "original",
+          "length_m": 7301,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 13,
+          "elevation_m": 32.0,
+          "longest_straight_m": 2000.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "South Clockwise",
+          "wiki_page": "Tokyo Expressway - South Clockwise",
+          "type": "original",
+          "length_m": 5201,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 17,
+          "elevation_m": 24.0,
+          "longest_straight_m": 900.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Central Counterclockwise",
+          "wiki_page": "Tokyo Expressway - Central Counterclockwise",
+          "type": "original",
+          "length_m": 4369,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": 16.0,
+          "longest_straight_m": 600.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "East Counterclockwise",
+          "wiki_page": "Tokyo Expressway - East Counterclockwise",
+          "type": "original",
+          "length_m": 7192,
+          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "turns": 13,
+          "elevation_m": 32.0,
+          "longest_straight_m": 2000.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "South Counterclockwise",
+          "wiki_page": "Tokyo Expressway - South Counterclockwise",
+          "type": "original",
+          "length_m": 6560,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 16,
+          "elevation_m": 24.0,
+          "longest_straight_m": 900.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Trial Mountain Circuit",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Trial Mountain Circuit",
+          "type": "original",
+          "length_m": 5434,
+          "reversible": true,
+          "rain": false,
+          "sophy": "forwards_only",
+          "turns": 15,
+          "elevation_m": null,
+          "longest_straight_m": null,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "PDI"
+    },
+    {
+      "name": "Tsukuba Circuit",
+      "country": "JPN",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Tsukuba Circuit",
+          "type": "real",
+          "length_m": 2045,
+          "reversible": false,
+          "rain": true,
+          "sophy": "yes",
+          "turns": 8,
+          "elevation_m": 5.3,
+          "longest_straight_m": 445.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "Japan"
+    },
+    {
+      "name": "Watkins Glen International",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Long Course",
+          "wiki_page": "Watkins Glen Long Course",
+          "type": "real",
+          "length_m": 5423,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 41.1,
+          "longest_straight_m": 560.5,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Short Course",
+          "wiki_page": "Watkins Glen Short Course",
+          "type": "real",
+          "length_m": 3942,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 7,
+          "elevation_m": 10.7,
+          "longest_straight_m": 621.8,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "WeatherTech Raceway Laguna Seca",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "WeatherTech Raceway Laguna Seca",
+          "type": "real",
+          "length_m": 3602,
+          "reversible": false,
+          "rain": false,
+          "sophy": "yes",
+          "turns": 11,
+          "elevation_m": null,
+          "longest_straight_m": null,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Willow Springs International Raceway",
+      "country": "USA",
+      "layouts": [
+        {
+          "name": "Big Willow",
+          "wiki_page": "Willow Springs International Raceway: Big Willow",
+          "type": "real",
+          "length_m": 3951,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 9,
+          "elevation_m": 50.0,
+          "longest_straight_m": 756.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Streets of Willow Springs",
+          "wiki_page": "Willow Springs International Raceway: Streets of Willow Springs",
+          "type": "real",
+          "length_m": 2675,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 14,
+          "elevation_m": 20.0,
+          "longest_straight_m": 400.0,
+          "roadway": "Tarmac"
+        },
+        {
+          "name": "Horse Thief Mile",
+          "wiki_page": "Willow Springs International Raceway: Horse Thief Mile",
+          "type": "real",
+          "length_m": 1624,
+          "reversible": true,
+          "rain": false,
+          "sophy": "no",
+          "turns": 11,
+          "elevation_m": 42.0,
+          "longest_straight_m": 216.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "USA"
+    },
+    {
+      "name": "Yas Marina Circuit",
+      "country": "UAE",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "wiki_page": "Yas Marina Circuit",
+          "type": "real",
+          "length_m": 5281,
+          "reversible": false,
+          "rain": false,
+          "sophy": "no",
+          "turns": 16,
+          "elevation_m": 11.0,
+          "longest_straight_m": 1233.0,
+          "roadway": "Tarmac"
+        }
+      ],
+      "country_name": "UAE"
+    }
+  ]
+}

--- a/backend/data/tracks.json
+++ b/backend/data/tracks.json
@@ -1,1400 +1,1725 @@
 {
   "meta": {
     "generated": "2026-08-08",
-    "source": "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List (CC BY-SA; upstream: https://www.gran-turismo.com/gb/gt7/tracklist/)",
+    "sources": {
+      "official": "https://www.gran-turismo.com/gb/gt7/tracklist/ (per-config ids, names, corner counts; exact metres from the metric locale of the same data)",
+      "wiki": "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List (CC BY-SA: real/original, rain, GT Sophy, reversibility, roadway, page links)"
+    },
     "tracks": 41,
-    "layouts": 84,
-    "configurations_including_reverse": 121,
-    "note": "Per-layout template data is authoritative; the list page's prose may state a different configuration total. page_describes_layout=false flags layouts whose wiki page infobox measures a different variant; their length_m (from the list) is still per-layout."
+    "layouts": 85,
+    "configurations_including_reverse": 121
   },
   "tracks": [
     {
       "name": "24 Heures du Mans Racing Circuit",
+      "official_track_id": "1d5980",
       "country": "FRA",
+      "country_name": "France",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Circuit de la Sarthe",
-          "type": "real",
+          "official_id": "c272b2",
+          "official_name": "24 Heures du Mans Racing Circuit",
+          "turns": 38,
           "length_m": 13629,
-          "reversible": false,
+          "elevation_m": 37.3,
+          "longest_straight_m": 1679,
+          "type": "real",
           "rain": true,
           "sophy": "yes",
-          "turns": 38,
-          "elevation_m": 37.3,
-          "longest_straight_m": 1679.0,
           "roadway": "Tarmac",
-          "page_describes_layout": false
+          "wiki_page": "Circuit de la Sarthe",
+          "reverse": null
         },
         {
           "name": "No Chicane",
-          "wiki_page": "Circuit de la Sarthe",
-          "type": "real",
+          "official_id": "fbd5bc",
+          "official_name": "24 Heures du Mans Racing Circuit No Chicane",
+          "turns": 32,
           "length_m": 13567,
-          "reversible": false,
+          "elevation_m": 37.3,
+          "longest_straight_m": 5700,
+          "type": "real",
           "rain": true,
           "sophy": "no",
-          "turns": 38,
-          "elevation_m": 37.3,
-          "longest_straight_m": 1679.0,
           "roadway": "Tarmac",
-          "page_describes_layout": false
+          "wiki_page": "Circuit de la Sarthe",
+          "reverse": null
         }
-      ],
-      "country_name": "France"
+      ]
     },
     {
       "name": "Alsace",
+      "official_track_id": "bbe708",
       "country": "FRA",
+      "country_name": "France",
       "layouts": [
         {
           "name": "Village",
-          "wiki_page": "Alsace - Village",
-          "type": "original",
+          "official_id": "81f860",
+          "official_name": "Alsace - Village",
+          "turns": 17,
           "length_m": 5423,
-          "reversible": true,
+          "elevation_m": 57.3,
+          "longest_straight_m": 450,
+          "type": "original",
           "rain": false,
           "sophy": "forwards_only",
-          "turns": 17,
-          "elevation_m": 57.3,
-          "longest_straight_m": 450.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Alsace - Village",
+          "reverse": {
+            "official_id": "ef9ee9",
+            "turns": 17
+          }
         },
         {
           "name": "Test Course",
-          "wiki_page": "Alsace - Test Course",
-          "type": "original",
+          "official_id": "42ea84",
+          "official_name": "Alsace - Test Course",
+          "turns": 7,
           "length_m": 2118,
-          "reversible": true,
+          "elevation_m": 35.3,
+          "longest_straight_m": 432,
+          "type": "original",
           "rain": false,
           "sophy": "no",
-          "turns": 7,
-          "elevation_m": 35.3,
-          "longest_straight_m": 432.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Alsace - Test Course",
+          "reverse": {
+            "official_id": "131d9e",
+            "turns": 7
+          }
         }
-      ],
-      "country_name": "France"
+      ]
     },
     {
       "name": "Autodrome Lago Maggiore",
+      "official_track_id": "39f155",
       "country": "ITA",
+      "country_name": "Italy",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Autodrome Lago Maggiore - GP",
-          "type": "original",
+          "official_id": "5ba087",
+          "official_name": "Autodrome Lago Maggiore - Full Course",
+          "turns": 17,
           "length_m": 5809,
-          "reversible": true,
+          "elevation_m": 74,
+          "longest_straight_m": 800,
+          "type": "original",
           "rain": false,
           "sophy": "forwards_only",
-          "turns": 17,
-          "elevation_m": 74.0,
-          "longest_straight_m": 800.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Centre",
-          "wiki_page": "Autodrome Lago Maggiore - Center",
-          "type": "original",
-          "length_m": 1706,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 8,
-          "elevation_m": 12.0,
-          "longest_straight_m": 550.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "East End",
-          "wiki_page": "Autodrome Lago Maggiore - East End",
-          "type": "original",
-          "length_m": 2010,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 8,
-          "elevation_m": 42.0,
-          "longest_straight_m": 500.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "West End",
-          "wiki_page": "Autodrome Lago Maggiore - West End",
-          "type": "original",
-          "length_m": 2444,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 10,
-          "elevation_m": 48.0,
-          "longest_straight_m": 373.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "East",
-          "wiki_page": "Autodrome Lago Maggiore - East",
-          "type": "original",
-          "length_m": 3643,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 11,
-          "elevation_m": 43.0,
-          "longest_straight_m": 550.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - GP",
+          "reverse": {
+            "official_id": "71b4d8",
+            "turns": 17
+          }
         },
         {
           "name": "West",
-          "wiki_page": "Autodrome Lago Maggiore - West",
-          "type": "original",
+          "official_id": "e829d7",
+          "official_name": "Autodrome Lago Maggiore - West",
+          "turns": 13,
           "length_m": 4168,
-          "reversible": true,
+          "elevation_m": 49,
+          "longest_straight_m": 800,
+          "type": "original",
           "rain": false,
           "sophy": "no",
-          "turns": 13,
-          "elevation_m": 49.0,
-          "longest_straight_m": 800.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Italy"
-    },
-    {
-      "name": "Autódromo de Interlagos",
-      "country": "BRA",
-      "layouts": [
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - West",
+          "reverse": {
+            "official_id": "297b7f",
+            "turns": 13
+          }
+        },
         {
-          "name": "Full Course",
-          "wiki_page": "Autódromo de Interlagos",
-          "type": "real",
-          "length_m": 4309,
-          "reversible": false,
+          "name": "East",
+          "official_id": "7828c0",
+          "official_name": "Autodrome Lago Maggiore - East",
+          "turns": 11,
+          "length_m": 3643,
+          "elevation_m": 43,
+          "longest_straight_m": 550,
+          "type": "original",
           "rain": false,
-          "sophy": "yes",
-          "turns": 15,
-          "elevation_m": 43.0,
-          "longest_straight_m": 650.0,
-          "roadway": "Tarmac"
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - East",
+          "reverse": {
+            "official_id": "d1f9b5",
+            "turns": 11
+          }
+        },
+        {
+          "name": "West End",
+          "official_id": "ab5c32",
+          "official_name": "Autodrome Lago Maggiore - West End",
+          "turns": 10,
+          "length_m": 2444,
+          "elevation_m": 48,
+          "longest_straight_m": 373,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - West End",
+          "reverse": {
+            "official_id": "5f2207",
+            "turns": 10
+          }
+        },
+        {
+          "name": "East End",
+          "official_id": "cdd5eb",
+          "official_name": "Autodrome Lago Maggiore - East End",
+          "turns": 8,
+          "length_m": 2010,
+          "elevation_m": 42,
+          "longest_straight_m": 500,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - East End",
+          "reverse": {
+            "official_id": "a2910f",
+            "turns": 8
+          }
+        },
+        {
+          "name": "Centre",
+          "official_id": "46b3d9",
+          "official_name": "Autodrome Lago Maggiore - Centre",
+          "turns": 8,
+          "length_m": 1706,
+          "elevation_m": 12,
+          "longest_straight_m": 550,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Autodrome Lago Maggiore - Center",
+          "reverse": {
+            "official_id": "bccdd8",
+            "turns": 8
+          }
         }
-      ],
-      "country_name": "Brazil"
+      ]
     },
     {
       "name": "Autodromo Nazionale Monza",
+      "official_track_id": "f8bd64",
       "country": "ITA",
+      "country_name": "Italy",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Autodromo Nazionale Monza",
-          "type": "real",
+          "official_id": "e6817f",
+          "official_name": "Autodromo Nazionale Monza",
+          "turns": 11,
           "length_m": 5793,
-          "reversible": false,
+          "elevation_m": 13.5,
+          "longest_straight_m": 938,
+          "type": "real",
           "rain": false,
           "sophy": "yes",
-          "turns": 10,
-          "elevation_m": null,
-          "longest_straight_m": null,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Autodromo Nazionale Monza",
+          "reverse": null
         },
         {
           "name": "No Chicane",
-          "wiki_page": "Autodromo Nazionale Monza (No Chicane)",
-          "type": "real",
+          "official_id": "f9e0f3",
+          "official_name": "Autodromo Nazionale Monza No Chicane",
+          "turns": 9,
           "length_m": 5755,
-          "reversible": false,
+          "elevation_m": 13.5,
+          "longest_straight_m": 1238,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 8,
-          "elevation_m": 14.3,
-          "longest_straight_m": 1248.7,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Autodromo Nazionale Monza (No Chicane)",
+          "reverse": null
         }
-      ],
-      "country_name": "Italy"
+      ]
     },
     {
-      "name": "Autopolis International Racing Course",
+      "name": "Autopolis",
+      "official_track_id": "8d9953",
       "country": "JPN",
+      "country_name": "Japan",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Autopolis International Racing Course",
-          "type": "real",
+          "official_id": "1d0c5e",
+          "official_name": "Autopolis International Racing Course",
+          "turns": 18,
           "length_m": 4674,
-          "reversible": false,
+          "elevation_m": 52,
+          "longest_straight_m": 902,
+          "type": "real",
           "rain": true,
           "sophy": "no",
-          "turns": 18,
-          "elevation_m": 52.0,
-          "longest_straight_m": 902.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Autopolis International Racing Course",
+          "reverse": null
         },
         {
           "name": "Shortcut Course",
-          "wiki_page": "Autopolis International Racing Course - Shortcut Course",
-          "type": "real",
+          "official_id": "2c2c67",
+          "official_name": "Autopolis International Racing Course - Short Course",
+          "turns": 11,
           "length_m": 3022,
-          "reversible": false,
+          "elevation_m": 30,
+          "longest_straight_m": 902,
+          "type": "real",
           "rain": true,
           "sophy": "no",
-          "turns": 11,
-          "elevation_m": 30.0,
-          "longest_straight_m": 902.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Autopolis International Racing Course - Shortcut Course",
+          "reverse": null
         }
-      ],
-      "country_name": "Japan"
+      ]
+    },
+    {
+      "name": "Autódromo de Interlagos",
+      "official_track_id": "fe330b",
+      "country": "BRA",
+      "country_name": "Brazil",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "101516",
+          "official_name": "Autódromo de Interlagos",
+          "turns": 15,
+          "length_m": 4309,
+          "elevation_m": 43,
+          "longest_straight_m": 650,
+          "type": "real",
+          "rain": false,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Autódromo de Interlagos",
+          "reverse": null
+        }
+      ]
     },
     {
       "name": "Blue Moon Bay Speedway",
+      "official_track_id": "971481",
       "country": "USA",
+      "country_name": "United States",
       "layouts": [
         {
-          "name": "Full Course",
-          "wiki_page": "Blue Moon Bay Speedway",
+          "name": "Infield A",
+          "official_id": "890aef",
+          "official_name": "Blue Moon Bay Speedway - Infield A",
+          "turns": 10,
+          "length_m": 3350,
+          "elevation_m": 0,
+          "longest_straight_m": 890,
           "type": "original",
-          "length_m": 3200,
-          "reversible": true,
           "rain": false,
           "sophy": "no",
-          "turns": 3,
-          "elevation_m": 0.0,
-          "longest_straight_m": 1060.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Blue Moon Bay Speedway - Infield A",
+          "reverse": {
+            "official_id": "940193",
+            "turns": 10
+          }
         },
         {
-          "name": "Infield A",
-          "wiki_page": "Blue Moon Bay Speedway - Infield A",
+          "name": "Full Course",
+          "official_id": "6bf104",
+          "official_name": "Blue Moon Bay Speedway",
+          "turns": 3,
+          "length_m": 3200,
+          "elevation_m": 0,
+          "longest_straight_m": 1060,
           "type": "original",
-          "length_m": 3350,
-          "reversible": true,
           "rain": false,
           "sophy": "no",
-          "turns": 10,
-          "elevation_m": 0.0,
-          "longest_straight_m": 890.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Blue Moon Bay Speedway",
+          "reverse": {
+            "official_id": "edfde6",
+            "turns": 3
+          }
         },
         {
           "name": "Infield B",
-          "wiki_page": "Blue Moon Bay Speedway - Infield B",
-          "type": "original",
+          "official_id": "02e205",
+          "official_name": "Blue Moon Bay Speedway - Infield B",
+          "turns": 5,
           "length_m": 2860,
-          "reversible": true,
+          "elevation_m": 0,
+          "longest_straight_m": 890,
+          "type": "original",
           "rain": false,
           "sophy": "no",
-          "turns": 5,
-          "elevation_m": 0.0,
-          "longest_straight_m": 890.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Blue Moon Bay Speedway - Infield B",
+          "reverse": {
+            "official_id": "c42430",
+            "turns": 5
+          }
         }
-      ],
-      "country_name": "USA"
+      ]
     },
     {
       "name": "Brands Hatch",
+      "official_track_id": "f3d2aa",
       "country": "GBR",
+      "country_name": "United Kingdom",
       "layouts": [
         {
           "name": "Grand Prix Circuit",
-          "wiki_page": "Brands Hatch GP",
-          "type": "real",
+          "official_id": "3f4c16",
+          "official_name": "Brands Hatch Grand Prix Circuit",
+          "turns": 9,
           "length_m": 3946,
-          "reversible": false,
+          "elevation_m": 35,
+          "longest_straight_m": 475,
+          "type": "real",
           "rain": false,
           "sophy": "yes",
-          "turns": 9,
-          "elevation_m": 35.0,
-          "longest_straight_m": 475.0,
           "roadway": "Tarmac",
-          "page_describes_layout": false
+          "wiki_page": "Brands Hatch GP",
+          "reverse": null
         },
         {
           "name": "Indy Circuit",
-          "wiki_page": "Brands Hatch Indy",
-          "type": "real",
+          "official_id": "4ff578",
+          "official_name": "Brands Hatch Indy Circuit",
+          "turns": 5,
           "length_m": 1944,
-          "reversible": false,
+          "elevation_m": 24,
+          "longest_straight_m": 400,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 5,
-          "elevation_m": 24.0,
-          "longest_straight_m": 400.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Brands Hatch Indy",
+          "reverse": null
         }
-      ],
-      "country_name": "United Kingdom"
+      ]
     },
     {
       "name": "Broad Bean Raceway",
+      "official_track_id": "184eaa",
       "country": "JPN",
+      "country_name": "Japan",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Broad Bean Raceway",
-          "type": "original",
-          "length_m": 1665,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
+          "official_id": "1fb373",
+          "official_name": "BB Raceway",
           "turns": 5,
-          "elevation_m": 0.0,
-          "longest_straight_m": 386.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Japan"
-    },
-    {
-      "name": "Circuit de Barcelona-Catalunya",
-      "country": "ESP",
-      "layouts": [
-        {
-          "name": "Grand Prix Layout",
-          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
-          "type": "real",
-          "length_m": 4655,
-          "reversible": false,
-          "rain": false,
-          "sophy": "yes",
-          "turns": 16,
-          "elevation_m": 30.0,
-          "longest_straight_m": 1047.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Grand Prix Layout No Chicane",
-          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
-          "type": "real",
-          "length_m": 4730,
-          "reversible": false,
+          "length_m": 1665,
+          "elevation_m": 0,
+          "longest_straight_m": 386,
+          "type": "original",
           "rain": false,
           "sophy": "no",
-          "turns": 16,
-          "elevation_m": 30.0,
-          "longest_straight_m": 1047.0,
           "roadway": "Tarmac",
-          "page_describes_layout": false
-        },
-        {
-          "name": "National Layout",
-          "wiki_page": "Circuit de Barcelona-Catalunya National Layout",
-          "type": "real",
-          "length_m": 2977,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 11,
-          "elevation_m": 28.0,
-          "longest_straight_m": 862.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Rallycross Layout",
-          "wiki_page": "Circuit de Barcelona-Catalunya Rallycross Layout",
-          "type": "original",
-          "length_m": 1133,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 11,
-          "elevation_m": 11.0,
-          "longest_straight_m": 148.0,
-          "roadway": "Tarmac & Dirt"
+          "wiki_page": "Broad Bean Raceway",
+          "reverse": {
+            "official_id": "092b5e",
+            "turns": 5
+          }
         }
-      ],
-      "country_name": "Spain"
-    },
-    {
-      "name": "Circuit de Sainte-Croix",
-      "country": "FRA",
-      "layouts": [
-        {
-          "name": "Layout A",
-          "wiki_page": "Circuit de Sainte-Croix - A",
-          "type": "original",
-          "length_m": 9477,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 19,
-          "elevation_m": 44.0,
-          "longest_straight_m": 915.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Layout B",
-          "wiki_page": "Circuit de Sainte-Croix - B",
-          "type": "original",
-          "length_m": 7062,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 14,
-          "elevation_m": 44.0,
-          "longest_straight_m": 915.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Layout C",
-          "wiki_page": "Circuit de Sainte-Croix - C",
-          "type": "original",
-          "length_m": 10825,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 24,
-          "elevation_m": 44.0,
-          "longest_straight_m": 1807.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "France"
-    },
-    {
-      "name": "Circuit de Spa-Francorchamps",
-      "country": "BEL",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Circuit de Spa-Francorchamps",
-          "type": "real",
-          "length_m": 7044,
-          "reversible": false,
-          "rain": true,
-          "sophy": "yes",
-          "turns": 21,
-          "elevation_m": 104.0,
-          "longest_straight_m": 751.8,
-          "roadway": "Tarmac",
-          "page_describes_layout": false
-        },
-        {
-          "name": "24h Layout",
-          "wiki_page": "Circuit de Spa-Francorchamps",
-          "type": "real",
-          "length_m": 7044,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 21,
-          "elevation_m": 104.0,
-          "longest_straight_m": 751.8,
-          "roadway": "Tarmac",
-          "page_describes_layout": false
-        }
-      ],
-      "country_name": "Belgium"
+      ]
     },
     {
       "name": "Circuit Gilles-Villeneuve",
+      "official_track_id": "4b2a08",
       "country": "CAN",
+      "country_name": "Canada",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Circuit Gilles-Villeneuve",
-          "type": "real",
+          "official_id": "e86599",
+          "official_name": "Circuit Gilles-Villeneuve",
+          "turns": 14,
           "length_m": 4361,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 14,
-          "elevation_m": null,
-          "longest_straight_m": null,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Canada"
-    },
-    {
-      "name": "Colorado Springs",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Lake",
-          "wiki_page": "Colorado Springs - Lake",
-          "type": "original",
-          "length_m": 2990,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 15,
-          "elevation_m": 15.0,
-          "longest_straight_m": 177.0,
-          "roadway": "Dirt"
-        }
-      ],
-      "country_name": "USA"
-    },
-    {
-      "name": "Daytona International Speedway",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Tri-Oval",
-          "wiki_page": "Daytona Superspeedway",
+          "elevation_m": 5,
+          "longest_straight_m": 1173,
           "type": "real",
-          "length_m": 4023,
-          "reversible": false,
           "rain": false,
           "sophy": "no",
-          "turns": 3,
-          "elevation_m": 0.0,
-          "longest_straight_m": 914.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Road Course",
-          "wiki_page": "Daytona Road Course",
-          "type": "real",
-          "length_m": 5729,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 12,
-          "elevation_m": 8.4,
-          "longest_straight_m": 575.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "USA"
-    },
-    {
-      "name": "Deep Forest Raceway",
-      "country": "Switzerland",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Deep Forest Raceway",
-          "type": "original",
-          "length_m": 4253,
-          "reversible": true,
-          "rain": false,
-          "sophy": "forwards_only",
-          "turns": 15,
-          "elevation_m": 45.2,
-          "longest_straight_m": 779.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "PDI"
-    },
-    {
-      "name": "Dragon Trail",
-      "country": "CRO",
-      "layouts": [
-        {
-          "name": "Seaside",
-          "wiki_page": "Dragon Trail - Seaside",
-          "type": "original",
-          "length_m": 5209,
-          "reversible": true,
-          "rain": false,
-          "sophy": "forwards_only",
-          "turns": 18,
-          "elevation_m": 38.0,
-          "longest_straight_m": 653.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Gardens",
-          "wiki_page": "Dragon Trail - Gardens",
-          "type": "original",
-          "length_m": 4352,
-          "reversible": true,
-          "rain": true,
-          "sophy": "no",
-          "turns": 17,
-          "elevation_m": 27.0,
-          "longest_straight_m": 781.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Croatia"
-    },
-    {
-      "name": "Eiger Nordwand",
-      "country": "Switzerland",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Eiger Nordwand Short Track",
-          "type": "original",
-          "length_m": 2436,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 11,
-          "elevation_m": 75.0,
-          "longest_straight_m": 250.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Switzerland"
-    },
-    {
-      "name": "Fishermans Ranch",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Fisherman's Ranch",
-          "type": "original",
-          "length_m": 6893,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 40,
-          "elevation_m": 145.0,
-          "longest_straight_m": 434.0,
-          "roadway": "Dirt"
-        }
-      ],
-      "country_name": "USA"
-    },
-    {
-      "name": "Fuji International Speedway",
-      "country": "JPN",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Fuji International Speedway",
-          "type": "real",
-          "length_m": 4563,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 16,
-          "elevation_m": 37.0,
-          "longest_straight_m": 1475.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Short Course",
-          "wiki_page": "Fuji International Speedway (Short)",
-          "type": "real",
-          "length_m": 4526,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 14,
-          "elevation_m": 37.0,
-          "longest_straight_m": 1475.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Japan"
-    },
-    {
-      "name": "Goodwood Motor Circuit",
-      "country": "GBR",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Goodwood Motor Circuit",
-          "type": "real",
-          "length_m": 3809,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 7,
-          "elevation_m": 10.0,
-          "longest_straight_m": 514.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "United Kingdom"
-    },
-    {
-      "name": "Grand Valley",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Highway 1",
-          "wiki_page": "Grand Valley Highway 1",
-          "type": "original",
-          "length_m": 5099,
-          "reversible": true,
-          "rain": false,
-          "sophy": "forwards_only",
-          "turns": 18,
-          "elevation_m": 97.0,
-          "longest_straight_m": 995.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "South",
-          "wiki_page": "Grand Valley South",
-          "type": "original",
-          "length_m": 3076,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 10,
-          "elevation_m": 85.0,
-          "longest_straight_m": 995.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "USA"
-    },
-    {
-      "name": "High Speed Ring",
-      "country": "JPN",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "High Speed Ring",
-          "type": "original",
-          "length_m": 4345,
-          "reversible": true,
-          "rain": true,
-          "sophy": "forwards_only",
-          "turns": 6,
-          "elevation_m": 8.5,
-          "longest_straight_m": 752.0,
           "roadway": "Tarmac",
-          "page_describes_layout": false
+          "wiki_page": "Circuit Gilles-Villeneuve",
+          "reverse": null
         }
-      ],
-      "country_name": "PDI"
+      ]
     },
     {
-      "name": "Kyoto Driving Park",
-      "country": "JPN",
+      "name": "Circuit de Barcelona-Catalunya",
+      "official_track_id": "083de2",
+      "country": "ESP",
+      "country_name": "Spain",
       "layouts": [
         {
-          "name": "Yamagiwa",
-          "wiki_page": "Kyoto Driving Park - Yamagiwa",
-          "type": "original",
-          "length_m": 4912,
-          "reversible": true,
+          "name": "Grand Prix Layout No Chicane",
+          "official_id": "a5d0f0",
+          "official_name": "Circuit de Barcelona-Catalunya GP Layout No Chicane",
+          "turns": 14,
+          "length_m": 4730,
+          "elevation_m": 30,
+          "longest_straight_m": 1047,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 15,
-          "elevation_m": 38.6,
-          "longest_straight_m": 743.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
+          "reverse": null
         },
         {
-          "name": "Miyabi",
-          "wiki_page": "Kyoto Driving Park - Miyabi",
-          "type": "original",
-          "length_m": 1953,
-          "reversible": false,
+          "name": "Grand Prix Layout",
+          "official_id": "aa8dc5",
+          "official_name": "Circuit de Barcelona-Catalunya GP Layout",
+          "turns": 16,
+          "length_m": 4655,
+          "elevation_m": 30,
+          "longest_straight_m": 1047,
+          "type": "real",
           "rain": false,
-          "sophy": "no",
-          "turns": 7,
-          "elevation_m": 17.5,
-          "longest_straight_m": 442.0,
-          "roadway": "Tarmac"
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Barcelona-Catalunya Grand Prix",
+          "reverse": null
         },
         {
-          "name": "Yamagiwa + Miyabi",
-          "wiki_page": "Kyoto Driving Park - Yamagiwa + Miyabi",
-          "type": "original",
-          "length_m": 6846,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 19,
-          "elevation_m": 38.6,
-          "longest_straight_m": 743.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Japan"
-    },
-    {
-      "name": "Lake Louise",
-      "country": "CAN",
-      "layouts": [
-        {
-          "name": "Tri-Oval",
-          "wiki_page": "Lake Louise Tri-Oval",
-          "type": "original",
-          "length_m": 3068,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 3,
-          "elevation_m": 78.0,
-          "longest_straight_m": 1184.0,
-          "roadway": "Snow"
-        },
-        {
-          "name": "Short Track",
-          "wiki_page": "Lake Louise Short Track",
-          "type": "original",
-          "length_m": 2577,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 7,
-          "elevation_m": 63.0,
-          "longest_straight_m": 1024.0,
-          "roadway": "Snow"
-        },
-        {
-          "name": "Long Track",
-          "wiki_page": "Lake Louise Long Track",
-          "type": "original",
-          "length_m": 3694,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
+          "name": "National Layout",
+          "official_id": "d84128",
+          "official_name": "Circuit de Barcelona-Catalunya National Layout",
           "turns": 11,
-          "elevation_m": 78.0,
-          "longest_straight_m": 765.0,
-          "roadway": "Snow"
-        }
-      ],
-      "country_name": "Canada"
-    },
-    {
-      "name": "Michelin Raceway Road Atlanta",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Michelin Raceway Road Atlanta",
+          "length_m": 2977,
+          "elevation_m": 28,
+          "longest_straight_m": 862,
           "type": "real",
-          "length_m": 4088,
-          "reversible": false,
           "rain": false,
-          "sophy": "yes",
-          "turns": 12,
-          "elevation_m": 38.0,
-          "longest_straight_m": 1275.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "USA"
-    },
-    {
-      "name": "Mount Panorama Circuit",
-      "country": "AUS",
-      "layouts": [
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Barcelona-Catalunya National Layout",
+          "reverse": null
+        },
         {
-          "name": "Full Course",
-          "wiki_page": "Mount Panorama",
-          "type": "real",
-          "length_m": 6213,
-          "reversible": false,
-          "rain": false,
-          "sophy": "yes",
-          "turns": 23,
-          "elevation_m": 174.0,
-          "longest_straight_m": 1916.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Australia"
-    },
-    {
-      "name": "Northern Isle Speedway",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Northern Isle Speedway",
+          "name": "Rallycross Layout",
+          "official_id": "3bee8b",
+          "official_name": "Circuit de Barcelona-Catalunya Rallycross Layout",
+          "turns": 11,
+          "length_m": 1133,
+          "elevation_m": 11,
+          "longest_straight_m": 148,
           "type": "original",
-          "length_m": 900,
-          "reversible": false,
           "rain": false,
           "sophy": "no",
-          "turns": 4,
-          "elevation_m": 0.0,
-          "longest_straight_m": 134.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac & Dirt",
+          "wiki_page": "Circuit de Barcelona-Catalunya Rallycross Layout",
+          "reverse": null
         }
-      ],
-      "country_name": "USA"
+      ]
     },
     {
-      "name": "Nürburgring",
-      "country": "GER",
+      "name": "Circuit de Sainte-Croix",
+      "official_track_id": "a768c9",
+      "country": "FRA",
+      "country_name": "France",
       "layouts": [
         {
-          "name": "Nordschleife",
-          "wiki_page": "Nürburgring Nordschleife",
-          "type": "real",
-          "length_m": 20832,
-          "reversible": false,
-          "rain": true,
+          "name": "Layout C",
+          "official_id": "041ba3",
+          "official_name": "Circuit de Sainte-Croix - C",
+          "turns": 24,
+          "length_m": 10825,
+          "elevation_m": 44,
+          "longest_straight_m": 1807,
+          "type": "original",
+          "rain": false,
           "sophy": "no",
-          "turns": 73,
-          "elevation_m": 300.0,
-          "longest_straight_m": 2135.0,
-          "roadway": "Tarmac & Concrete"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Sainte-Croix - C",
+          "reverse": {
+            "official_id": "5c21c8",
+            "turns": 24
+          }
         },
-        {
-          "name": "Nordschleife Tourist",
-          "wiki_page": "Nürburgring Nordschleife",
-          "type": "real",
-          "length_m": 20832,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 73,
-          "elevation_m": 300.0,
-          "longest_straight_m": 2135.0,
-          "roadway": "Tarmac & Concrete"
-        },
-        {
-          "name": "24h",
-          "wiki_page": "Nürburgring 24h",
-          "type": "real",
-          "length_m": 25378,
-          "reversible": false,
-          "rain": true,
-          "sophy": "yes",
-          "turns": 89,
-          "elevation_m": 300.0,
-          "longest_straight_m": 2135.0,
-          "roadway": "Tarmac & Concrete",
-          "page_describes_layout": false
-        },
-        {
-          "name": "Grand Prix",
-          "wiki_page": "Nürburgring GP/F",
-          "type": "real",
-          "length_m": 5148,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 17,
-          "elevation_m": 57.0,
-          "longest_straight_m": 620.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Endurance",
-          "wiki_page": "Nürburgring Endurance",
-          "type": "real",
-          "length_m": 23864,
-          "reversible": true,
-          "rain": true,
-          "sophy": "no",
-          "turns": 84,
-          "elevation_m": 300.0,
-          "longest_straight_m": 2135.0,
-          "roadway": "Tarmac & Concrete",
-          "page_describes_layout": false
-        },
-        {
-          "name": "Sprint",
-          "wiki_page": "Nürburgring Sprint",
-          "type": "real",
-          "length_m": 3629,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 12,
-          "elevation_m": 33.0,
-          "longest_straight_m": 620.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Germany"
-    },
-    {
-      "name": "Red Bull Ring",
-      "country": "AUT",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Red Bull Ring",
-          "type": "real",
-          "length_m": 4318,
-          "reversible": false,
-          "rain": true,
-          "sophy": "yes",
-          "turns": 9,
-          "elevation_m": 65.5,
-          "longest_straight_m": 939.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Short Track",
-          "wiki_page": "Red Bull Ring Short Track",
-          "type": "real",
-          "length_m": 2336,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 6,
-          "elevation_m": 32.4,
-          "longest_straight_m": 939.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Austria"
-    },
-    {
-      "name": "Sardegna - Road Track",
-      "country": "ITA",
-      "layouts": [
         {
           "name": "Layout A",
-          "wiki_page": "Sardegna - Road Track - A",
+          "official_id": "954433",
+          "official_name": "Circuit de Sainte-Croix - A",
+          "turns": 19,
+          "length_m": 9477,
+          "elevation_m": 44,
+          "longest_straight_m": 915,
           "type": "original",
-          "length_m": 5113,
-          "reversible": true,
           "rain": false,
           "sophy": "no",
-          "turns": 15,
-          "elevation_m": 38.0,
-          "longest_straight_m": 915.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Sainte-Croix - A",
+          "reverse": {
+            "official_id": "9f7218",
+            "turns": 19
+          }
         },
         {
           "name": "Layout B",
-          "wiki_page": "Sardegna - Road Track - B",
-          "type": "original",
-          "length_m": 3893,
-          "reversible": true,
-          "rain": false,
-          "sophy": "forwards_only",
-          "turns": 13,
-          "elevation_m": 56.0,
-          "longest_straight_m": 915.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Layout C",
-          "wiki_page": "Sardegna - Road Track - C",
-          "type": "original",
-          "length_m": 2661,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
-          "turns": 10,
-          "elevation_m": 54.0,
-          "longest_straight_m": 915.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Italy"
-    },
-    {
-      "name": "Sardegna - Windmills",
-      "country": "ITA",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Sardegna - Windmills",
-          "type": "original",
-          "length_m": 3310,
-          "reversible": true,
-          "rain": false,
-          "sophy": "no",
+          "official_id": "c81c02",
+          "official_name": "Circuit de Sainte-Croix - B",
           "turns": 14,
-          "elevation_m": 75.0,
-          "longest_straight_m": 298.0,
-          "roadway": "Dirt"
-        }
-      ],
-      "country_name": "Italy"
-    },
-    {
-      "name": "Special Stage Route X",
-      "country": "USA",
-      "layouts": [
-        {
-          "name": "Full Course",
-          "wiki_page": "Special Stage Route X",
+          "length_m": 7062,
+          "elevation_m": 44,
+          "longest_straight_m": 915,
           "type": "original",
-          "length_m": 30283,
-          "reversible": false,
           "rain": false,
           "sophy": "no",
-          "turns": 2,
-          "elevation_m": 65.0,
-          "longest_straight_m": 12000.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Sainte-Croix - B",
+          "reverse": {
+            "official_id": "893d93",
+            "turns": 14
+          }
         }
-      ],
-      "country_name": "PDI"
+      ]
     },
     {
-      "name": "Suzuka Circuit",
-      "country": "JPN",
+      "name": "Circuit de Spa-Francorchamps",
+      "official_track_id": "000971",
+      "country": "BEL",
+      "country_name": "Belgium",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Suzuka Circuit",
+          "official_id": "3c4be1",
+          "official_name": "Circuit de Spa-Francorchamps",
+          "turns": 21,
+          "length_m": 7004,
+          "elevation_m": 104,
+          "longest_straight_m": 751.8,
           "type": "real",
-          "length_m": 5807,
-          "reversible": false,
           "rain": true,
           "sophy": "yes",
-          "turns": 20,
-          "elevation_m": 40.0,
-          "longest_straight_m": 1200.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Spa-Francorchamps",
+          "reverse": null
         },
         {
-          "name": "East Course",
-          "wiki_page": "Suzuka Circuit East",
+          "name": "24h Layout",
+          "official_id": "d60ebc",
+          "official_name": "Spa 24h Layout",
+          "turns": 21,
+          "length_m": 7004,
+          "elevation_m": 104,
+          "longest_straight_m": 751.8,
           "type": "real",
-          "length_m": 2243,
-          "reversible": false,
           "rain": true,
           "sophy": "no",
-          "turns": 9,
-          "elevation_m": 33.6,
-          "longest_straight_m": 800.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Circuit de Spa-Francorchamps",
+          "reverse": null
         }
-      ],
-      "country_name": "Japan"
+      ]
     },
     {
-      "name": "Tokyo Expressway",
-      "country": "JPN",
-      "layouts": [
-        {
-          "name": "Central Clockwise",
-          "wiki_page": "Tokyo Expressway - Central Clockwise",
-          "type": "original",
-          "length_m": 4405,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 13,
-          "elevation_m": 8.0,
-          "longest_straight_m": 600.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "East Clockwise",
-          "wiki_page": "Tokyo Expressway - East Clockwise",
-          "type": "original",
-          "length_m": 7301,
-          "reversible": false,
-          "rain": true,
-          "sophy": "yes",
-          "turns": 13,
-          "elevation_m": 32.0,
-          "longest_straight_m": 2000.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "South Clockwise",
-          "wiki_page": "Tokyo Expressway - South Clockwise",
-          "type": "original",
-          "length_m": 5201,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 17,
-          "elevation_m": 24.0,
-          "longest_straight_m": 900.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "Central Counterclockwise",
-          "wiki_page": "Tokyo Expressway - Central Counterclockwise",
-          "type": "original",
-          "length_m": 4369,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 14,
-          "elevation_m": 16.0,
-          "longest_straight_m": 600.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "East Counterclockwise",
-          "wiki_page": "Tokyo Expressway - East Counterclockwise",
-          "type": "original",
-          "length_m": 7192,
-          "reversible": false,
-          "rain": true,
-          "sophy": "no",
-          "turns": 13,
-          "elevation_m": 32.0,
-          "longest_straight_m": 2000.0,
-          "roadway": "Tarmac"
-        },
-        {
-          "name": "South Counterclockwise",
-          "wiki_page": "Tokyo Expressway - South Counterclockwise",
-          "type": "original",
-          "length_m": 6560,
-          "reversible": false,
-          "rain": false,
-          "sophy": "no",
-          "turns": 16,
-          "elevation_m": 24.0,
-          "longest_straight_m": 900.0,
-          "roadway": "Tarmac"
-        }
-      ],
-      "country_name": "Japan"
-    },
-    {
-      "name": "Trial Mountain Circuit",
+      "name": "Colorado Springs",
+      "official_track_id": "cea600",
       "country": "USA",
+      "country_name": "United States",
       "layouts": [
         {
-          "name": "Full Course",
-          "wiki_page": "Trial Mountain Circuit",
-          "type": "original",
-          "length_m": 5434,
-          "reversible": true,
-          "rain": false,
-          "sophy": "forwards_only",
+          "name": "Lake",
+          "official_id": "14872f",
+          "official_name": "Colorado Springs - Lake",
           "turns": 15,
-          "elevation_m": null,
-          "longest_straight_m": null,
-          "roadway": "Tarmac"
+          "length_m": 2990,
+          "elevation_m": 15,
+          "longest_straight_m": 177,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Dirt",
+          "wiki_page": "Colorado Springs - Lake",
+          "reverse": {
+            "official_id": "46d3f1",
+            "turns": 15
+          }
         }
-      ],
-      "country_name": "PDI"
+      ]
     },
     {
-      "name": "Tsukuba Circuit",
-      "country": "JPN",
+      "name": "Daytona International Speedway",
+      "official_track_id": "d1f17e",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Road Course",
+          "official_id": "c58e28",
+          "official_name": "Daytona Road Course",
+          "turns": 12,
+          "length_m": 5729,
+          "elevation_m": 8.4,
+          "longest_straight_m": 575,
+          "type": "real",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Daytona Road Course",
+          "reverse": null
+        },
+        {
+          "name": "Tri-Oval",
+          "official_id": "d93f3a",
+          "official_name": "Daytona Tri-Oval",
+          "turns": 4,
+          "length_m": 4023,
+          "elevation_m": 10,
+          "longest_straight_m": 914,
+          "type": "real",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Daytona Superspeedway",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Deep Forest Raceway",
+      "official_track_id": "c81494",
+      "country": "Switzerland",
+      "country_name": "Switzerland",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Tsukuba Circuit",
-          "type": "real",
-          "length_m": 2045,
-          "reversible": false,
-          "rain": true,
-          "sophy": "yes",
-          "turns": 8,
-          "elevation_m": 5.3,
-          "longest_straight_m": 445.0,
-          "roadway": "Tarmac"
+          "official_id": "0457d4",
+          "official_name": "Deep Forest Raceway",
+          "turns": 18,
+          "length_m": 4253,
+          "elevation_m": 50,
+          "longest_straight_m": 765,
+          "type": "original",
+          "rain": false,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "Deep Forest Raceway",
+          "reverse": {
+            "official_id": "f3e708",
+            "turns": 18
+          }
         }
-      ],
-      "country_name": "Japan"
+      ]
     },
     {
-      "name": "Watkins Glen International",
-      "country": "USA",
+      "name": "Dragon Trail",
+      "official_track_id": "08df62",
+      "country": "CRO",
+      "country_name": "Croatia",
       "layouts": [
         {
-          "name": "Long Course",
-          "wiki_page": "Watkins Glen Long Course",
-          "type": "real",
-          "length_m": 5423,
-          "reversible": false,
+          "name": "Seaside",
+          "official_id": "36a3db",
+          "official_name": "Dragon Trail - Seaside",
+          "turns": 18,
+          "length_m": 5209,
+          "elevation_m": 38,
+          "longest_straight_m": 653,
+          "type": "original",
+          "rain": false,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "Dragon Trail - Seaside",
+          "reverse": {
+            "official_id": "1095b7",
+            "turns": 18
+          }
+        },
+        {
+          "name": "Gardens",
+          "official_id": "1a1157",
+          "official_name": "Dragon Trail - Gardens",
+          "turns": 17,
+          "length_m": 4352,
+          "elevation_m": 27,
+          "longest_straight_m": 781,
+          "type": "original",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Dragon Trail - Gardens",
+          "reverse": {
+            "official_id": "a93c4d",
+            "turns": 17
+          }
+        }
+      ]
+    },
+    {
+      "name": "Eiger Nordwand",
+      "official_track_id": "678583",
+      "country": "Switzerland",
+      "country_name": "Switzerland",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "8d429d",
+          "official_name": "Eiger Nordwand",
+          "turns": 11,
+          "length_m": 2436,
+          "elevation_m": 90,
+          "longest_straight_m": 250,
+          "type": "original",
           "rain": false,
           "sophy": "no",
-          "turns": 11,
-          "elevation_m": 41.1,
-          "longest_straight_m": 560.5,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Eiger Nordwand Short Track",
+          "reverse": {
+            "official_id": "24f937",
+            "turns": 11
+          }
+        }
+      ]
+    },
+    {
+      "name": "Fishermans Ranch",
+      "official_track_id": "f2875b",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "795ed4",
+          "official_name": "Fishermans Ranch",
+          "turns": 40,
+          "length_m": 6893,
+          "elevation_m": 145,
+          "longest_straight_m": 434,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Dirt",
+          "wiki_page": "Fisherman's Ranch",
+          "reverse": {
+            "official_id": "45e222",
+            "turns": 40
+          }
+        }
+      ]
+    },
+    {
+      "name": "Fuji International Speedway",
+      "official_track_id": "664e17",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "d066e4",
+          "official_name": "Fuji International Speedway",
+          "turns": 16,
+          "length_m": 4563,
+          "elevation_m": 40,
+          "longest_straight_m": 1475,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Fuji International Speedway",
+          "reverse": null
         },
         {
           "name": "Short Course",
-          "wiki_page": "Watkins Glen Short Course",
+          "official_id": "b1c9f8",
+          "official_name": "Fuji International Speedway (Short)",
+          "turns": 14,
+          "length_m": 4526,
+          "elevation_m": 40,
+          "longest_straight_m": 1475,
           "type": "real",
-          "length_m": 3942,
-          "reversible": false,
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Fuji International Speedway (Short)",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Goodwood",
+      "official_track_id": "ee72eb",
+      "country": "GBR",
+      "country_name": "United Kingdom",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "b72701",
+          "official_name": "Goodwood Motor Circuit",
+          "turns": 7,
+          "length_m": 3809,
+          "elevation_m": 10,
+          "longest_straight_m": 514,
+          "type": "real",
           "rain": false,
           "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Goodwood Motor Circuit",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Grand Valley - Highway 1",
+      "official_track_id": "df54ec",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Highway 1",
+          "official_id": "c2fd94",
+          "official_name": "Grand Valley - Highway 1",
+          "turns": 18,
+          "length_m": 5099,
+          "elevation_m": 97,
+          "longest_straight_m": 995,
+          "type": "original",
+          "rain": false,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "Grand Valley Highway 1",
+          "reverse": {
+            "official_id": "19fb71",
+            "turns": 18
+          }
+        },
+        {
+          "name": "South",
+          "official_id": "a8725d",
+          "official_name": "Grand Valley - South",
+          "turns": 10,
+          "length_m": 3076,
+          "elevation_m": 85,
+          "longest_straight_m": 995,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Grand Valley South",
+          "reverse": {
+            "official_id": "b34920",
+            "turns": 10
+          }
+        }
+      ]
+    },
+    {
+      "name": "High Speed Ring",
+      "official_track_id": "9a42fb",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "65e108",
+          "official_name": "High Speed Ring",
+          "turns": 6,
+          "length_m": 4345,
+          "elevation_m": 8.5,
+          "longest_straight_m": 1060,
+          "type": "original",
+          "rain": true,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "High Speed Ring",
+          "reverse": {
+            "official_id": "ede05f",
+            "turns": 6
+          }
+        }
+      ]
+    },
+    {
+      "name": "Kyoto Driving Park",
+      "official_track_id": "16ccbf",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "Yamagiwa + Miyabi",
+          "official_id": "6d5688",
+          "official_name": "Kyoto Driving Park - Yamagiwa+Miyabi",
+          "turns": 19,
+          "length_m": 6846,
+          "elevation_m": 38.6,
+          "longest_straight_m": 743,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Kyoto Driving Park - Yamagiwa + Miyabi",
+          "reverse": {
+            "official_id": "341218",
+            "turns": 19
+          }
+        },
+        {
+          "name": "Yamagiwa",
+          "official_id": "6dfca5",
+          "official_name": "Kyoto Driving Park - Yamagiwa",
+          "turns": 15,
+          "length_m": 4912,
+          "elevation_m": 38.6,
+          "longest_straight_m": 743,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Kyoto Driving Park - Yamagiwa",
+          "reverse": {
+            "official_id": "d83aeb",
+            "turns": 15
+          }
+        },
+        {
+          "name": "Miyabi",
+          "official_id": "53f1ef",
+          "official_name": "Kyoto Driving Park - Miyabi",
           "turns": 7,
+          "length_m": 1953,
+          "elevation_m": 17.5,
+          "longest_straight_m": 442,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Kyoto Driving Park - Miyabi",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Lake Louise",
+      "official_track_id": "2b352d",
+      "country": "CAN",
+      "country_name": "Canada",
+      "layouts": [
+        {
+          "name": "Long Track",
+          "official_id": "40e254",
+          "official_name": "Lake Louise Long Track",
+          "turns": 11,
+          "length_m": 3694,
+          "elevation_m": 78,
+          "longest_straight_m": 765,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Snow",
+          "wiki_page": "Lake Louise Long Track",
+          "reverse": {
+            "official_id": "154e68",
+            "turns": 11
+          }
+        },
+        {
+          "name": "Tri-Oval",
+          "official_id": "97aa3b",
+          "official_name": "Lake Louise Tri-Oval",
+          "turns": 3,
+          "length_m": 3068,
+          "elevation_m": 78,
+          "longest_straight_m": 1184,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Snow",
+          "wiki_page": "Lake Louise Tri-Oval",
+          "reverse": {
+            "official_id": "44b0a2",
+            "turns": 3
+          }
+        },
+        {
+          "name": "Short Track",
+          "official_id": "26e1df",
+          "official_name": "Lake Louise Short Track",
+          "turns": 7,
+          "length_m": 2577,
+          "elevation_m": 63,
+          "longest_straight_m": 1024,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Snow",
+          "wiki_page": "Lake Louise Short Track",
+          "reverse": {
+            "official_id": "96dc0c",
+            "turns": 7
+          }
+        }
+      ]
+    },
+    {
+      "name": "Michelin Raceway Road Atlanta",
+      "official_track_id": "051834",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "da093f",
+          "official_name": "Michelin Raceway Road Atlanta",
+          "turns": 12,
+          "length_m": 4088,
+          "elevation_m": 38,
+          "longest_straight_m": 1275,
+          "type": "real",
+          "rain": false,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Michelin Raceway Road Atlanta",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Mount Panorama Circuit",
+      "official_track_id": "28b64f",
+      "country": "AUS",
+      "country_name": "Australia",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "ec1eb6",
+          "official_name": "Mount Panorama Motor Racing Circuit",
+          "turns": 23,
+          "length_m": 6213,
+          "elevation_m": 174,
+          "longest_straight_m": 1916,
+          "type": "real",
+          "rain": false,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Mount Panorama",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Northern Isle Speedway",
+      "official_track_id": "512b99",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "6e659a",
+          "official_name": "Northern Isle Speedway",
+          "turns": 4,
+          "length_m": 900,
+          "elevation_m": 0,
+          "longest_straight_m": 134,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Northern Isle Speedway",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Nürburgring",
+      "official_track_id": "246f6d",
+      "country": "GER",
+      "country_name": "Germany",
+      "layouts": [
+        {
+          "name": "24h",
+          "official_id": "fd4818",
+          "official_name": "Nürburgring 24h",
+          "turns": 89,
+          "length_m": 25378,
+          "elevation_m": 300,
+          "longest_straight_m": 2135,
+          "type": "real",
+          "rain": true,
+          "sophy": "yes",
+          "roadway": "Tarmac & Concrete",
+          "wiki_page": "Nürburgring 24h",
+          "reverse": null
+        },
+        {
+          "name": "Endurance",
+          "official_id": "31acde",
+          "official_name": "Nürburgring Endurance",
+          "turns": 85,
+          "length_m": 23864,
+          "elevation_m": 300,
+          "longest_straight_m": 2135,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac & Concrete",
+          "wiki_page": "Nürburgring Endurance",
+          "reverse": null
+        },
+        {
+          "name": "Endurance II",
+          "official_id": "592211",
+          "official_name": "Nürburgring Endurance II",
+          "turns": 85,
+          "length_m": 23864,
+          "elevation_m": 300,
+          "longest_straight_m": 2135,
+          "type": null,
+          "rain": null,
+          "sophy": null,
+          "roadway": null,
+          "wiki_page": null,
+          "reverse": null
+        },
+        {
+          "name": "Nordschleife",
+          "official_id": "12ceac",
+          "official_name": "Nürburgring Nordschleife",
+          "turns": 73,
+          "length_m": 20832,
+          "elevation_m": 300,
+          "longest_straight_m": 2135,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac & Concrete",
+          "wiki_page": "Nürburgring Nordschleife",
+          "reverse": null
+        },
+        {
+          "name": "Nordschleife Tourist",
+          "official_id": "8dd16b",
+          "official_name": "Nürburgring Nordschleife Tourist",
+          "turns": 73,
+          "length_m": 20832,
+          "elevation_m": 300,
+          "longest_straight_m": 2135,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac & Concrete",
+          "wiki_page": "Nürburgring Nordschleife",
+          "reverse": null
+        },
+        {
+          "name": "Grand Prix",
+          "official_id": "2066d9",
+          "official_name": "Nürburgring GP",
+          "turns": 17,
+          "length_m": 5148,
+          "elevation_m": 57,
+          "longest_straight_m": 620,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Nürburgring GP/F",
+          "reverse": null
+        },
+        {
+          "name": "Sprint",
+          "official_id": "9ec2c6",
+          "official_name": "Nürburgring Sprint",
+          "turns": 12,
+          "length_m": 3629,
+          "elevation_m": 33,
+          "longest_straight_m": 620,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Nürburgring Sprint",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Red Bull Ring",
+      "official_track_id": "f99788",
+      "country": "AUT",
+      "country_name": "Austria",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "f3f7f9",
+          "official_name": "Red Bull Ring",
+          "turns": 10,
+          "length_m": 4318,
+          "elevation_m": 65.5,
+          "longest_straight_m": 939,
+          "type": "real",
+          "rain": true,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Red Bull Ring",
+          "reverse": null
+        },
+        {
+          "name": "Short Track",
+          "official_id": "c7e77c",
+          "official_name": "Red Bull Ring Short Track",
+          "turns": 6,
+          "length_m": 2336,
+          "elevation_m": 32.4,
+          "longest_straight_m": 939,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Red Bull Ring Short Track",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Sardegna - Road Track",
+      "official_track_id": "748156",
+      "country": "ITA",
+      "country_name": "Italy",
+      "layouts": [
+        {
+          "name": "Layout A",
+          "official_id": "e9eec1",
+          "official_name": "Sardegna - Road Track - A",
+          "turns": 15,
+          "length_m": 5113,
+          "elevation_m": 38,
+          "longest_straight_m": 915,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Sardegna - Road Track - A",
+          "reverse": {
+            "official_id": "630793",
+            "turns": 15
+          }
+        },
+        {
+          "name": "Layout B",
+          "official_id": "394c28",
+          "official_name": "Sardegna - Road Track - B",
+          "turns": 13,
+          "length_m": 3893,
+          "elevation_m": 56,
+          "longest_straight_m": 915,
+          "type": "original",
+          "rain": false,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "Sardegna - Road Track - B",
+          "reverse": {
+            "official_id": "62b62e",
+            "turns": 13
+          }
+        },
+        {
+          "name": "Layout C",
+          "official_id": "3a0fe1",
+          "official_name": "Sardegna - Road Track - C",
+          "turns": 10,
+          "length_m": 2661,
+          "elevation_m": 54,
+          "longest_straight_m": 915,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Sardegna - Road Track - C",
+          "reverse": {
+            "official_id": "c4a6df",
+            "turns": 10
+          }
+        }
+      ]
+    },
+    {
+      "name": "Sardegna - Windmills",
+      "official_track_id": "71bfba",
+      "country": "ITA",
+      "country_name": "Italy",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "89bb71",
+          "official_name": "Sardegna - Windmills",
+          "turns": 14,
+          "length_m": 3310,
+          "elevation_m": 75,
+          "longest_straight_m": 298,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Dirt",
+          "wiki_page": "Sardegna - Windmills",
+          "reverse": {
+            "official_id": "98a1b3",
+            "turns": 14
+          }
+        }
+      ]
+    },
+    {
+      "name": "Special Stage Route X",
+      "official_track_id": "de15df",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "ef3232",
+          "official_name": "Special Stage Route X",
+          "turns": 2,
+          "length_m": 30283,
+          "elevation_m": 65,
+          "longest_straight_m": 12000.0,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Special Stage Route X",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Suzuka Circuit",
+      "official_track_id": "fd167d",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "6e378b",
+          "official_name": "Suzuka Circuit",
+          "turns": 20,
+          "length_m": 5807,
+          "elevation_m": 40,
+          "longest_straight_m": 1200,
+          "type": "real",
+          "rain": true,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Suzuka Circuit",
+          "reverse": null
+        },
+        {
+          "name": "East Course",
+          "official_id": "4414cb",
+          "official_name": "Suzuka Circuit East Course",
+          "turns": 9,
+          "length_m": 2243,
+          "elevation_m": 33.6,
+          "longest_straight_m": 800,
+          "type": "real",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Suzuka Circuit East",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Tokyo Expressway",
+      "official_track_id": "e9dd33",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "East Clockwise",
+          "official_id": "779efe",
+          "official_name": "Tokyo Expressway - East Clockwise",
+          "turns": 13,
+          "length_m": 7301,
+          "elevation_m": 32,
+          "longest_straight_m": 2000.0,
+          "type": "original",
+          "rain": true,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - East Clockwise",
+          "reverse": null
+        },
+        {
+          "name": "East Counterclockwise",
+          "official_id": "fd9a21",
+          "official_name": "Tokyo Expressway - East Counterclockwise",
+          "turns": 13,
+          "length_m": 7192,
+          "elevation_m": 32,
+          "longest_straight_m": 2000.0,
+          "type": "original",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - East Counterclockwise",
+          "reverse": null
+        },
+        {
+          "name": "South Counterclockwise",
+          "official_id": "80ef82",
+          "official_name": "Tokyo Expressway - South Counterclockwise",
+          "turns": 16,
+          "length_m": 6560,
+          "elevation_m": 24,
+          "longest_straight_m": 900,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - South Counterclockwise",
+          "reverse": null
+        },
+        {
+          "name": "South Clockwise",
+          "official_id": "afcb24",
+          "official_name": "Tokyo Expressway - South Clockwise",
+          "turns": 17,
+          "length_m": 5201,
+          "elevation_m": 24,
+          "longest_straight_m": 900,
+          "type": "original",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - South Clockwise",
+          "reverse": null
+        },
+        {
+          "name": "Central Clockwise",
+          "official_id": "5aeb53",
+          "official_name": "Tokyo Expressway - Central Clockwise",
+          "turns": 13,
+          "length_m": 4405,
+          "elevation_m": 8,
+          "longest_straight_m": 600,
+          "type": "original",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - Central Clockwise",
+          "reverse": null
+        },
+        {
+          "name": "Central Counterclockwise",
+          "official_id": "dcdc93",
+          "official_name": "Tokyo Expressway - Central Counterclockwise",
+          "turns": 14,
+          "length_m": 4369,
+          "elevation_m": 16,
+          "longest_straight_m": 600,
+          "type": "original",
+          "rain": true,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Tokyo Expressway - Central Counterclockwise",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Trial Mountain Circuit",
+      "official_track_id": "e60841",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "802508",
+          "official_name": "Trial Mountain Circuit",
+          "turns": 15,
+          "length_m": 5434,
+          "elevation_m": 58,
+          "longest_straight_m": 1340,
+          "type": "original",
+          "rain": false,
+          "sophy": "forwards_only",
+          "roadway": "Tarmac",
+          "wiki_page": "Trial Mountain Circuit",
+          "reverse": {
+            "official_id": "26514b",
+            "turns": 15
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tsukuba Circuit",
+      "official_track_id": "c5de8a",
+      "country": "JPN",
+      "country_name": "Japan",
+      "layouts": [
+        {
+          "name": "Full Course",
+          "official_id": "f18da2",
+          "official_name": "Tsukuba Circuit",
+          "turns": 8,
+          "length_m": 2045,
+          "elevation_m": 5.3,
+          "longest_straight_m": 445,
+          "type": "real",
+          "rain": true,
+          "sophy": "yes",
+          "roadway": "Tarmac",
+          "wiki_page": "Tsukuba Circuit",
+          "reverse": null
+        }
+      ]
+    },
+    {
+      "name": "Watkins Glen International",
+      "official_track_id": "e6ef89",
+      "country": "USA",
+      "country_name": "United States",
+      "layouts": [
+        {
+          "name": "Long Course",
+          "official_id": "60d74b",
+          "official_name": "Watkins Glen Long Course",
+          "turns": 11,
+          "length_m": 5423,
+          "elevation_m": 41.1,
+          "longest_straight_m": 560.5,
+          "type": "real",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Watkins Glen International",
+          "reverse": null
+        },
+        {
+          "name": "Short Course",
+          "official_id": "59f32b",
+          "official_name": "Watkins Glen Short Course",
+          "turns": 7,
+          "length_m": 3942,
           "elevation_m": 10.7,
           "longest_straight_m": 621.8,
-          "roadway": "Tarmac"
+          "type": "real",
+          "rain": false,
+          "sophy": "no",
+          "roadway": "Tarmac",
+          "wiki_page": "Watkins Glen International",
+          "reverse": null
         }
-      ],
-      "country_name": "USA"
+      ]
     },
     {
       "name": "WeatherTech Raceway Laguna Seca",
+      "official_track_id": "c75e61",
       "country": "USA",
+      "country_name": "United States",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "WeatherTech Raceway Laguna Seca",
-          "type": "real",
+          "official_id": "6cdd45",
+          "official_name": "WeatherTech Raceway Laguna Seca",
+          "turns": 11,
           "length_m": 3602,
-          "reversible": false,
+          "elevation_m": 55,
+          "longest_straight_m": 453,
+          "type": "real",
           "rain": false,
           "sophy": "yes",
-          "turns": 11,
-          "elevation_m": null,
-          "longest_straight_m": null,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "WeatherTech Raceway Laguna Seca",
+          "reverse": null
         }
-      ],
-      "country_name": "USA"
+      ]
     },
     {
       "name": "Willow Springs International Raceway",
+      "official_track_id": "fb6d1f",
       "country": "USA",
+      "country_name": "United States",
       "layouts": [
         {
           "name": "Big Willow",
-          "wiki_page": "Willow Springs International Raceway: Big Willow",
-          "type": "real",
+          "official_id": "381321",
+          "official_name": "Willow Springs International Raceway: Big Willow",
+          "turns": 10,
           "length_m": 3951,
-          "reversible": false,
+          "elevation_m": 50,
+          "longest_straight_m": 756,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 9,
-          "elevation_m": 50.0,
-          "longest_straight_m": 756.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Willow Springs International Raceway: Big Willow",
+          "reverse": null
         },
         {
           "name": "Streets of Willow Springs",
-          "wiki_page": "Willow Springs International Raceway: Streets of Willow Springs",
-          "type": "real",
+          "official_id": "1d6a80",
+          "official_name": "Willow Springs International Raceway: Streets of Willow Springs",
+          "turns": 14,
           "length_m": 2675,
-          "reversible": true,
+          "elevation_m": 20,
+          "longest_straight_m": 400,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 14,
-          "elevation_m": 20.0,
-          "longest_straight_m": 400.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Willow Springs International Raceway: Streets of Willow Springs",
+          "reverse": {
+            "official_id": "9caea1",
+            "turns": 14
+          }
         },
         {
           "name": "Horse Thief Mile",
-          "wiki_page": "Willow Springs International Raceway: Horse Thief Mile",
-          "type": "real",
+          "official_id": "38d7ae",
+          "official_name": "Willow Springs International Raceway: Horse Thief Mile",
+          "turns": 11,
           "length_m": 1624,
-          "reversible": true,
+          "elevation_m": 42,
+          "longest_straight_m": 216,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 11,
-          "elevation_m": 42.0,
-          "longest_straight_m": 216.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Willow Springs International Raceway: Horse Thief Mile",
+          "reverse": {
+            "official_id": "bcfdfc",
+            "turns": 11
+          }
         }
-      ],
-      "country_name": "USA"
+      ]
     },
     {
       "name": "Yas Marina Circuit",
+      "official_track_id": "27adb9",
       "country": "UAE",
+      "country_name": "UAE",
       "layouts": [
         {
           "name": "Full Course",
-          "wiki_page": "Yas Marina Circuit",
-          "type": "real",
+          "official_id": "d3bd76",
+          "official_name": "Yas Marina Circuit",
+          "turns": 16,
           "length_m": 5281,
-          "reversible": false,
+          "elevation_m": 11,
+          "longest_straight_m": 1233,
+          "type": "real",
           "rain": false,
           "sophy": "no",
-          "turns": 16,
-          "elevation_m": 11.0,
-          "longest_straight_m": 1233.0,
-          "roadway": "Tarmac"
+          "roadway": "Tarmac",
+          "wiki_page": "Yas Marina Circuit",
+          "reverse": null
         }
-      ],
-      "country_name": "UAE"
+      ]
     }
   ]
 }

--- a/backend/scripts/build_track_metadata.py
+++ b/backend/scripts/build_track_metadata.py
@@ -1,26 +1,32 @@
-"""Regenerate backend/data/tracks.json from the Gran Turismo wiki.
+"""Regenerate backend/data/tracks.json from official GT7 data + the GT wiki.
 
-The wiki's Gran_Turismo_7/Track_List page carries one CourseWithLayouts
-template per track and one CourseLayout template per layout — name, country,
-real/original, per-layout length, reversible/rain/Sophy flags. Each layout's
-own page adds an Infobox/Track with turns, elevation and longest straight.
-Both are parsed from wikitext via the MediaWiki API: the templates are
-structured data, so no HTML scraping and no guesswork.
+Primary source is the official tracklist's own data bundle — the JS asset the
+page at gran-turismo.com/gb/gt7/tracklist/ renders from. It carries what no
+wiki can: Polyphony's per-configuration ids (config `id`, track `baseId`),
+official corner counts, and — in metric locales — exact integer metres for
+length, elevation gap and longest straight. Two locales are fetched and joined
+by id: `gb` for English names, `de` for the metric values. The asset URLs are
+hash-stamped per build, so they are discovered from the page each run
+(HTML -> index chunk -> tracks.<locale>-<hash>.js).
+
+The wiki's Gran_Turismo_7/Track_List then enriches each layout with the facts
+the official data lacks: real/original, rain, GT Sophy support, reversibility,
+roadway, and the wiki page link. Wiki layouts are matched to official configs
+by track name (a small alias table), then length + fuzzy layout name.
 
 Run it again when a GT7 update adds tracks:
 
     python scripts/build_track_metadata.py
 
-Pages are cached in the system temp dir for the run, and the wiki is fetched
-politely (one request every 250 ms, ~85 pages). The list's per-layout length
-is authoritative; a layout whose wiki page measures a different variant (some
-layouts share a page) is flagged page_describes_layout=false rather than
-inheriting the wrong numbers silently.
+Validation is printed at the end; a wiki layout that stops matching or an
+official config with no wiki data (e.g. Nürburgring Endurance II, which the
+wiki list omits) is reported rather than silently dropped.
 """
 
 from __future__ import annotations
 
 import datetime
+import difflib
 import json
 import re
 import tempfile
@@ -30,21 +36,81 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
-API = "https://gran-turismo.fandom.com/api.php"
+OFFICIAL_PAGE = "https://www.gran-turismo.com/gb/gt7/tracklist/"
+OFFICIAL_ASSETS = "https://www.gran-turismo.com/common/dist/gt7/tracklist/assets/"
+WIKI_API = "https://gran-turismo.fandom.com/api.php"
+WIKI_LIST_PAGE = "Gran Turismo 7/Track List"
 UA = {"User-Agent": "gt7-datalogger track metadata builder"}
-LIST_PAGE = "Gran Turismo 7/Track List"
 OUT = Path(__file__).resolve().parents[1] / "data" / "tracks.json"
 
-# The track list links some layouts to a hub page (Infobox/Location) instead
-# of the layout's own page; point them at the page that has the infobox.
-PAGE_OVERRIDES = {
-    ("Watkins Glen International", "Long Course"): "Watkins Glen Long Course",
-    ("Watkins Glen International", "Short Course"): "Watkins Glen Short Course",
+# Official nameBase -> wiki course name, where they differ.
+WIKI_TRACK_ALIASES = {
+    "Autopolis": "Autopolis International Racing Course",
+    "Goodwood": "Goodwood Motor Circuit",
+    "Grand Valley - Highway 1": "Grand Valley",
+    "Michelin Raceway Road Atlanta": "Michelin Raceway Road Atlanta",
 }
 
-CONVERT = re.compile(r"\{\{Convert-lua\|([\d.,]+)\|m\|")
-FLAG = re.compile(r"\{\{Flag\|([^}|]+)")
 
+def http_get(url: str) -> str:
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return str(resp.read().decode("utf-8"))
+
+
+# ---------------------------------------------------------------- official ---
+
+def discover_locale_assets(page_html: str) -> dict[str, str]:
+    """Page HTML -> index chunk -> {locale: tracks asset filename}."""
+    index = re.search(r"assets/(index-[A-Za-z0-9_-]+\.js)", page_html)
+    if not index:
+        raise RuntimeError("could not find the tracklist index chunk in the page")
+    chunk = http_get(OFFICIAL_ASSETS + index.group(1))
+    return {
+        m.group(1): m.group(0)
+        for m in re.finditer(r"tracks\.([a-z]+)-[A-Za-z0-9_-]+\.js", chunk)
+    }
+
+
+def parse_official_js(src: str) -> dict[str, dict[str, Any]]:
+    """The asset is `const e={...};export{e as Tracks};` — quote the keys and
+    fix bare decimals, then it is JSON."""
+    body = src[src.index("{"): src.rindex(";export")]
+    body = re.sub(r"([{,])([A-Za-z_][A-Za-z0-9_]*|\d+):", r'\1"\2":', body)
+    body = re.sub(r":\s*\.(\d)", r":0.\1", body)
+    parsed: dict[str, dict[str, Any]] = json.loads(body)
+    return parsed
+
+
+def fetch_official() -> list[dict[str, Any]]:
+    """Join gb (English names) and de (exact metres) locales by config id."""
+    assets = discover_locale_assets(http_get(OFFICIAL_PAGE))
+    for locale in ("gb", "de"):
+        if locale not in assets:
+            raise RuntimeError(f"tracklist assets missing locale {locale!r}: {assets}")
+    en = parse_official_js(http_get(OFFICIAL_ASSETS + assets["gb"]))
+    metric = parse_official_js(http_get(OFFICIAL_ASSETS + assets["de"]))
+    configs = []
+    for cid, e in en.items():
+        m = metric[cid]
+        configs.append(
+            {
+                "id": e["id"],
+                "track_id": e["baseId"],
+                "name_base": e["nameBase"].strip(),
+                "name_long": e["nameLong"].strip(),
+                "country_name": e["countryName"],
+                "turns": e["cornerCount"],
+                "length_m": m["length_v"],
+                "elevation_m": m["elevationGap_v"],
+                "longest_straight_m": m["straight_v"],
+                "reverse": e["nameLong"].strip().endswith("Reverse"),
+            }
+        )
+    return configs
+
+
+# -------------------------------------------------------------------- wiki ---
 
 def fetch_wikitext(page: str, cache: Path) -> str:
     cached = cache / (re.sub(r"[^A-Za-z0-9]+", "_", page) + ".json")
@@ -60,9 +126,7 @@ def fetch_wikitext(page: str, cache: Path) -> str:
                 "redirects": "1",
             }
         )
-        req = urllib.request.Request(f"{API}?{query}", headers=UA)
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            data = json.load(resp)
+        data = json.loads(http_get(f"{WIKI_API}?{query}"))
         cached.write_text(json.dumps(data))
         time.sleep(0.25)
     if "error" in data:
@@ -79,20 +143,22 @@ def parse_params(chunk: str) -> dict[str, str]:
     return params
 
 
-def parse_track_list(wikitext: str) -> list[dict[str, Any]]:
-    tracks: list[dict[str, Any]] = []
+def parse_wiki_list(wikitext: str) -> list[dict[str, Any]]:
+    """One record per wiki layout: flags the official data does not carry."""
+    layouts: list[dict[str, Any]] = []
     for block in wikitext.split("{{CourseWithLayouts")[1:]:
         header = parse_params(block.split("|layouts=")[0])
-        layouts: list[dict[str, Any]] = []
         for chunk in re.findall(r"\{\{CourseLayout\|(.*?)\}\}", block, re.S):
             p = parse_params(chunk)
             length = p.get("length", "").replace(",", "")
             layouts.append(
                 {
+                    "track": header.get("name", ""),
+                    "country": header.get("country") or None,
                     "name": p.get("name", ""),
                     "wiki_page": p.get("link") or header.get("link") or header.get("name", ""),
-                    "type": "real" if p.get("type", "").lower() == "real" else "original",
                     "length_m": int(length) if length.isdigit() else None,
+                    "type": "real" if p.get("type", "").lower() == "real" else "original",
                     "reversible": p.get("reversible", "").lower() in ("y", "yes"),
                     "rain": p.get("rain", "").lower() == "yes",
                     "sophy": {
@@ -102,101 +168,154 @@ def parse_track_list(wikitext: str) -> list[dict[str, Any]]:
                     }.get(p.get("sophy", "").lower(), "no"),
                 }
             )
-        tracks.append(
-            {
-                "name": header.get("name", ""),
-                "country": header.get("country") or None,
-                "layouts": layouts,
-            }
-        )
-    return tracks
+    return layouts
 
 
-def infobox_field(box: str, field: str) -> str | None:
-    m = re.search(rf"^\|{field}\s*=\s*(.+?)\s*$", box, re.M)
+def infobox_roadway(wikitext: str) -> str | None:
+    m = re.search(r"^\|roadway\s*=\s*(.+?)\s*$", wikitext, re.M)
     return m.group(1).strip() if m else None
 
 
-def metres(raw: str | None) -> float | None:
-    if not raw:
-        return None
-    m = CONVERT.search(raw)
-    return float(m.group(1).replace(",", "")) if m else None
+# ------------------------------------------------------------------- merge ---
+
+FILLER = re.compile(r"\b(layout|course|circuit|full|the)\b|[^a-z0-9]")
 
 
-def parse_infobox(wikitext: str) -> dict[str, Any]:
-    if "{{Infobox/Track" not in wikitext:
-        return {}
-    box = wikitext.split("{{Infobox/Track", 1)[1]
-    turns = re.search(r"\d+", infobox_field(box, "turns") or "")
-    flag = FLAG.search(infobox_field(box, "country") or "")
-    return {
-        "turns": int(turns.group()) if turns else None,
-        "elevation_m": metres(infobox_field(box, "elevation")),
-        "longest_straight_m": metres(infobox_field(box, "straight")),
-        "length_m_infobox": metres(infobox_field(box, "length")),
-        "roadway": infobox_field(box, "roadway") or None,
-        "country_name": flag.group(1).strip() if flag else None,
-    }
+def norm_layout(name: str, track: str) -> str:
+    """Comparable form of a layout name: drop the track name, filler words and
+    punctuation, and normalise the synonyms the two sources disagree on."""
+    n = name.lower()
+    for word in re.findall(r"[a-z0-9]+", track.lower()):
+        n = n.replace(word, " ", 1)
+    n = n.replace("grand prix", " gp ").replace("shortcut", " short ")
+    n = FILLER.sub(" ", n)
+    return "".join(n.split())
+
+
+def match_wiki(
+    config: dict[str, Any], candidates: list[dict[str, Any]]
+) -> dict[str, Any] | None:
+    """Best wiki layout for an official forward config: length within 60 m,
+    ties broken by layout-name similarity."""
+    best, best_score = None, -1.0
+    target = norm_layout(config["name_long"], config["name_base"]) or "fullcourse"
+    for w in candidates:
+        if w["length_m"] is None or abs(w["length_m"] - config["length_m"]) > 60:
+            continue
+        name = norm_layout(w["name"], "") or "fullcourse"
+        score = difflib.SequenceMatcher(None, target, name).ratio()
+        if score > best_score:
+            best, best_score = w, score
+    return best
 
 
 def main() -> None:
     cache = Path(tempfile.gettempdir()) / "gt7-track-wiki-cache"
     cache.mkdir(exist_ok=True)
 
-    tracks = parse_track_list(fetch_wikitext(LIST_PAGE, cache))
-    for track in tracks:
-        for layout in track["layouts"]:
-            layout["wiki_page"] = PAGE_OVERRIDES.get(
-                (track["name"], layout["name"]), layout["wiki_page"]
+    configs = fetch_official()
+    forward = [c for c in configs if not c["reverse"]]
+    reverse = [c for c in configs if c["reverse"]]
+    print(f"official: {len(configs)} configs = {len(forward)} forward + {len(reverse)} reverse")
+
+    wiki = parse_wiki_list(fetch_wikitext(WIKI_LIST_PAGE, cache))
+    print(f"wiki: {len(wiki)} layouts")
+
+    roadway_cache: dict[str, str | None] = {}
+
+    # Group official configs into tracks by Polyphony's track id.
+    by_track: dict[str, list[dict[str, Any]]] = {}
+    for c in configs:
+        by_track.setdefault(c["track_id"], []).append(c)
+
+    tracks: list[dict[str, Any]] = []
+    unmatched_official: list[str] = []
+    claimed: set[int] = set()
+    for track_id, group in sorted(by_track.items(), key=lambda kv: kv[1][0]["name_base"]):
+        base = group[0]["name_base"]
+        wiki_track = WIKI_TRACK_ALIASES.get(base, base)
+        wiki_layouts = [w for w in wiki if w["track"] == wiki_track]
+
+        layouts: list[dict[str, Any]] = []
+        for c in sorted((g for g in group if not g["reverse"]), key=lambda g: -g["length_m"]):
+            # Reverse partner: same track, closest length (names abbreviate,
+            # e.g. "BB Raceway Reverse", so length is the reliable key).
+            partner = min(
+                (r for r in group if r["reverse"]),
+                key=lambda r: abs(r["length_m"] - c["length_m"]),
+                default=None,
             )
+            if partner is not None and abs(partner["length_m"] - c["length_m"]) > 60:
+                partner = None
+            w = match_wiki(c, [x for x in wiki_layouts if id(x) not in claimed])
+            if w is None:
+                unmatched_official.append(c["name_long"])
+            else:
+                claimed.add(id(w))
+            if w and w["wiki_page"] not in roadway_cache:
+                roadway_cache[w["wiki_page"]] = infobox_roadway(
+                    fetch_wikitext(w["wiki_page"], cache)
+                )
+            short = c["name_long"].removeprefix(c["name_base"]).strip(" -–:")
+            layouts.append(
+                {
+                    "name": w["name"] if w else (short or "Full Course"),
+                    "official_id": c["id"],
+                    "official_name": c["name_long"],
+                    "turns": c["turns"],
+                    "length_m": c["length_m"],
+                    "elevation_m": c["elevation_m"],
+                    "longest_straight_m": c["longest_straight_m"],
+                    "type": w["type"] if w else None,
+                    "rain": w["rain"] if w else None,
+                    "sophy": w["sophy"] if w else None,
+                    "roadway": roadway_cache.get(w["wiki_page"]) if w else None,
+                    "wiki_page": w["wiki_page"] if w else None,
+                    "reverse": (
+                        {"official_id": partner["id"], "turns": partner["turns"]}
+                        if partner
+                        else None
+                    ),
+                }
+            )
+        tracks.append(
+            {
+                "name": base,
+                "official_track_id": track_id,
+                "country": next(
+                    (w["country"] for w in wiki_layouts if w["country"]), None
+                ),
+                "country_name": group[0]["country_name"],
+                "layouts": layouts,
+            }
+        )
 
-    pages = sorted(
-        {la["wiki_page"] for t in tracks for la in t["layouts"] if la["wiki_page"]}
-    )
-    total = sum(len(t["layouts"]) for t in tracks)
-    print(f"{len(tracks)} tracks, {total} layouts, {len(pages)} wiki pages to fetch")
-
-    boxes = {}
-    for i, page in enumerate(pages, 1):
-        boxes[page] = parse_infobox(fetch_wikitext(page, cache))
-        print(f"[{i}/{len(pages)}] {page}: turns={boxes[page].get('turns')}")
-
-    for track in tracks:
-        for layout in track["layouts"]:
-            box = boxes.get(layout["wiki_page"], {})
-            layout["turns"] = box.get("turns")
-            layout["elevation_m"] = box.get("elevation_m")
-            layout["longest_straight_m"] = box.get("longest_straight_m")
-            layout["roadway"] = box.get("roadway")
-            box_len = box.get("length_m_infobox")
-            if box_len and layout["length_m"] and abs(box_len - layout["length_m"]) > 5:
-                layout["page_describes_layout"] = False
-            track.setdefault("country_name", box.get("country_name"))
-
-    reversible = sum(1 for t in tracks for la in t["layouts"] if la["reversible"])
-    missing_turns = sum(1 for t in tracks for la in t["layouts"] if not la["turns"])
+    orphan_wiki = [
+        f"{w['track']} / {w['name']}" for w in wiki if id(w) not in claimed
+    ]
+    total_layouts = sum(len(t["layouts"]) for t in tracks)
+    with_reverse = sum(1 for t in tracks for la in t["layouts"] if la["reverse"])
     print(
-        f"tracks={len(tracks)} layouts={total} reversible={reversible} "
-        f"configs={total + reversible} layouts-missing-turns={missing_turns}"
+        f"merged: tracks={len(tracks)} layouts={total_layouts} "
+        f"with-reverse={with_reverse} configs={total_layouts + with_reverse}"
     )
+    print(f"official configs without wiki enrichment: {unmatched_official or 'none'}")
+    print(f"wiki layouts not matched to official: {orphan_wiki or 'none'}")
 
     out = {
         "meta": {
             "generated": datetime.date.today().isoformat(),
-            "source": (
-                "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List "
-                "(CC BY-SA; upstream: https://www.gran-turismo.com/gb/gt7/tracklist/)"
-            ),
+            "sources": {
+                "official": OFFICIAL_PAGE
+                + " (per-config ids, names, corner counts; exact metres from the "
+                "metric locale of the same data)",
+                "wiki": "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List"
+                " (CC BY-SA: real/original, rain, GT Sophy, reversibility, roadway,"
+                " page links)",
+            },
             "tracks": len(tracks),
-            "layouts": total,
-            "configurations_including_reverse": total + reversible,
-            "note": (
-                "Per-layout template data is authoritative; the list page's prose "
-                "may state a different configuration total. page_describes_layout="
-                "false flags layouts whose wiki page infobox measures a different "
-                "variant; their length_m (from the list) is still per-layout."
-            ),
+            "layouts": total_layouts,
+            "configurations_including_reverse": total_layouts + with_reverse,
         },
         "tracks": tracks,
     }

--- a/backend/scripts/build_track_metadata.py
+++ b/backend/scripts/build_track_metadata.py
@@ -1,0 +1,208 @@
+"""Regenerate backend/data/tracks.json from the Gran Turismo wiki.
+
+The wiki's Gran_Turismo_7/Track_List page carries one CourseWithLayouts
+template per track and one CourseLayout template per layout — name, country,
+real/original, per-layout length, reversible/rain/Sophy flags. Each layout's
+own page adds an Infobox/Track with turns, elevation and longest straight.
+Both are parsed from wikitext via the MediaWiki API: the templates are
+structured data, so no HTML scraping and no guesswork.
+
+Run it again when a GT7 update adds tracks:
+
+    python scripts/build_track_metadata.py
+
+Pages are cached in the system temp dir for the run, and the wiki is fetched
+politely (one request every 250 ms, ~85 pages). The list's per-layout length
+is authoritative; a layout whose wiki page measures a different variant (some
+layouts share a page) is flagged page_describes_layout=false rather than
+inheriting the wrong numbers silently.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+API = "https://gran-turismo.fandom.com/api.php"
+UA = {"User-Agent": "gt7-datalogger track metadata builder"}
+LIST_PAGE = "Gran Turismo 7/Track List"
+OUT = Path(__file__).resolve().parents[1] / "data" / "tracks.json"
+
+# The track list links some layouts to a hub page (Infobox/Location) instead
+# of the layout's own page; point them at the page that has the infobox.
+PAGE_OVERRIDES = {
+    ("Watkins Glen International", "Long Course"): "Watkins Glen Long Course",
+    ("Watkins Glen International", "Short Course"): "Watkins Glen Short Course",
+}
+
+CONVERT = re.compile(r"\{\{Convert-lua\|([\d.,]+)\|m\|")
+FLAG = re.compile(r"\{\{Flag\|([^}|]+)")
+
+
+def fetch_wikitext(page: str, cache: Path) -> str:
+    cached = cache / (re.sub(r"[^A-Za-z0-9]+", "_", page) + ".json")
+    if cached.exists():
+        data = json.loads(cached.read_text())
+    else:
+        query = urllib.parse.urlencode(
+            {
+                "action": "parse",
+                "page": page,
+                "format": "json",
+                "prop": "wikitext",
+                "redirects": "1",
+            }
+        )
+        req = urllib.request.Request(f"{API}?{query}", headers=UA)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+        cached.write_text(json.dumps(data))
+        time.sleep(0.25)
+    if "error" in data:
+        return ""
+    return str(data["parse"]["wikitext"]["*"])
+
+
+def parse_params(chunk: str) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for part in chunk.split("|"):
+        if "=" in part:
+            key, _, value = part.partition("=")
+            params[key.strip()] = value.strip().rstrip("}").strip()
+    return params
+
+
+def parse_track_list(wikitext: str) -> list[dict[str, Any]]:
+    tracks: list[dict[str, Any]] = []
+    for block in wikitext.split("{{CourseWithLayouts")[1:]:
+        header = parse_params(block.split("|layouts=")[0])
+        layouts: list[dict[str, Any]] = []
+        for chunk in re.findall(r"\{\{CourseLayout\|(.*?)\}\}", block, re.S):
+            p = parse_params(chunk)
+            length = p.get("length", "").replace(",", "")
+            layouts.append(
+                {
+                    "name": p.get("name", ""),
+                    "wiki_page": p.get("link") or header.get("link") or header.get("name", ""),
+                    "type": "real" if p.get("type", "").lower() == "real" else "original",
+                    "length_m": int(length) if length.isdigit() else None,
+                    "reversible": p.get("reversible", "").lower() in ("y", "yes"),
+                    "rain": p.get("rain", "").lower() == "yes",
+                    "sophy": {
+                        "yes": "yes",
+                        "no": "no",
+                        "forwards only": "forwards_only",
+                    }.get(p.get("sophy", "").lower(), "no"),
+                }
+            )
+        tracks.append(
+            {
+                "name": header.get("name", ""),
+                "country": header.get("country") or None,
+                "layouts": layouts,
+            }
+        )
+    return tracks
+
+
+def infobox_field(box: str, field: str) -> str | None:
+    m = re.search(rf"^\|{field}\s*=\s*(.+?)\s*$", box, re.M)
+    return m.group(1).strip() if m else None
+
+
+def metres(raw: str | None) -> float | None:
+    if not raw:
+        return None
+    m = CONVERT.search(raw)
+    return float(m.group(1).replace(",", "")) if m else None
+
+
+def parse_infobox(wikitext: str) -> dict[str, Any]:
+    if "{{Infobox/Track" not in wikitext:
+        return {}
+    box = wikitext.split("{{Infobox/Track", 1)[1]
+    turns = re.search(r"\d+", infobox_field(box, "turns") or "")
+    flag = FLAG.search(infobox_field(box, "country") or "")
+    return {
+        "turns": int(turns.group()) if turns else None,
+        "elevation_m": metres(infobox_field(box, "elevation")),
+        "longest_straight_m": metres(infobox_field(box, "straight")),
+        "length_m_infobox": metres(infobox_field(box, "length")),
+        "roadway": infobox_field(box, "roadway") or None,
+        "country_name": flag.group(1).strip() if flag else None,
+    }
+
+
+def main() -> None:
+    cache = Path(tempfile.gettempdir()) / "gt7-track-wiki-cache"
+    cache.mkdir(exist_ok=True)
+
+    tracks = parse_track_list(fetch_wikitext(LIST_PAGE, cache))
+    for track in tracks:
+        for layout in track["layouts"]:
+            layout["wiki_page"] = PAGE_OVERRIDES.get(
+                (track["name"], layout["name"]), layout["wiki_page"]
+            )
+
+    pages = sorted(
+        {la["wiki_page"] for t in tracks for la in t["layouts"] if la["wiki_page"]}
+    )
+    total = sum(len(t["layouts"]) for t in tracks)
+    print(f"{len(tracks)} tracks, {total} layouts, {len(pages)} wiki pages to fetch")
+
+    boxes = {}
+    for i, page in enumerate(pages, 1):
+        boxes[page] = parse_infobox(fetch_wikitext(page, cache))
+        print(f"[{i}/{len(pages)}] {page}: turns={boxes[page].get('turns')}")
+
+    for track in tracks:
+        for layout in track["layouts"]:
+            box = boxes.get(layout["wiki_page"], {})
+            layout["turns"] = box.get("turns")
+            layout["elevation_m"] = box.get("elevation_m")
+            layout["longest_straight_m"] = box.get("longest_straight_m")
+            layout["roadway"] = box.get("roadway")
+            box_len = box.get("length_m_infobox")
+            if box_len and layout["length_m"] and abs(box_len - layout["length_m"]) > 5:
+                layout["page_describes_layout"] = False
+            track.setdefault("country_name", box.get("country_name"))
+
+    reversible = sum(1 for t in tracks for la in t["layouts"] if la["reversible"])
+    missing_turns = sum(1 for t in tracks for la in t["layouts"] if not la["turns"])
+    print(
+        f"tracks={len(tracks)} layouts={total} reversible={reversible} "
+        f"configs={total + reversible} layouts-missing-turns={missing_turns}"
+    )
+
+    out = {
+        "meta": {
+            "generated": datetime.date.today().isoformat(),
+            "source": (
+                "https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List "
+                "(CC BY-SA; upstream: https://www.gran-turismo.com/gb/gt7/tracklist/)"
+            ),
+            "tracks": len(tracks),
+            "layouts": total,
+            "configurations_including_reverse": total + reversible,
+            "note": (
+                "Per-layout template data is authoritative; the list page's prose "
+                "may state a different configuration total. page_describes_layout="
+                "false flags layouts whose wiki page infobox measures a different "
+                "variant; their length_m (from the list) is still per-layout."
+            ),
+        },
+        "tracks": tracks,
+    }
+    OUT.write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n")
+    print(f"wrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Seed metadata for track bundles and auto-identification (#35, supports #17).

## What

- **`backend/data/tracks.json`** — every GT7 track from Polyphony's own data: **41 tracks, 85 layouts, 121 configurations including reverse**. Per layout: official config id + track id, name, turns (official corner counts), exact length/elevation/longest-straight in metres, real/original, roadway, reversible/rain/GT Sophy flags, wiki link, and the reverse configuration's id + turns where one exists.
- **`backend/scripts/build_track_metadata.py`** — regenerates the file. Passes ruff + strict mypy.

## Sources

**Primary: the official tracklist's own data bundle** — the JS asset `gran-turismo.com/gb/gt7/tracklist/` renders from, discovered from the page each run (HTML → index chunk → `tracks.<locale>-<hash>.js`, so hash changes don't break it). Two locales joined by config id: `gb` for English names, `de` for exact integer metres.

**Enrichment: the [GT wiki track list](https://gran-turismo.fandom.com/wiki/Gran_Turismo_7/Track_List)** (CC BY-SA) for what official data lacks: real vs original, rain, GT Sophy support, reversibility, roadway, page links. Matched per layout by a small track-alias table + length + name similarity; the builder reports anything unmatched on either side.

## What the official data settled

- **121 configurations** (85 forward + 36 reverse) — the wiki prose's "120" was stale.
- **Nürburgring Endurance II** exists officially but is absent from the wiki list — included, flagged as official-only.
- **Spa is 7,004 m** (wiki list said 7,044) and **Sarthe No Chicane has 32 corners** (wiki's shared page said 38) — 9 such corner-count corrections in total.
- Official metric lengths otherwise match the wiki's exactly (e.g. Sarthe 13,629 / 13,567 m) — good cross-validation of both sources.

## Why now

#35's track bundles want name/location/turn metadata keyed to stable ids, and auto-identification can attach official names + layout disambiguation (length is a strong discriminator) before any surveying exists. Nothing consumes the file yet — deliberately just the dataset + reproducible builder.