### PR TITLE
Surface survey system: per-tick surface persistence + live track mapping (#17, #37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ frontend/dist/
 data/*.db
 data/*.db-journal
 data/*.sqlite*
+data/surface_survey_*.jsonl
+data/track-bundles/
 
 # Docs
 site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Notable changes to GT7 Datalogger. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **Per-tick surface data is now recorded** (packet C): each lap stores a
+  packed per-wheel `surface` sample column. Every lap gets an honest
+  track-limits verdict — an off-track excursion count (3+ wheels on
+  grass/gravel/dirt for ≥ 0.1 s) and a `clean_lap` flag, shown as an
+  **Off-track** column in the Sessions lap table. The Analysis race-line map
+  shades where wheels touched kerbs (yellow) or left the road (orange).
+  Laps recorded before this release, or without packet format C, show "–"
+  (unknown) rather than pretending to be clean. (#17)
+- **Survey view** (new tab): validates GT7's `surface_types` encoding and the
+  wheel-contact derivation on a real PS5, from any browser on the LAN while
+  driving. Capture runs server-side in the 60 Hz packet path (the ~30 Hz live
+  stream would miss single-tick transitions); the view shows the live
+  per-wheel surface, the char histogram with a loud banner for unknown chars,
+  and every transition's derived contact points on a scatter map. The full
+  transition log (raw rotation floats included) is downloadable as JSONL,
+  feeding the findings note at `docs/internals/surface-survey.md`. Runs are
+  tied to the live session — lap recording continues alongside — and labeled
+  with the circuit being surveyed (picked from the official GT7 track
+  catalog, or auto-identified — even mid-run, when the label is appended to
+  the log as a `track` line). The JSONL meta header carries the label and
+  width assumption; every record carries the session id and lap.
+  The survey map draws the track taking shape lap by lap: border evidence
+  accumulates server-side for the whole run (left/right perimeters draw
+  themselves as edge ticks, the road fills in wherever opposite borders
+  face each other), driving with one side's wheels held off the track
+  traces that border continuously (straddle sampling — not just at the
+  crossing moments), manual marking buttons trace boundaries surface data
+  cannot see (walls, paved run-off limits) from the driven wheel line, a
+  raw-packet inspector shows every decoded field live with changes
+  highlighted, a completeness card grades each perimeter against the driven
+  loop (percent, largest gap, closed ✓) and locates the finish line from
+  lap rollovers, per-circuit **track bundles** persist everything across
+  runs and app restarts (grid-deduped so they converge; resumed
+  automatically, downloadable via `/api/track-bundles`), and the
+  track-width assumption calibrates
+  itself: riding all four wheels over an edge and back measures the real
+  axle width, which replaces the assumption once three rides agree. Live
+  frames now carry the packed `surface` value. (#37)
+
 ## [0.4.1] - 2026-08-07
 
 ### Fixed

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import csv
 import io
+import json
 import math
+import re
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Any
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse
@@ -126,6 +130,7 @@ CSV_CHANNELS = (
     ("sus_rl", "Susp Travel RL", "mm"),
     ("sus_rr", "Susp Travel RR", "mm"),
     ("aids", "Driver Aids", ""),
+    ("surface", "Surface Mask", ""),
 )
 
 
@@ -212,6 +217,26 @@ async def create_track(request: Request, payload: TrackPayload) -> dict[str, Any
 async def delete_track(request: Request, track_id: int) -> dict[str, str]:
     await svc(request).repo.delete_track(track_id)
     return {"status": "deleted"}
+
+
+@lru_cache(maxsize=1)
+def _load_track_catalog(path: str) -> dict[str, Any]:
+    # The bundled file only changes with a release; cache the parse.
+    data: dict[str, Any] = json.loads(Path(path).read_text(encoding="utf-8"))
+    return data
+
+
+@router.get("/track-catalog")
+async def track_catalog(request: Request) -> dict[str, Any]:
+    """Official GT7 track/layout metadata (bundled data/tracks.json)."""
+    path = svc(request).settings.tracks_json
+    if not path.exists():
+        # The default is relative to backend/; dev servers often run from the
+        # repo root (cars.csv papers over this with GT7_CARS_CSV in .env).
+        path = Path(__file__).resolve().parents[2] / "data" / "tracks.json"
+    if not path.exists():
+        raise HTTPException(404, "track catalog not bundled")
+    return _load_track_catalog(str(path))
 
 
 class ImportPayload(BaseModel):
@@ -399,6 +424,153 @@ async def fuel(request: Request, lap_id: int) -> dict[str, Any]:
         "base_fuel_per_lap": lap["fuel_consumed"],
         "rows": [asdict(r) for r in rows],
     }
+
+
+# --- surface survey (issue #37) ----------------------------------------------
+
+
+class SurveyStartPayload(BaseModel):
+    # Track width isn't broadcast by GT7; the survey applies this assumption
+    # to derive wheel-contact points and measures how far off it lands.
+    track_width_m: float = Field(1.6, gt=0.5, lt=3.0)
+    # Which circuit the samples describe (the per-track grid needs this).
+    # Empty = use the current session's identified track.
+    track: str = Field("", max_length=80)
+
+
+@router.post("/survey/start", dependencies=[Depends(require_admin)])
+async def survey_start(request: Request, payload: SurveyStartPayload) -> dict[str, Any]:
+    service = svc(request)
+    if service.survey.active:
+        # start() would silently keep the old run's width/track otherwise —
+        # a 200 that reflects none of the payload is worse than an error.
+        raise HTTPException(409, "survey already running — stop it first")
+    user_track = payload.track.strip()
+    service.survey.start(
+        service.settings.db_path.parent,
+        payload.track_width_m,
+        track=user_track or service.track_name,
+        track_user_set=bool(user_track),
+        session_id=service.session_id,
+    )
+    return service.survey.status()
+
+
+@router.post("/survey/stop", dependencies=[Depends(require_admin)])
+async def survey_stop(request: Request) -> dict[str, Any]:
+    svc(request).survey.stop()
+    return svc(request).survey.status()
+
+
+@router.get("/survey/status")
+async def survey_status(request: Request) -> dict[str, Any]:
+    return svc(request).survey.status()
+
+
+@router.get("/survey/trail")
+async def survey_trail(
+    request: Request,
+    since: int = Query(0, ge=0, description="index of the first point to return"),
+    epoch: int = Query(-1, description="client's trail epoch; mismatch returns all"),
+) -> dict[str, Any]:
+    """Breadcrumb of the path driven, fetched incrementally.
+
+    The trail is decimated 2:1 when it grows past its cap, which invalidates
+    client point indices — the epoch bumps when that happens and the full
+    trail is returned again.
+    """
+    survey = svc(request).survey
+    if epoch != survey.trail_epoch or since > len(survey.trail):
+        since = 0
+    return {
+        "epoch": survey.trail_epoch,
+        "since": since,
+        "points": survey.trail[since:],
+        "total": len(survey.trail),
+    }
+
+
+@router.get("/survey/edges")
+async def survey_edges(
+    request: Request,
+    since: int = Query(0, ge=0, description="index of the first edge point to return"),
+    epoch: int = Query(-1, description="client's edges epoch; mismatch returns all"),
+) -> dict[str, Any]:
+    """Border-edge points of the whole run — the track taking shape.
+
+    Append-only within a run (the epoch bumps when a new run starts), so
+    incremental fetches are just index slices.
+    """
+    survey = svc(request).survey
+    if epoch != survey.edges_epoch or since > len(survey.edges):
+        since = 0
+    return {
+        "epoch": survey.edges_epoch,
+        "since": since,
+        "points": survey.edges[since:],
+        "total": len(survey.edges),
+    }
+
+
+class SurveyMarkPayload(BaseModel):
+    # side None disarms marking; kind says what boundary is being traced.
+    side: Literal["L", "R"] | None = None
+    kind: Literal["edge", "runoff", "wall"] = "edge"
+
+
+@router.post("/survey/mark", dependencies=[Depends(require_admin)])
+async def survey_mark(request: Request, payload: SurveyMarkPayload) -> dict[str, Any]:
+    """Arm manual boundary marking: trace walls/run-off limits by driving them."""
+    survey = svc(request).survey
+    if not survey.active:
+        raise HTTPException(409, "no survey running")
+    survey.set_mark(payload.side, payload.kind)
+    return survey.status()
+
+
+@router.get("/survey/packet")
+async def survey_packet(request: Request) -> dict[str, Any]:
+    """The latest raw telemetry packet, fully decoded — for eyeballing fields."""
+    packet = svc(request).latest_packet
+    return {"packet": packet.to_dict() if packet is not None else None}
+
+
+@router.get("/survey/export.jsonl")
+async def survey_export(request: Request) -> PlainTextResponse:
+    """Full transition log of the current (or last) survey run."""
+    path = svc(request).survey.log_path
+    if path is None or not path.exists():
+        raise HTTPException(404, "no survey has run yet")
+    return PlainTextResponse(
+        path.read_text(encoding="ascii"),
+        media_type="application/jsonl",
+        headers={"Content-Disposition": f'attachment; filename="{path.name}"'},
+    )
+
+
+# --- track bundles (persistent survey knowledge per circuit) ------------------
+
+
+@router.get("/track-bundles")
+async def track_bundles(request: Request) -> list[dict[str, Any]]:
+    """Every circuit's accumulated survey bundle (perimeters, finish line)."""
+    from app.processing import track_bundle
+
+    return track_bundle.list_bundles(svc(request).settings.db_path.parent)
+
+
+@router.get("/track-bundles/{slug}")
+async def track_bundle_download(request: Request, slug: str) -> dict[str, Any]:
+    """One bundle document — the export unit for a future track-data repo."""
+    from app.processing import track_bundle
+
+    if not re.fullmatch(r"[a-z0-9-]+", slug):
+        raise HTTPException(400, "invalid bundle name")
+    path = svc(request).settings.db_path.parent / track_bundle.BUNDLE_DIR / f"{slug}.json"
+    if not path.exists():
+        raise HTTPException(404, "no bundle for this track")
+    data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return data
 
 
 # --- controls ---------------------------------------------------------------

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
 
     db_path: Path = Path("data/gt7.db")
     cars_csv: Path = Path("data/cars.csv")
+    # Official GT7 track/layout metadata (see scripts/build_track_metadata.py)
+    tracks_json: Path = Path("data/tracks.json")
     sample_lap: Path = Path("data/sample_lap.json")
 
     http_host: str = "0.0.0.0"

--- a/backend/app/processing/analysis.py
+++ b/backend/app/processing/analysis.py
@@ -14,6 +14,11 @@ Samples = dict[str, list[float]]
 
 DEFAULT_STEP_M = 5.0
 
+# Discrete per-tick columns (packed bitfields) where linear interpolation
+# would fabricate values that decode to nonsense — resampled with
+# nearest-neighbor instead.
+NEAREST_COLUMNS = frozenset({"surface"})
+
 
 def _interp(xs: list[float], ys: list[float], x: float) -> float:
     """Linear interpolation with edge clamping. xs must be ascending."""
@@ -44,8 +49,23 @@ def resample_by_distance(
     cols = columns or tuple(k for k in samples if k != "dist")
     for col in cols:
         ys = samples[col]
-        out[col] = [round(_interp(dist, ys, d), 4) for d in grid]
+        if col in NEAREST_COLUMNS:
+            out[col] = [_nearest(dist, ys, d) for d in grid]
+        else:
+            out[col] = [round(_interp(dist, ys, d), 4) for d in grid]
     return out
+
+
+def _nearest(xs: list[float], ys: list[float], x: float) -> float:
+    """Value of the sample nearest to x. xs must be ascending."""
+    if not xs:
+        return 0.0
+    i = bisect_left(xs, x)
+    if i <= 0:
+        return ys[0]
+    if i >= len(xs):
+        return ys[-1]
+    return ys[i] if xs[i] - x < x - xs[i - 1] else ys[i - 1]
 
 
 def time_delta_at(dist_m: float, t_s: float, ref: Samples) -> float | None:

--- a/backend/app/processing/laps.py
+++ b/backend/app/processing/laps.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from statistics import median
 
 from app.models import TelemetryPacket
+from app.processing.surface import encode_surface, off_track_excursions
 
 log = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ SAMPLE_COLUMNS = (
     "tt_fl", "tt_fr", "tt_rl", "tt_rr",
     "sus_fl", "sus_fr", "sus_rl", "sus_rr",  # suspension compression, mm
     "aids",  # AidsBits mask: TCS | ASM | handbrake | rev limiter
+    "surface",  # packed per-wheel surface codes (see processing/surface.py)
 )
 
 
@@ -105,6 +107,11 @@ class CompletedLap:
     max_water_temp: float = 0.0
     max_oil_temp: float = 0.0
     min_oil_pressure: float = -1.0  # sampled above idle rpm only; -1 = unknown
+    # Track-limits verdict from the per-tick surface column. Distinct from
+    # counts_for_best (which flags partial pit out-laps): a lap can be full
+    # AND dirty. -1/None = unknown (recorded without packet-C surface data).
+    off_track_count: int = -1
+    clean_lap: bool | None = None
     # Static per lap: {"ratios": [...], "top_speed": float, "rpm_alert": float}
     gearing: dict[str, object] | None = None
     events: list[dict[str, object]] = field(default_factory=list)
@@ -155,6 +162,10 @@ class CompletedLap:
         if len(aids) == n:
             self.tcs_active_pct = pct([bool(int(v) & AidsBits.TCS) for v in aids])
             self.asm_active_pct = pct([bool(int(v) & AidsBits.ASM) for v in aids])
+        surface = s.get("surface") or []
+        if len(surface) == n:
+            self.off_track_count = off_track_excursions(surface)
+            self.clean_lap = self.off_track_count == 0 if self.off_track_count >= 0 else None
         self.events = detect_events(s)
 
 
@@ -417,6 +428,7 @@ class LapProcessor:
         s["sus_rl"].append(round(p.suspension_rl * 1000, 1))
         s["sus_rr"].append(round(p.suspension_rr * 1000, 1))
         s["aids"].append(float(p.aids_bits))
+        s["surface"].append(float(encode_surface(p.surface_types)))
         # Engine-health aggregates (per-lap, not per-tick)
         self._max_water = max(self._max_water, p.water_temp)
         self._max_oil = max(self._max_oil, p.oil_temp)

--- a/backend/app/processing/live_events.py
+++ b/backend/app/processing/live_events.py
@@ -22,10 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from app.models import TelemetryPacket
-
-# Loose surfaces per packet-C surface chars: Dirt, Grass, Sand, snow.
-# "T" (tarmac) and "C" (curb/kerb) count as on-road.
-LOOSE_SURFACES = frozenset("DGSs")
+from app.processing.surface import LOOSE_SURFACES
 
 POSITION_HOLD_TICKS = 60  # ~1 s at 60 Hz
 OFFROAD_MIN_TICKS = 30  # ~0.5 s

--- a/backend/app/processing/surface.py
+++ b/backend/app/processing/surface.py
@@ -1,0 +1,92 @@
+"""Per-wheel surface contact: encoding, decoding, and off-track detection.
+
+Packet format C reports one ASCII char per wheel (FL FR RL RR). The chars
+seen so far: T (tarmac), C (curb/kerb), D (dirt), G (grass), S (sand),
+s (snow) — enumerated from the community layout docs and being validated on
+real hardware (issue #37; see scripts/surface_spike.py).
+
+Per tick the four chars are packed into one small int stored in the lap's
+"surface" sample column — 4 bits per wheel, FL in the lowest nibble:
+
+    value = FL | FR << 4 | RL << 8 | RR << 12
+
+Code 0 means "no surface data" (packet A/B/~), so a column of zeros from an
+old capture stays distinguishable from four wheels on tarmac (0x1111).
+The frontend mirrors this in frontend/src/lib/types.ts (SURFACE_*).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+# Loose surfaces (chars): Dirt, Grass, Sand, snow. "T" (tarmac) and
+# "C" (curb/kerb) count as on-road. Kept here as the single source of truth;
+# live_events imports it for the off-road webhook.
+LOOSE_SURFACES = frozenset("DGSs")
+
+SURFACE_NONE = 0  # packet A/B/~ — no surface data
+SURFACE_TARMAC = 1
+SURFACE_KERB = 2
+SURFACE_DIRT = 3
+SURFACE_GRASS = 4
+SURFACE_SAND = 5
+SURFACE_SNOW = 6
+SURFACE_OTHER = 7  # char the mapping doesn't know (yet) — treated as on-road
+
+CHAR_CODES = {
+    "T": SURFACE_TARMAC,
+    "C": SURFACE_KERB,
+    "D": SURFACE_DIRT,
+    "G": SURFACE_GRASS,
+    "S": SURFACE_SAND,
+    "s": SURFACE_SNOW,
+}
+LOOSE_CODES = frozenset({SURFACE_DIRT, SURFACE_GRASS, SURFACE_SAND, SURFACE_SNOW})
+
+# An off-track excursion = >= 3 wheels on a loose surface (two wheels over a
+# line is a normal track-limits nibble, matching the live off-road webhook)
+# held for >= 6 ticks (~0.1 s), so a single-frame surface flicker on a kerb
+# edge doesn't condemn the lap.
+OFF_TRACK_MIN_WHEELS = 3
+OFF_TRACK_MIN_TICKS = 6
+
+
+def encode_surface(surface: str | None) -> int:
+    """Pack the packet's 4-char surface string into one int (0 = no data)."""
+    if surface is None or len(surface) < 4:
+        return SURFACE_NONE
+    value = 0
+    for i in range(4):
+        value |= CHAR_CODES.get(surface[i], SURFACE_OTHER) << (4 * i)
+    return value
+
+
+def wheel_codes(value: int) -> tuple[int, int, int, int]:
+    """Unpack a surface sample into per-wheel codes (FL, FR, RL, RR)."""
+    v = int(value)
+    return (v & 0xF, (v >> 4) & 0xF, (v >> 8) & 0xF, (v >> 12) & 0xF)
+
+
+def loose_wheel_count(value: int) -> int:
+    """How many wheels of this sample sit on a loose surface."""
+    return sum(1 for c in wheel_codes(value) if c in LOOSE_CODES)
+
+
+def off_track_excursions(surface_col: Sequence[float]) -> int:
+    """Count off-track excursions in a lap's "surface" column.
+
+    Returns -1 when the column carries no surface data at all (empty, or
+    recorded with a packet format below C) — "unknown", not "clean".
+    """
+    if not surface_col or all(v == SURFACE_NONE for v in surface_col):
+        return -1
+    count = 0
+    run = 0
+    for v in surface_col:
+        if loose_wheel_count(int(v)) >= OFF_TRACK_MIN_WHEELS:
+            run += 1
+            if run == OFF_TRACK_MIN_TICKS:
+                count += 1
+        else:
+            run = 0
+    return count

--- a/backend/app/processing/survey.py
+++ b/backend/app/processing/survey.py
@@ -1,0 +1,795 @@
+"""Live surface survey (issue #37, the seed of #38/#39).
+
+Validates the packet-C `surface_types` encoding and the wheel-contact
+derivation on real hardware: while a survey is running, every per-wheel
+surface char is histogrammed, chars the mapping doesn't know are flagged,
+and every surface TRANSITION is logged with derived wheel-contact positions
+(car position + velocity-heading rotation of (±wheelbase/2, ±track/2)).
+
+This lives server-side in the 60 Hz packet path, not in the browser:
+transitions are single-tick events, and the ~30 Hz live WebSocket stream
+would miss half of them. The Survey view is a window onto this state —
+transitions are pushed to it as they happen, a breadcrumb trail of the path
+driven shows coverage, and the full record is written to a JSONL file for
+offline analysis (raw rotation floats included, so the euler-vs-quaternion
+question can be settled after the drive).
+
+Track width is NOT broadcast by GT7, but it can be MEASURED: riding all four
+wheels over one surface edge and back pins the crossing contact points onto
+a single boundary line. The same wheel's out-and-back crossings give the
+edge DIRECTION (a single one-way pass cannot — the rear wheels retrace the
+fronts' paths, leaving the edge angle unconstrained); opposite-side wheels
+crossing the same line then fix the width, and remaining same-side wheels
+must agree the points are collinear, which rejects two-edged strips, curved
+kerbs and mid-corner crossings. The median over accepted crossings replaces
+the assumed width once enough agree (the assumption remains the fallback,
+and the value stored in the JSONL meta header). The "right" vector is
+assumed to be (forward_z, -forward_x); if kerb contacts come out mirrored
+left/right, that sign is wrong — flip it and note it in
+docs/internals/surface-survey.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections import Counter, deque
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import median
+from typing import IO, Any
+
+from app.models import TelemetryPacket
+from app.processing import track_bundle
+from app.processing.surface import CHAR_CODES
+
+log = logging.getLogger(__name__)
+
+WHEELS = ("FL", "FR", "RL", "RR")
+MIN_HEADING_SPEED_MPS = 3.0  # below this the velocity heading is noise
+DEFAULT_TRACK_WIDTH_M = 1.6
+RECENT_TRANSITIONS = 50  # kept in memory for the status endpoint / view seed
+
+# GT7 does NOT broadcast a track-limits/penalty field in any known packet —
+# the documented flag bits stop at TCS (bit 11). If one exists it can only
+# hide in the undocumented upper bits, so the survey watches them: any of
+# these ever activating on real hardware is a finding.
+DOCUMENTED_FLAG_BITS = 12  # bits 0..11 are known (SimulatorFlags)
+
+# --- driven-path breadcrumb ---------------------------------------------------
+TRAIL_MIN_STEP_M = 2.0  # don't record a point until the car moved this far
+TRAIL_MAX_POINTS = 20_000  # on overflow the trail is decimated 2:1
+
+# Border-edge points are the track taking shape — every lap adds more, and
+# unlike breadcrumbs each one is unique boundary evidence, so they are kept
+# server-side for the whole run (the browser only ever holds a window of
+# recent transitions) and served incrementally like the trail.
+EDGES_MAX_POINTS = 50_000  # hard backstop; the JSONL always has everything
+
+# Autosave the labeled run's bundle roughly once a minute: dev reloads,
+# crashes and hard kills must never cost more than the last few corners
+# (graceful shutdown saves too, but never rely on shutdowns being graceful).
+AUTOSAVE_PACKETS = 3600  # ~60 s at 60 Hz
+
+# Finish line: GT7 increments current_lap exactly as the car crosses the
+# start/finish line, so each rollover pins a point ON the line. One crossing
+# locates it provisionally; repeat crossings landing close together make it
+# confident. Guards keep menu/restart lap-counter flicker out.
+FINISH_MIN_SPEED_MPS = 5.0
+FINISH_CONFIDENT_CROSSINGS = 2
+FINISH_CONFIDENT_SPREAD_M = 15.0
+FINISH_KEEP = 50
+
+# Manual boundary marking: the driver declares "the boundary is on my
+# left/right right now, and it is <kind>". Needed where surface data is
+# silent — paved run-off reads as plain tarmac, and wall-lined track has no
+# off-surface at all — so while a side is armed, the survey samples edge
+# points from the car's own path (that side's wheel line) every few meters.
+# kind "edge" = ordinary track edge, "runoff" = outer limit of paved
+# run-off (excluded from road fill), "wall" = wall-lined boundary.
+MARK_KINDS = ("edge", "runoff", "wall")
+MARK_STEP_M = 2.0  # one manual edge point per this much travel
+
+# --- track-width auto-estimation ----------------------------------------------
+# A measurement needs an out-and-back ride over ONE edge: the same wheel
+# crossing X→Y and later Y→X (edge direction), at least one opposite-side
+# crossing of the same line (the width equation), and a further same-side
+# crossing agreeing the points are collinear (strip/curve rejection).
+CROSSING_WINDOW_TICKS = 180  # ~3 s at 60 Hz: the whole ride must fit
+CROSSING_HEADING_MIN_DOT = 0.95  # cos ~18°: near-straight rides only
+MIN_EDGE_SEGMENT_M = 1.0  # out/back points closer than this give a bad angle
+COLLINEAR_TOL_M = 0.25  # same-side agreement required of a straight edge
+WIDTH_DENOM_MIN = 0.3  # crossing too perpendicular: no width information
+WIDTH_RANGE_M = (0.8, 2.4)  # plausible axle track widths
+WIDTH_MIN_SAMPLES = 3  # accepted rides needed before the estimate is used
+WIDTH_KEEP_SAMPLES = 200
+
+
+def _border_side(prev: str, cur: str) -> str | None:
+    """"L"/"R" when a transition unambiguously belongs to one track border.
+
+    Wheel order is FL FR RL RR: indices 0/2 are the left side, 1/3 the
+    right. The verdict needs the whole opposite side on plain tarmac in
+    both states — once wheels of both sides are off the racing surface the
+    car may be anywhere (deep excursion, re-entry), so no side is claimed.
+    """
+    changed = [i for i in range(4) if prev[i] != cur[i]]
+    if not changed:
+        return None
+    left = all(i in (0, 2) for i in changed)
+    right = all(i in (1, 3) for i in changed)
+    if left and all(prev[i] == "T" and cur[i] == "T" for i in (1, 3)):
+        return "L"
+    if right and all(prev[i] == "T" and cur[i] == "T" for i in (0, 2)):
+        return "R"
+    return None
+
+
+@dataclass(slots=True)
+class _Crossing:
+    """One wheel's char flip, positioned for the width solver."""
+
+    pid: int
+    wheel: int  # index into WHEELS
+    sig: tuple[str, str]  # (from char, to char)
+    px: float  # car position, pulled back half a tick: the flip is seen on
+    pz: float  # the first packet AFTER the wheel crossed the line
+    fx: float  # forward unit (from velocity)
+    fz: float
+    wheelbase_m: float
+    surface: str  # full 4-char state AFTER the flip (for same-line gating)
+
+
+class SurfaceSurvey:
+    """Feed packets while active; ask for status; stop to close the log."""
+
+    def __init__(self) -> None:
+        self.active = False
+        self.track_width_m = DEFAULT_TRACK_WIDTH_M
+        self.started_at: str | None = None
+        # What this run describes: the per-track grid (#38) needs samples
+        # keyed by circuit, and the JSONL must be joinable back to the laps
+        # recorded during the same drive. Both may update mid-run (session
+        # restart, late track identification).
+        self.track = ""
+        # True when the label was typed by the user (never auto-overwritten);
+        # auto-filled labels follow identification across circuit changes.
+        self.track_locked = False
+        self.session_id: int | None = None
+        self.log_path: Path | None = None
+        self._out: IO[str] | None = None
+        self._prev: str | None = None
+        self.packets = 0
+        self.no_surface_packets = 0
+        self.transitions = 0
+        self.char_counts: list[Counter[str]] = [Counter() for _ in WHEELS]
+        self.unknown_chars: Counter[str] = Counter()
+        self.recent: deque[dict[str, Any]] = deque(maxlen=RECENT_TRANSITIONS)
+        # Path driven while surveying, decimated 2:1 whenever it overflows.
+        # The epoch tells incremental readers their point indices went stale.
+        self.trail: list[list[float]] = []
+        self.trail_epoch = 0
+        self._trail_step = TRAIL_MIN_STEP_M
+        # Every border-edge point of the run — the track taking shape.
+        # Append-only within a run; the epoch bumps when a new run starts.
+        # Deduped on the bundle grid at append time, so re-driving mapped
+        # ground refines nothing into duplicates (in memory or on the map).
+        self.edges: list[dict[str, Any]] = []
+        self.edges_epoch = 0
+        self._edge_keys: set[tuple[int, int, str, str]] = set()
+        # Manual marking state (see MARK_KINDS above).
+        self.mark_side: str | None = None  # "L" | "R" | None = off
+        self.mark_kind: str = "edge"
+        self._last_mark: tuple[float, float] | None = None
+        self._last_straddle: tuple[float, float] | None = None
+        self._prev_lap: int | None = None
+        self.finish_crossings: list[dict[str, float]] = []
+        self._data_dir: Path | None = None
+        self._since_autosave = 0
+        # Meta of the bundle this run resumed from (None = fresh circuit).
+        self.bundle_info: dict[str, Any] | None = None
+        self._crossings: deque[_Crossing] = deque(maxlen=64)
+        self._width_estimates: list[float] = []
+        # Undocumented packet-flag bits seen active: bit index -> tick count.
+        self.unknown_flag_ticks: Counter[int] = Counter()
+
+    def start(
+        self,
+        data_dir: Path,
+        track_width_m: float,
+        track: str = "",
+        track_user_set: bool = False,
+        session_id: int | None = None,
+    ) -> None:
+        if self.active:
+            return
+        self.track_width_m = track_width_m
+        self.track = track
+        self.track_locked = track_user_set
+        self.session_id = session_id
+        self.started_at = datetime.now(UTC).isoformat()
+        self.packets = 0
+        self.no_surface_packets = 0
+        self.transitions = 0
+        self.char_counts = [Counter() for _ in WHEELS]
+        self.unknown_chars = Counter()
+        self.recent.clear()
+        self._prev = None
+        self.trail = []
+        self.trail_epoch += 1
+        self._trail_step = TRAIL_MIN_STEP_M
+        self.edges = []
+        self.edges_epoch += 1
+        self._edge_keys = set()
+        self.mark_side = None
+        self.mark_kind = "edge"
+        self._last_mark = None
+        self._last_straddle = None
+        self._prev_lap = None
+        self.finish_crossings = []
+        self._data_dir = data_dir
+        self._since_autosave = 0
+        self.bundle_info = None
+        self._crossings.clear()
+        self._width_estimates = []  # widths are per-car; a new run may swap cars
+        self.unknown_flag_ticks = Counter()
+        data_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        self.log_path = data_dir / f"surface_survey_{ts}.jsonl"
+        self._out = self.log_path.open("w", encoding="ascii")
+        # Header line, so the log stays self-describing offline: the track
+        # width assumption in particular is invisible in the records that
+        # were derived with it (each record also carries the tw_m it used).
+        self._out.write(json.dumps({"meta": {
+            "started_at": self.started_at,
+            "track_width_m": track_width_m,
+            "track": track,
+            "session_id": session_id,
+            "wheels": list(WHEELS),
+        }}, separators=(",", ":")) + "\n")
+        self._out.flush()
+        self.active = True
+        log.info("surface survey started (track %r, width %.2f m) -> %s",
+                 track or "?", track_width_m, self.log_path)
+        if self.track:
+            self._load_bundle()  # start from everything already mapped here
+
+    def set_track(self, name: str) -> None:
+        """Update the circuit label mid-run — and put it in the JSONL, which
+        must stay joinable to a circuit offline (a header written before
+        identification carries no label)."""
+        if name == self.track:
+            return
+        if self.active and self.track:
+            # Leaving a labeled circuit (session restart; the next one may be
+            # a different track): flush what this run learned to its bundle,
+            # then clear the run's evidence so it can never pollute another
+            # circuit's bundle. If the same circuit is identified again, the
+            # bundle load below restores everything just saved.
+            self._save_bundle(count_run=False)
+            self.edges = []
+            self.edges_epoch += 1
+            self._edge_keys = set()
+            self.finish_crossings = []
+            self.bundle_info = None
+        self.track = name
+        if self.active and self._out is not None and name:
+            self._out.write(json.dumps({"track": name}, separators=(",", ":")) + "\n")
+            self._out.flush()
+        if self.active and name:
+            self._load_bundle()
+
+    def _load_bundle(self) -> None:
+        if self._data_dir is None or not self.track:
+            return
+        doc = track_bundle.load(self._data_dir, self.track)
+        if doc is None:
+            return
+        # Bundle first, this run's (few, pre-identification) points merged in;
+        # the list is replaced wholesale, so incremental readers must resync.
+        self.edges = track_bundle.merge_edges(doc["edges"], self.edges)
+        self.edges_epoch += 1
+        self._edge_keys = {track_bundle.edge_key(e) for e in self.edges}
+        self.finish_crossings = track_bundle.merge_finish(
+            doc["finish_crossings"], self.finish_crossings
+        )
+        self.bundle_info = {**doc["meta"], "points": len(doc["edges"])}
+        log.info("resumed track bundle %r: %d points from %d runs",
+                 self.track, len(doc["edges"]), doc["meta"]["runs"])
+
+    def _save_bundle(self, count_run: bool) -> None:
+        if self._data_dir is None or not self.track:
+            return
+        if not self.edges and not self.finish_crossings:
+            return
+        self._since_autosave = 0
+        self.bundle_info = track_bundle.save(
+            self._data_dir, self.track, self.edges, self.finish_crossings, count_run
+        )
+
+    def stop(self) -> None:
+        if self.active:
+            self._save_bundle(count_run=True)
+        self.active = False
+        if self._out is not None:
+            self._out.close()
+            self._out = None
+        if self.transitions or self.packets:
+            log.info("surface survey stopped: %d packets, %d transitions",
+                     self.packets, self.transitions)
+
+    @property
+    def width_estimate_m(self) -> float | None:
+        """Median of the accepted edge-crossing measurements, if any."""
+        if not self._width_estimates:
+            return None
+        return round(median(self._width_estimates), 3)
+
+    @property
+    def width_in_use_m(self) -> float:
+        """Width applied to contact derivation: measured once trusted."""
+        estimate = self.width_estimate_m
+        if estimate is not None and len(self._width_estimates) >= WIDTH_MIN_SAMPLES:
+            return estimate
+        return self.track_width_m
+
+    def feed(self, p: TelemetryPacket) -> dict[str, Any] | None:
+        """Record one packet; returns the transition record when one occurred."""
+        self.packets += 1
+        self._since_autosave += 1
+        if self._since_autosave >= AUTOSAVE_PACKETS:
+            self._since_autosave = 0
+            self._save_bundle(count_run=False)
+        if p.surface_types is None:
+            self.no_surface_packets += 1
+            return None
+        if p.is_paused or not p.is_on_track:
+            return None
+        self._append_trail(p)
+        self._watch_finish_line(p)
+        if self.mark_side is not None:
+            self._append_manual_edge(p)
+        else:
+            self._append_straddle_edge(p)
+        for bit in range(DOCUMENTED_FLAG_BITS, 16):
+            if p.flags & (1 << bit):
+                if self.unknown_flag_ticks[bit] == 0:
+                    log.warning("undocumented packet flag bit %d active (flags=0x%04x) "
+                                "at (%.1f, %.1f)", bit, p.flags, p.position_x, p.position_z)
+                self.unknown_flag_ticks[bit] += 1
+        surface = p.surface_types
+        for i, ch in enumerate(surface):
+            self.char_counts[i][ch] += 1
+            if ch not in CHAR_CODES:
+                if self.unknown_chars[ch] == 0:
+                    log.warning("NEW surface char %r on %s at (%.1f, %.1f)",
+                                ch, WHEELS[i], p.position_x, p.position_z)
+                self.unknown_chars[ch] += 1
+        record = None
+        if self._prev is not None and surface != self._prev:
+            record = self._transition(p, self._prev, surface)
+            self.transitions += 1
+            self.recent.append(record)
+            if self._out is not None:
+                self._out.write(json.dumps(record, separators=(",", ":")) + "\n")
+                self._out.flush()  # export must see it while the run is live
+        self._prev = surface
+        return record
+
+    def _watch_finish_line(self, p: TelemetryPacket) -> None:
+        """Each lap rollover pins a point on the start/finish line.
+
+        Only exact +1 increments between racing laps count: menu flicker,
+        restarts (counter falls back) and grid starts (0 -> 1 away from the
+        line) all fail the guards.
+        """
+        prev = self._prev_lap
+        self._prev_lap = p.current_lap
+        if prev is None or prev < 1 or p.current_lap != prev + 1:
+            return
+        if p.speed_mps < FINISH_MIN_SPEED_MPS:
+            return
+        norm = math.hypot(p.velocity_x, p.velocity_z)
+        if norm <= 0 or len(self.finish_crossings) >= FINISH_KEEP:
+            return
+        crossing = {
+            "x": round(p.position_x, 3), "z": round(p.position_z, 3),
+            "hx": round(p.velocity_x / norm, 5), "hz": round(p.velocity_z / norm, 5),
+            "lap": float(p.current_lap),
+        }
+        self.finish_crossings.append(crossing)
+        if self._out is not None:
+            self._out.write(json.dumps({"finish": crossing}, separators=(",", ":")) + "\n")
+            self._out.flush()
+        log.info("finish-line crossing #%d at (%.1f, %.1f)",
+                 len(self.finish_crossings), p.position_x, p.position_z)
+
+    def _finish_summary(self) -> dict[str, Any] | None:
+        """Mean crossing point + heading; confident once repeats agree."""
+        if not self.finish_crossings:
+            return None
+        n = len(self.finish_crossings)
+        mx = sum(c["x"] for c in self.finish_crossings) / n
+        mz = sum(c["z"] for c in self.finish_crossings) / n
+        spread = max(
+            math.hypot(c["x"] - mx, c["z"] - mz) for c in self.finish_crossings
+        )
+        hx = sum(c["hx"] for c in self.finish_crossings)
+        hz = sum(c["hz"] for c in self.finish_crossings)
+        norm = math.hypot(hx, hz)
+        if norm < 0.1:  # crossings disagree on direction; trust the first
+            hx, hz = self.finish_crossings[0]["hx"], self.finish_crossings[0]["hz"]
+        else:
+            hx, hz = hx / norm, hz / norm
+        return {
+            "x": round(mx, 2), "z": round(mz, 2),
+            "hx": round(hx, 5), "hz": round(hz, 5),
+            "crossings": n,
+            "spread_m": round(spread, 1),
+            "confident": n >= FINISH_CONFIDENT_CROSSINGS
+            and spread <= FINISH_CONFIDENT_SPREAD_M,
+        }
+
+    def set_mark(self, side: str | None, kind: str) -> None:
+        """Arm or disarm manual boundary marking (validated by the API layer)."""
+        self.mark_side = side
+        self.mark_kind = kind
+        self._last_mark = None
+        if side is not None:
+            log.info("marking %s boundary on the %s side", kind, side)
+
+    def _append_manual_edge(self, p: TelemetryPacket) -> None:
+        """One edge point at the armed side's wheel line, every few meters.
+
+        This is what maps boundaries the surface chars cannot see: hug the
+        wall / white line / run-off limit and the driven line becomes the
+        boundary polyline.
+        """
+        if p.speed_mps < MIN_HEADING_SPEED_MPS:
+            return
+        if self._last_mark is not None:
+            lx, lz = self._last_mark
+            dx, dz = p.position_x - lx, p.position_z - lz
+            if dx * dx + dz * dz < MARK_STEP_M**2:
+                return
+        norm = math.hypot(p.velocity_x, p.velocity_z)
+        if norm <= 0:
+            return
+        fx, fz = p.velocity_x / norm, p.velocity_z / norm
+        rx, rz = fz, -fx
+        lat = -self.width_in_use_m / 2.0 if self.mark_side == "L" else self.width_in_use_m / 2.0
+        self._last_mark = (p.position_x, p.position_z)
+        self._append_edge(
+            x=p.position_x + lat * rx, z=p.position_z + lat * rz,
+            hx=fx, hz=fz, side=self.mark_side or "L", kind=self.mark_kind,
+            pid=p.packet_id,
+        )
+
+    def _append_straddle_edge(self, p: TelemetryPacket) -> None:
+        """Continuous automatic border tracing, no button required.
+
+        Surface flips only pin the border at the moment a wheel crosses it;
+        a lap driven with one side's wheels HELD off the track produces
+        almost no flips and would leave the border untraced between them.
+        But that sustained state is itself the evidence: both wheels of one
+        side off the tarmac while the other side is fully on it means the
+        car is straddling that border, so the off-side wheel line traces
+        it — one point per couple of meters, exactly like manual marking.
+        """
+        surface = p.surface_types
+        assert surface is not None  # feed() returned before this otherwise
+        left_off = surface[0] != "T" and surface[2] != "T"
+        right_off = surface[1] != "T" and surface[3] != "T"
+        left_on = surface[0] == "T" and surface[2] == "T"
+        right_on = surface[1] == "T" and surface[3] == "T"
+        if left_off and right_on:
+            side = "L"
+        elif right_off and left_on:
+            side = "R"
+        else:
+            # Fully on, fully off, or diagonal — no border underneath the car.
+            self._last_straddle = None
+            return
+        if p.speed_mps < MIN_HEADING_SPEED_MPS:
+            return
+        if self._last_straddle is not None:
+            lx, lz = self._last_straddle
+            dx, dz = p.position_x - lx, p.position_z - lz
+            if dx * dx + dz * dz < MARK_STEP_M**2:
+                return
+        norm = math.hypot(p.velocity_x, p.velocity_z)
+        if norm <= 0:
+            return
+        fx, fz = p.velocity_x / norm, p.velocity_z / norm
+        rx, rz = fz, -fx
+        lat = -self.width_in_use_m / 2.0 if side == "L" else self.width_in_use_m / 2.0
+        self._last_straddle = (p.position_x, p.position_z)
+        self._append_edge(
+            x=p.position_x + lat * rx, z=p.position_z + lat * rz,
+            hx=fx, hz=fz, side=side, kind="straddle", pid=p.packet_id,
+        )
+
+    def _append_edge(
+        self, x: float, z: float, hx: float, hz: float, side: str, kind: str, pid: int
+    ) -> None:
+        edge = {
+            "x": round(x, 3), "z": round(z, 3),
+            "hx": round(hx, 5), "hz": round(hz, 5),
+            "side": side, "kind": kind,
+        }
+        key = track_bundle.edge_key(edge)
+        if key in self._edge_keys:
+            return  # this meter of boundary is already evidenced
+        self._edge_keys.add(key)
+        if self._out is not None and kind != "auto":
+            # "auto" edges are reconstructable from the transition records;
+            # manual and straddle-sampled ones exist nowhere else, so they
+            # go to the JSONL too (as "mark" lines) — BEFORE the memory cap,
+            # which must never cost log completeness.
+            self._out.write(
+                json.dumps({"mark": {**edge, "pid": pid}}, separators=(",", ":")) + "\n"
+            )
+        if len(self.edges) >= EDGES_MAX_POINTS:
+            return  # in-memory backstop only; the JSONL has everything
+        self.edges.append(edge)
+
+    def _append_trail(self, p: TelemetryPacket) -> None:
+        x, z = p.position_x, p.position_z
+        if self.trail:
+            lx, lz = self.trail[-1]
+            if (x - lx) ** 2 + (z - lz) ** 2 < self._trail_step**2:
+                return
+        self.trail.append([round(x, 2), round(z, 2)])
+        if len(self.trail) > TRAIL_MAX_POINTS:
+            # Halve the resolution instead of forgetting the oldest laps —
+            # coverage of the whole drive is the point of the trail.
+            self.trail = self.trail[::2]
+            self._trail_step *= 2
+            self.trail_epoch += 1
+
+    def _transition(self, p: TelemetryPacket, prev: str, cur: str) -> dict[str, Any]:
+        speed = p.speed_mps
+        heading = None
+        contacts: dict[str, list[float]] | None = None
+        tw_used: float | None = None
+        if speed >= MIN_HEADING_SPEED_MPS and p.wheelbase_m:
+            # Ground-plane forward from velocity; the assumed right vector is
+            # exactly what the survey validates (see module docstring).
+            norm = math.hypot(p.velocity_x, p.velocity_z)
+            fx, fz = p.velocity_x / norm, p.velocity_z / norm
+            self._record_crossings(p, prev, cur, fx, fz)
+            rx, rz = fz, -fx
+            half_wb = p.wheelbase_m / 2.0
+            tw_used = self.width_in_use_m
+            half_tw = tw_used / 2.0
+            offsets = {
+                "FL": (half_wb, -half_tw),
+                "FR": (half_wb, half_tw),
+                "RL": (-half_wb, -half_tw),
+                "RR": (-half_wb, half_tw),
+            }
+            heading = math.atan2(p.velocity_x, p.velocity_z)
+            contacts = {
+                w: [
+                    round(p.position_x + fwd * fx + lat * rx, 3),
+                    round(p.position_z + fwd * fz + lat * rz, 3),
+                ]
+                for w, (fwd, lat) in offsets.items()
+            }
+        # Which track border this contact belongs to, relative to the
+        # direction of travel: wheels of one side touching kerb/loose while
+        # the whole other side stays on tarmac can only happen at that
+        # side's edge of the road. Accumulated left/right-tagged points ARE
+        # the two perimeter polylines forming — kept in self.edges for the
+        # whole run so the map can draw the track taking shape lap by lap.
+        border = _border_side(prev, cur)
+        if border is not None and contacts is not None:
+            for i in range(4):
+                if prev[i] == cur[i]:
+                    continue
+                point = contacts[WHEELS[i]]
+                norm = math.hypot(p.velocity_x, p.velocity_z)
+                self._append_edge(
+                    x=point[0], z=point[1],
+                    hx=p.velocity_x / norm, hz=p.velocity_z / norm,
+                    side=border, kind="auto", pid=p.packet_id,
+                )
+        return {
+            "n": self.transitions + 1,
+            "pid": p.packet_id,
+            "session_id": self.session_id,
+            "lap": p.current_lap,
+            "from": prev,
+            "to": cur,
+            "changed": [WHEELS[i] for i in range(4) if prev[i] != cur[i]],
+            "border": border,
+            # Manual marking active while this transition happened, if any.
+            "mark": self.mark_kind if self.mark_side is not None else None,
+            "pos": [round(p.position_x, 3), round(p.position_y, 3), round(p.position_z, 3)],
+            "vel": [round(p.velocity_x, 3), round(p.velocity_y, 3), round(p.velocity_z, 3)],
+            "speed_mps": round(speed, 2),
+            "heading_rad": round(heading, 5) if heading is not None else None,
+            # Raw orientation fields, for settling euler-vs-quaternion offline.
+            "rotation": [p.rotation_pitch, p.rotation_yaw, p.rotation_roll],
+            "rel_north": p.rel_orientation_to_north,
+            "wheelbase_m": p.wheelbase_m,
+            # Raw flags, so undocumented bits can be correlated with
+            # off-track moments offline (no track-limits field is known).
+            "flags": p.flags,
+            "tw_m": round(tw_used, 3) if tw_used is not None else None,
+            "contacts": contacts,
+        }
+
+    # --- track-width estimation ----------------------------------------------
+
+    def _record_crossings(
+        self, p: TelemetryPacket, prev: str, cur: str, fx: float, fz: float
+    ) -> None:
+        assert p.wheelbase_m is not None
+        # The flip is observed on the first packet after the wheel crossed,
+        # so pull the position back half a tick to center the timing error.
+        px = p.position_x - p.velocity_x * (0.5 / 60.0)
+        pz = p.position_z - p.velocity_z * (0.5 / 60.0)
+        for i in range(4):
+            if prev[i] == cur[i]:
+                continue
+            self._crossings.append(_Crossing(
+                pid=p.packet_id, wheel=i, sig=(prev[i], cur[i]),
+                px=px, pz=pz, fx=fx, fz=fz, wheelbase_m=p.wheelbase_m,
+                surface=cur,
+            ))
+        self._try_estimate_width(p.packet_id)
+
+    def _try_estimate_width(self, pid: int) -> None:
+        recent = [c for c in self._crossings if pid - c.pid <= CROSSING_WINDOW_TICKS]
+        groups: dict[frozenset[str], list[_Crossing]] = {}
+        for c in recent:
+            groups.setdefault(frozenset(c.sig), []).append(c)
+        for key, group in groups.items():
+            width = self._estimate_from_group(group)
+            if width is None:
+                continue
+            self._width_estimates.append(width)
+            del self._width_estimates[:-WIDTH_KEEP_SAMPLES]
+            log.info("track width measured: %.2f m (median %.2f m over %d rides)",
+                     width, self.width_estimate_m or 0.0, len(self._width_estimates))
+            # This edge ride is spent; keep events of other boundary types.
+            remaining = [c for c in self._crossings if frozenset(c.sig) != key]
+            self._crossings.clear()
+            self._crossings.extend(remaining)
+
+    def _estimate_from_group(self, group: list[_Crossing]) -> float | None:
+        """One width measurement from an out-and-back ride over one edge.
+
+        Every crossing pins a contact point P + a·f + b·(tw/2)·r onto the
+        edge line n·x = const (a = ±wheelbase/2 and b = ±1 known per wheel).
+        The same wheel's out/back crossings both lie on the line and their
+        b-terms cancel, giving n without knowing tw; each opposite-side
+        crossing then yields tw; remaining same-side crossings must agree
+        the points are collinear or the "edge" wasn't one straight line.
+        """
+        if len(group) < 4:
+            return None
+        f0 = group[0]
+        for c in group[1:]:
+            if c.fx * f0.fx + c.fz * f0.fz < CROSSING_HEADING_MIN_DOT:
+                return None
+
+        def a_of(c: _Crossing) -> float:
+            return c.wheelbase_m / 2.0 if c.wheel in (0, 1) else -c.wheelbase_m / 2.0
+
+        def b_of(c: _Crossing) -> float:
+            return -1.0 if c.wheel in (0, 2) else 1.0  # left wheels sit at -tw/2
+
+        # Edge direction: the same wheel's out/back pair, widest apart.
+        by_wheel: dict[int, list[_Crossing]] = {}
+        for c in group:
+            by_wheel.setdefault(c.wheel, []).append(c)
+        pair: tuple[_Crossing, _Crossing] | None = None
+        best_len = MIN_EDGE_SEGMENT_M
+        for events in by_wheel.values():
+            for i, one in enumerate(events):
+                for two in events[i + 1:]:
+                    if one.sig != (two.sig[1], two.sig[0]):
+                        continue
+                    a = a_of(one)
+                    dx = (two.px - one.px) + a * (two.fx - one.fx)
+                    dz = (two.pz - one.pz) + a * (two.fz - one.fz)
+                    length = math.hypot(dx, dz)
+                    if length > best_len:
+                        best_len = length
+                        pair = (one, two)
+        if pair is None:
+            return None
+        out, back = pair
+        a = a_of(out)
+        ex = ((back.px - out.px) + a * (back.fx - out.fx)) / best_len
+        ez = ((back.pz - out.pz) + a * (back.fz - out.fz)) / best_len
+        nx, nz = ez, -ex  # normal sign is irrelevant: |tw| is the answer
+
+        def along_normal(c: _Crossing, tw: float) -> float:
+            rx, rz = c.fz, -c.fx
+            return (nx * c.px + nz * c.pz + a_of(c) * (nx * c.fx + nz * c.fz)
+                    + b_of(c) * (tw / 2.0) * (nx * rx + nz * rz))
+
+        # Same-side crossings must land on the pair's line, or this was a
+        # two-edged strip / curved kerb — no straight edge to measure against.
+        side = b_of(out)
+        reference = along_normal(out, self.width_in_use_m)
+        validated = False
+        for c in group:
+            if c is out or c is back or b_of(c) != side:
+                continue
+            if abs(along_normal(c, self.width_in_use_m) - reference) > COLLINEAR_TOL_M:
+                return None
+            validated = True
+        if not validated:
+            return None
+
+        candidates: list[float] = []
+        # A genuine full ride has the pair-side wheels already off tarmac
+        # when the opposite side crosses the same line. Weaving a narrow
+        # lane with boundaries on BOTH sides (grass left AND right) leaves
+        # them on tarmac at that moment — the opposite wheels crossed a
+        # DIFFERENT parallel line, and using them would solve for the lane
+        # separation instead of the axle width.
+        pair_wheels = (0, 2) if side < 0 else (1, 3)
+        for m in group:
+            if b_of(m) == side:
+                continue
+            if all(m.surface[i] == "T" for i in pair_wheels):
+                continue
+            for anchor in (out, back):
+                denom = (
+                    b_of(anchor) * (nx * anchor.fz + nz * -anchor.fx)
+                    - b_of(m) * (nx * m.fz + nz * -m.fx)
+                )
+                if abs(denom) < WIDTH_DENOM_MIN:
+                    continue
+                num = (
+                    nx * (m.px - anchor.px) + nz * (m.pz - anchor.pz)
+                    + a_of(m) * (nx * m.fx + nz * m.fz)
+                    - a_of(anchor) * (nx * anchor.fx + nz * anchor.fz)
+                )
+                candidates.append(2.0 * num / denom)
+        if not candidates:
+            return None
+        width = abs(median(candidates))
+        if not WIDTH_RANGE_M[0] <= width <= WIDTH_RANGE_M[1]:
+            return None
+        return round(width, 3)
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "active": self.active,
+            "started_at": self.started_at,
+            "track": self.track,
+            "session_id": self.session_id,
+            "track_width_m": self.track_width_m,
+            "width_estimate_m": self.width_estimate_m,
+            "width_samples": len(self._width_estimates),
+            "width_in_use_m": round(self.width_in_use_m, 3),
+            "packets": self.packets,
+            "no_surface_packets": self.no_surface_packets,
+            "transitions": self.transitions,
+            "trail_points": len(self.trail),
+            "trail_epoch": self.trail_epoch,
+            "edge_points": len(self.edges),
+            "edges_epoch": self.edges_epoch,
+            "finish": self._finish_summary(),
+            "bundle": self.bundle_info,
+            "mark_side": self.mark_side,
+            "mark_kind": self.mark_kind,
+            "histogram": {
+                WHEELS[i]: dict(self.char_counts[i].most_common())
+                for i in range(len(WHEELS))
+            },
+            "chars_seen": sorted({c for counter in self.char_counts for c in counter}),
+            "known_chars": sorted(CHAR_CODES),
+            "unknown_chars": dict(self.unknown_chars),
+            "unknown_flag_bits": {str(bit): n for bit, n in self.unknown_flag_ticks.items()},
+            "recent": list(self.recent),
+            "log_path": str(self.log_path) if self.log_path else None,
+        }

--- a/backend/app/processing/survey.py
+++ b/backend/app/processing/survey.py
@@ -554,10 +554,13 @@ class SurfaceSurvey:
         heading = None
         contacts: dict[str, list[float]] | None = None
         tw_used: float | None = None
-        if speed >= MIN_HEADING_SPEED_MPS and p.wheelbase_m:
+        # speed_mps is its own packet field, decoded separately from the
+        # velocity vector — guard the norm too, or a mismatched packet
+        # (speed reported, ground-plane velocity zero) divides by zero.
+        norm = math.hypot(p.velocity_x, p.velocity_z)
+        if speed >= MIN_HEADING_SPEED_MPS and p.wheelbase_m and norm > 0:
             # Ground-plane forward from velocity; the assumed right vector is
             # exactly what the survey validates (see module docstring).
-            norm = math.hypot(p.velocity_x, p.velocity_z)
             fx, fz = p.velocity_x / norm, p.velocity_z / norm
             self._record_crossings(p, prev, cur, fx, fz)
             rx, rz = fz, -fx
@@ -589,8 +592,7 @@ class SurfaceSurvey:
             for i in range(4):
                 if prev[i] == cur[i]:
                     continue
-                point = contacts[WHEELS[i]]
-                norm = math.hypot(p.velocity_x, p.velocity_z)
+                point = contacts[WHEELS[i]]  # norm > 0: contacts exist
                 self._append_edge(
                     x=point[0], z=point[1],
                     hx=p.velocity_x / norm, hz=p.velocity_z / norm,

--- a/backend/app/processing/track_bundle.py
+++ b/backend/app/processing/track_bundle.py
@@ -1,0 +1,147 @@
+"""Per-track survey bundles: track knowledge that outlives a run.
+
+A survey run is ephemeral (restarts, new sessions), but the track isn't —
+its perimeters and finish line don't move. Every run's border evidence is
+merged into one JSON document per circuit under data/track-bundles/, and
+every new run on that circuit starts from it: the map opens with everything
+ever mapped and improves from there.
+
+Merging dedups on a 1 m grid per (side, kind), so re-driving the same edges
+does not grow the file — it converges. First-seen points win, keeping the
+files stable (small diffs once these live in their own repo: the format is
+self-describing and versioned precisely so bundles can be exported there
+and imported at build time later, like data/tracks.json).
+
+Track width calibration is deliberately NOT in the bundle: it is a property
+of the car being driven, not of the circuit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+BUNDLE_FORMAT = "gt7-datalogger-track-bundle"
+BUNDLE_VERSION = 1
+BUNDLE_DIR = "track-bundles"
+GRID_M = 1.0  # dedup cell: one point per meter per (side, kind)
+MAX_POINTS = 50_000
+MAX_FINISH_CROSSINGS = 20
+
+
+def slugify(track: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", track.lower()).strip("-") or "unnamed"
+
+
+def bundle_path(data_dir: Path, track: str) -> Path:
+    return data_dir / BUNDLE_DIR / f"{slugify(track)}.json"
+
+
+def edge_key(e: dict[str, Any]) -> tuple[int, int, str, str]:
+    return (round(e["x"] / GRID_M), round(e["z"] / GRID_M), e["side"], e["kind"])
+
+
+def merge_edges(
+    existing: list[dict[str, Any]], new: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Union on the dedup grid; existing points win (file stability)."""
+    merged = list(existing)
+    seen = {edge_key(e) for e in existing}
+    for e in new:
+        key = edge_key(e)
+        if key in seen or len(merged) >= MAX_POINTS:
+            continue
+        seen.add(key)
+        merged.append(e)
+    return merged
+
+
+def merge_finish(
+    existing: list[dict[str, float]], new: list[dict[str, float]]
+) -> list[dict[str, float]]:
+    merged = list(existing)
+    seen = {(round(c["x"]), round(c["z"])) for c in existing}
+    for c in new:
+        key = (round(c["x"]), round(c["z"]))
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(c)
+    return merged[-MAX_FINISH_CROSSINGS:]
+
+
+def load(data_dir: Path, track: str) -> dict[str, Any] | None:
+    path = bundle_path(data_dir, track)
+    if not path.exists():
+        return None
+    try:
+        doc: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        if doc.get("format") != BUNDLE_FORMAT:
+            return None
+        return doc
+    except (ValueError, OSError) as exc:
+        log.warning("unreadable track bundle %s: %s", path, exc)
+        return None
+
+
+def save(
+    data_dir: Path,
+    track: str,
+    edges: list[dict[str, Any]],
+    finish_crossings: list[dict[str, float]],
+    count_run: bool,
+) -> dict[str, Any]:
+    """Merge a run's evidence into the circuit's bundle; returns its meta."""
+    existing = load(data_dir, track)
+    merged_edges = merge_edges(existing["edges"] if existing else [], edges)
+    merged_finish = merge_finish(
+        existing["finish_crossings"] if existing else [], finish_crossings
+    )
+    runs = (existing["meta"]["runs"] if existing else 0) + (1 if count_run else 0)
+    meta: dict[str, Any] = {
+        "track": track,
+        "runs": runs,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    doc: dict[str, Any] = {
+        "format": BUNDLE_FORMAT,
+        "version": BUNDLE_VERSION,
+        "meta": meta,
+        "edges": merged_edges,
+        "finish_crossings": merged_finish,
+    }
+    path = bundle_path(data_dir, track)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(doc, separators=(",", ":")), encoding="utf-8")
+    tmp.replace(path)  # atomic: a crash never leaves a half-written bundle
+    log.info("track bundle saved: %s (%d points, %d runs)",
+             path.name, len(merged_edges), runs)
+    return {**meta, "points": len(merged_edges)}
+
+
+def list_bundles(data_dir: Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    directory = data_dir / BUNDLE_DIR
+    if not directory.is_dir():
+        return out
+    for path in sorted(directory.glob("*.json")):
+        try:
+            doc: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+            if doc.get("format") != BUNDLE_FORMAT:
+                continue
+            out.append({
+                **doc["meta"],
+                "slug": path.stem,
+                "points": len(doc.get("edges", [])),
+                "finish_crossings": len(doc.get("finish_crossings", [])),
+            })
+        except (ValueError, OSError):
+            continue
+    return out

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -19,6 +19,8 @@ from app.processing.analysis import Samples, time_delta_at
 from app.processing.cars import CarDatabase
 from app.processing.laps import CompletedLap, LapProcessor, SessionInfo
 from app.processing.live_events import LiveEvent, LiveEventWatcher
+from app.processing.surface import encode_surface
+from app.processing.survey import SurfaceSurvey
 from app.processing.tracks import signature_from_samples
 from app.race_engineer import CATEGORIES, VoiceCallout
 from app.race_engineer.manager import RaceEngineerManager
@@ -92,6 +94,7 @@ class TelemetryService:
         self.notifier.url = settings.webhook_url
         self.notifier.enabled = settings.enabled_webhook_events()
         self.event_watcher = LiveEventWatcher()
+        self.survey = SurfaceSurvey()
         self.engineer = RaceEngineerManager(
             enabled=settings.race_engineer,
             verbosity=settings.race_engineer_verbosity,
@@ -120,6 +123,7 @@ class TelemetryService:
 
     async def stop(self) -> None:
         await self.source.stop()
+        self.survey.stop()
         tasks = [c.task for c in self._clients.values() if c.task]
         for t in tasks:
             t.cancel()
@@ -170,6 +174,12 @@ class TelemetryService:
             await self.processor.feed(p)
         for event in self.event_watcher.feed(p):
             self._notify_live_event(event, p)
+        if self.survey.active:
+            # 60 Hz on purpose: transitions are single-tick events that the
+            # downsampled live stream below would miss.
+            record = self.survey.feed(p)
+            if record is not None:
+                self._publish({"type": "survey", "data": record})
         if self.engineer_active:
             self._publish_callouts(self.engineer.on_packet(p))
         now = time.monotonic()
@@ -200,6 +210,14 @@ class TelemetryService:
         self.event_watcher.reset()
         await self._close_previous_session()
         self.session_id = await self.repo.create_session(info, self.cars.name(info.car_id))
+        # A survey spanning a restart keeps labeling its records with the
+        # session its transitions actually belong to. An auto-filled track
+        # label goes back to unknown too — the new session may be a
+        # different circuit, and identification will re-label it; a label
+        # the user typed is theirs and stays.
+        self.survey.session_id = self.session_id
+        if self.survey.active and not self.survey.track_locked:
+            self.survey.set_track("")
         self.engineer.on_session(info, self.session_id)
         self.track_name = ""
         self._session_best_ms = None
@@ -292,6 +310,8 @@ class TelemetryService:
             "time_ms": lap.time_ms,
             "car_id": lap.car_id,
             "counts_for_best": lap.counts_for_best,
+            "off_track_count": lap.off_track_count,
+            "clean_lap": lap.clean_lap,
             "car_name": self.cars.name(lap.car_id),
             "fuel_consumed": round(lap.fuel_consumed, 3),
             "full_throttle_pct": round(lap.full_throttle_pct, 1),
@@ -314,6 +334,10 @@ class TelemetryService:
         if name:
             self.track_name = name
             await self.repo.set_session_track(self.session_id, name)
+            # A survey started before the circuit was known picks the label
+            # up now; an explicit user-picked label is never overwritten.
+            if self.survey.active and not self.survey.track_locked:
+                self.survey.set_track(name)
             log.info("track identified: %s", name)
             self._publish({"type": "session", "data": await self.status()})
 
@@ -324,6 +348,8 @@ class TelemetryService:
             raise ValueError("lap has no position data")
         await self.repo.create_track(name, sig)
         self.track_name = name
+        if self.survey.active and not self.survey.track_locked:
+            self.survey.set_track(name)
         if self.session_id is not None:
             await self.repo.set_session_track(self.session_id, name)
         log.info("track saved: %s (%.0f m)", name, sig.length_m)
@@ -369,6 +395,7 @@ class TelemetryService:
             "oil_temp": round(p.oil_temp, 1),
             "oil_pressure": round(p.oil_pressure, 2),
             "aids": p.aids_bits,
+            "surface": encode_surface(p.surface_types),
             "car_id": p.car_id,
             "car_name": self.cars.name(p.car_id),
             "session_best_ms": session.best_lap_time_ms if session else -1,
@@ -558,14 +585,21 @@ class TelemetryService:
         if not self._clients:
             return
         text = json.dumps(message)
-        droppable = message["type"] == "telemetry"
+        kind = message["type"]
         for client in list(self._clients.values()):
-            if droppable:
+            if kind == "telemetry":
                 client.frame = text
             else:
                 try:
                     client.events.put_nowait(text)
                 except asyncio.QueueFull:
+                    # Survey transitions can burst at 60 Hz (kerb chatter)
+                    # and are recoverable from the status/edges endpoints —
+                    # drop them for a slow client rather than shrinking the
+                    # lap/session lane's minutes-long overflow budget to
+                    # seconds and disconnecting a dashboard mid-session.
+                    if kind == "survey":
+                        continue
                     # Unreadable for minutes — disconnect rather than lose
                     # a lap/session event silently.
                     self._drop_client(client)

--- a/backend/app/storage/db.py
+++ b/backend/app/storage/db.py
@@ -98,6 +98,10 @@ class LapRow(Base):
     min_oil_pressure: Mapped[float] = mapped_column(default=-1.0)
     # False for partial laps (pit out-laps): excluded from best-lap aggregates
     counts_for_best: Mapped[bool] = mapped_column(default=True)
+    # Track-limits verdict from per-tick surface data (packet C). Distinct
+    # from counts_for_best: -1 / NULL = unknown (no surface data recorded).
+    off_track_count: Mapped[int] = mapped_column(default=-1)
+    clean_lap: Mapped[bool | None] = mapped_column(default=None)
     events_json: Mapped[str] = mapped_column(Text, default="[]")
     gearing_json: Mapped[str] = mapped_column(Text, default="")
     samples_json: Mapped[str] = mapped_column(Text)
@@ -141,6 +145,8 @@ _SQLITE_MIGRATIONS = (
         ("min_oil_pressure", "FLOAT NOT NULL DEFAULT -1"),
         ("events_json", "TEXT NOT NULL DEFAULT '[]'"),
         ("gearing_json", "TEXT NOT NULL DEFAULT ''"),
+        ("off_track_count", "INTEGER NOT NULL DEFAULT -1"),
+        ("clean_lap", "BOOLEAN"),
     )
 )
 

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -43,6 +43,8 @@ def lap_summary(row: LapRow) -> dict[str, Any]:
         "max_oil_temp": row.max_oil_temp,
         "min_oil_pressure": row.min_oil_pressure,
         "counts_for_best": row.counts_for_best,
+        "off_track_count": row.off_track_count,
+        "clean_lap": row.clean_lap,
         "event_counts": _event_counts(row.events_json),
     }
 
@@ -90,6 +92,8 @@ class Repository:
                 tcs_active_pct=lap.tcs_active_pct,
                 asm_active_pct=lap.asm_active_pct,
                 counts_for_best=lap.counts_for_best,
+                off_track_count=lap.off_track_count,
+                clean_lap=lap.clean_lap,
                 max_water_temp=lap.max_water_temp,
                 max_oil_temp=lap.max_oil_temp,
                 min_oil_pressure=lap.min_oil_pressure,

--- a/backend/tests/test_surface.py
+++ b/backend/tests/test_surface.py
@@ -1,0 +1,742 @@
+"""Surface encoding, off-track excursion counting, and per-tick persistence."""
+
+import pytest
+
+from app.models import SimulatorFlags, TelemetryPacket
+from app.processing.analysis import resample_by_distance
+from app.processing.laps import CompletedLap, LapProcessor, SessionInfo
+from app.processing.surface import (
+    OFF_TRACK_MIN_TICKS,
+    SURFACE_GRASS,
+    SURFACE_KERB,
+    SURFACE_NONE,
+    SURFACE_OTHER,
+    SURFACE_TARMAC,
+    encode_surface,
+    loose_wheel_count,
+    off_track_excursions,
+    wheel_codes,
+)
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+
+TTTT = encode_surface("TTTT")
+GGGG = encode_surface("GGGG")
+
+
+def make_packet(**kwargs) -> TelemetryPacket:
+    kwargs.setdefault("flags", ON_TRACK)
+    return parse_packet(build_packet(**kwargs))
+
+
+# --- encoding ----------------------------------------------------------------
+
+
+def test_encode_none_and_short() -> None:
+    assert encode_surface(None) == SURFACE_NONE
+    assert encode_surface("TT") == SURFACE_NONE
+
+
+def test_encode_wheel_order_fl_lowest_nibble() -> None:
+    assert wheel_codes(encode_surface("CTTT")) == (
+        SURFACE_KERB, SURFACE_TARMAC, SURFACE_TARMAC, SURFACE_TARMAC,
+    )
+    assert wheel_codes(encode_surface("TTTG"))[3] == SURFACE_GRASS
+
+
+def test_encode_roundtrip_all_known() -> None:
+    codes = wheel_codes(encode_surface("TCDG"))
+    assert codes == (1, 2, 3, 4)
+    assert wheel_codes(encode_surface("SsTT"))[:2] == (5, 6)
+
+
+def test_unknown_char_maps_to_other_not_loose() -> None:
+    value = encode_surface("XXXX")
+    assert wheel_codes(value) == (SURFACE_OTHER,) * 4
+    assert loose_wheel_count(value) == 0
+
+
+def test_loose_wheel_count() -> None:
+    assert loose_wheel_count(TTTT) == 0
+    assert loose_wheel_count(GGGG) == 4
+    assert loose_wheel_count(encode_surface("GGCT")) == 2
+
+
+# --- excursion counting -------------------------------------------------------
+
+
+def test_excursions_unknown_without_data() -> None:
+    assert off_track_excursions([]) == -1
+    assert off_track_excursions([0.0] * 100) == -1
+
+
+def test_excursions_clean_lap() -> None:
+    col = [float(TTTT)] * 50 + [float(encode_surface("CTCT"))] * 10
+    assert off_track_excursions(col) == 0
+
+
+def test_excursion_counted_once_per_run() -> None:
+    col = (
+        [float(TTTT)] * 20
+        + [float(encode_surface("GGGT"))] * (OFF_TRACK_MIN_TICKS + 5)
+        + [float(TTTT)] * 20
+    )
+    assert off_track_excursions(col) == 1
+
+
+def test_short_flicker_not_an_excursion() -> None:
+    col = (
+        [float(TTTT)] * 20
+        + [float(GGGG)] * (OFF_TRACK_MIN_TICKS - 1)
+        + [float(TTTT)] * 20
+    )
+    assert off_track_excursions(col) == 0
+
+
+def test_two_wheels_on_grass_is_not_off_track() -> None:
+    col = [float(encode_surface("GGTT"))] * 100
+    assert off_track_excursions(col) == 0
+
+
+def test_separate_runs_count_separately() -> None:
+    burst = [float(GGGG)] * OFF_TRACK_MIN_TICKS
+    clean = [float(TTTT)] * 10
+    assert off_track_excursions(clean + burst + clean + burst + clean) == 2
+
+
+# --- lap integration ----------------------------------------------------------
+
+
+class Collector:
+    def __init__(self) -> None:
+        self.laps: list[CompletedLap] = []
+        self.sessions: list[SessionInfo] = []
+
+    async def on_lap(self, lap: CompletedLap) -> None:
+        self.laps.append(lap)
+
+    async def on_session(self, info: SessionInfo) -> None:
+        self.sessions.append(info)
+
+
+@pytest.fixture
+def setup() -> tuple[LapProcessor, Collector]:
+    c = Collector()
+    return LapProcessor(on_lap=c.on_lap, on_session=c.on_session, min_lap_ticks=1), c
+
+
+async def test_surface_column_recorded_and_lap_judged(setup) -> None:
+    proc, c = setup
+    for _ in range(30):
+        await proc.feed(make_packet(current_lap=1, fmt="C", surface_types="TTTT"))
+    for _ in range(OFF_TRACK_MIN_TICKS + 2):
+        await proc.feed(make_packet(current_lap=1, fmt="C", surface_types="GGGG"))
+    for _ in range(30):
+        await proc.feed(make_packet(current_lap=1, fmt="C", surface_types="TTTT"))
+    await proc.feed(
+        make_packet(current_lap=2, last_lap_time_ms=61_000, fmt="C", surface_types="TTTT")
+    )
+    assert len(c.laps) == 1
+    lap = c.laps[0]
+    assert lap.samples["surface"][0] == float(TTTT)
+    assert float(GGGG) in lap.samples["surface"]
+    assert lap.off_track_count == 1
+    assert lap.clean_lap is False
+
+
+async def test_lap_without_surface_data_is_unknown(setup) -> None:
+    proc, c = setup
+    for _ in range(30):
+        await proc.feed(make_packet(current_lap=1))  # format A: no surface
+    await proc.feed(make_packet(current_lap=2, last_lap_time_ms=61_000))
+    lap = c.laps[0]
+    assert set(lap.samples["surface"]) == {float(SURFACE_NONE)}
+    assert lap.off_track_count == -1
+    assert lap.clean_lap is None
+
+
+# --- resampling ----------------------------------------------------------------
+
+
+def test_surface_resamples_nearest_not_interpolated() -> None:
+    samples = {
+        "dist": [0.0, 10.0, 20.0, 30.0],
+        "surface": [float(TTTT), float(TTTT), float(GGGG), float(GGGG)],
+    }
+    out = resample_by_distance(samples, step=5.0, columns=("surface",))
+    assert set(out["surface"]) <= {float(TTTT), float(GGGG)}
+
+
+# --- live survey (issue #37) ----------------------------------------------------
+
+
+def test_survey_records_transition_with_contacts(tmp_path) -> None:
+    import json
+    import math
+
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6, track="Suzuka Circuit", session_id=7)
+    common = dict(
+        fmt="C", position=(100.0, 2.0, 50.0), velocity=(20.0, 0.0, 10.0),
+        speed_mps=22.4, wheelbase_m=2.6,
+    )
+    assert survey.feed(make_packet(surface_types="TTTT", packet_id=1, **common)) is None
+    record = survey.feed(make_packet(surface_types="CTTT", packet_id=2, **common))
+    assert record is not None
+    assert record["changed"] == ["FL"]
+    contacts = record["contacts"]
+    assert contacts is not None
+    # Every contact sits one (wheelbase/2, track/2) diagonal from the car.
+    expected = math.hypot(2.6 / 2, 1.6 / 2)
+    for x, z in contacts.values():
+        assert math.hypot(x - 100.0, z - 50.0) == pytest.approx(expected, rel=1e-3)
+    # Front contacts lead the car along its velocity (positive projection).
+    vx, vz = 20.0, 10.0
+    assert (contacts["FL"][0] - 100.0) * vx + (contacts["FL"][1] - 50.0) * vz > 0
+    assert (contacts["RL"][0] - 100.0) * vx + (contacts["RL"][1] - 50.0) * vz < 0
+
+    survey.stop()
+    assert survey.log_path is not None
+    lines = survey.log_path.read_text().splitlines()
+    # Self-describing log: a meta header (the track-width assumption is
+    # invisible in the derived records), then one line per transition.
+    assert len(lines) == 2
+    meta = json.loads(lines[0])["meta"]
+    assert meta["track"] == "Suzuka Circuit"
+    assert meta["session_id"] == 7
+    assert meta["track_width_m"] == 1.6
+    assert json.loads(lines[1])["to"] == "CTTT"
+    assert json.loads(lines[1])["session_id"] == 7
+    status = survey.status()
+    assert status["transitions"] == 1
+    assert status["track"] == "Suzuka Circuit"
+    assert status["histogram"]["FL"] == {"T": 1, "C": 1}
+    assert status["recent"][0]["n"] == 1
+
+
+def test_survey_trail_breadcrumbs(tmp_path) -> None:
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    for i in range(101):  # 0.5 m steps, 50 m total
+        survey.feed(make_packet(
+            fmt="C", surface_types="TTTT", packet_id=i, position=(i * 0.5, 0.0, 0.0),
+        ))
+    status = survey.status()
+    # One point per >= 2 m of travel, plus the starting point.
+    assert 24 <= status["trail_points"] <= 27
+    assert survey.trail[0] == [0.0, 0.0]
+    assert survey.trail[-1][0] == pytest.approx(50.0, abs=2.0)
+    survey.stop()
+
+
+def test_survey_width_measured_from_kerb_rides(tmp_path) -> None:
+    """Riding all four wheels over an edge and back measures the axle width."""
+    import math
+
+    from app.processing.survey import SurfaceSurvey
+
+    tw_true, wb, speed, z_edge = 1.5, 2.6, 40.0, 1.0
+    angle = math.radians(6)  # shallow approach, like a real kerb ride
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.9)  # deliberately wrong assumption
+
+    # (a, b) per wheel as in the production contact formula: contact =
+    # P + a·f + b·(tw/2)·r with r = (f_z, -f_x); left wheels have b = -1.
+    wheel_geometry = ((wb / 2, -1), (wb / 2, 1), (-wb / 2, -1), (-wb / 2, 1))
+
+    px = pz = 0.0
+    pid = 0
+    for _ride in range(3):  # angle in, angle out, then run straight
+        for heading, ticks in ((angle, 60), (-angle, 60), (0.0, 40)):
+            fx, fz = math.cos(heading), math.sin(heading)
+            for _ in range(ticks):
+                pid += 1
+                px += fx * speed / 60
+                pz += fz * speed / 60
+                surface = "".join(
+                    "C" if pz + a * fz + b * (tw_true / 2) * -fx > z_edge else "T"
+                    for a, b in wheel_geometry
+                )
+                survey.feed(make_packet(
+                    fmt="C", surface_types=surface, packet_id=pid,
+                    position=(px, 0.0, pz), velocity=(speed * fx, 0.0, speed * fz),
+                    speed_mps=speed, wheelbase_m=wb,
+                ))
+
+    status = survey.status()
+    # Every ride yields at least one accepted measurement (crossings of
+    # adjacent rides inside the pairing window can add extra, equally valid
+    # ones), and the measured width replaces the (wrong) assumption.
+    assert status["width_samples"] >= 3
+    assert status["width_estimate_m"] == pytest.approx(tw_true, abs=0.15)
+    assert status["width_in_use_m"] == pytest.approx(tw_true, abs=0.15)
+    assert status["recent"][-1]["tw_m"] is not None
+    survey.stop()
+
+
+def test_survey_width_rejects_strip_crossings(tmp_path) -> None:
+    """Crossing a two-edged stripe is NOT a width measurement.
+
+    The out/back crossings land on two different (parallel) lines, so the
+    fitted "edge" is bogus — the group must be rejected, not mismeasured.
+    """
+    import math
+
+    from app.processing.survey import SurfaceSurvey
+
+    tw_true, wb = 1.5, 2.6
+    nx = nz = math.sqrt(0.5)  # stripe edges at 45° to the direction of travel
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.9)
+    offsets = (  # (dx, dz), FL FR RL RR with f=(1,0) so r=(0,-1)
+        (wb / 2, tw_true / 2), (wb / 2, -tw_true / 2),
+        (-wb / 2, tw_true / 2), (-wb / 2, -tw_true / 2),
+    )
+    for i in range(260):
+        px = 5.0 * i / 60.0
+        surface = "".join(
+            "G" if 4.0 < nx * (px + dx) + nz * dz < 8.0 else "T"
+            for dx, dz in offsets
+        )
+        survey.feed(make_packet(
+            fmt="C", surface_types=surface, packet_id=i,
+            position=(px, 0.0, 0.0), velocity=(5.0, 0.0, 0.0),
+            speed_mps=5.0, wheelbase_m=wb,
+        ))
+    status = survey.status()
+    assert status["width_samples"] == 0
+    assert status["width_in_use_m"] == 1.9  # assumption stays in force
+    survey.stop()
+
+
+def test_survey_width_falls_back_to_assumption(tmp_path) -> None:
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.7)
+    survey.feed(make_packet(fmt="C", surface_types="TTTT", packet_id=1))
+    status = survey.status()
+    assert status["width_estimate_m"] is None
+    assert status["width_in_use_m"] == 1.7
+    survey.stop()
+
+
+def test_survey_flags_unknown_chars_and_non_c_packets(tmp_path) -> None:
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    survey.feed(make_packet(fmt="C", surface_types="TTTW", packet_id=1))
+    assert survey.status()["unknown_chars"] == {"W": 1}
+    survey.feed(make_packet(packet_id=2))  # format A: no surface data
+    assert survey.status()["no_surface_packets"] == 1
+    survey.stop()
+    assert survey.status()["active"] is False
+
+
+def test_survey_border_side_tagging() -> None:
+    """One side on kerb/loose + other side fully on tarmac = that border."""
+    from app.processing.survey import _border_side
+
+    assert _border_side("TTTT", "CTTT") == "L"  # FL onto kerb
+    assert _border_side("CTTT", "TTTT") == "L"  # ...and back off it
+    assert _border_side("TTTT", "CTGT") == "L"  # FL kerb + RL grass together
+    assert _border_side("TTTT", "TCTT") == "R"  # FR onto kerb
+    assert _border_side("TTTT", "TTTG") == "R"  # RR onto grass
+    # Both sides involved, or the opposite side already off tarmac: no claim.
+    assert _border_side("TTTT", "CCTT") is None
+    assert _border_side("TGTT", "CGTT") is None  # FR was on grass already
+    assert _border_side("GGGG", "GGGG") is None  # nothing changed
+
+
+def test_survey_transition_carries_border(tmp_path) -> None:
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    survey.feed(make_packet(fmt="C", surface_types="TTTT", packet_id=1))
+    record = survey.feed(make_packet(fmt="C", surface_types="TTGT", packet_id=2))
+    assert record is not None
+    assert record["border"] == "L"  # RL is a left-side wheel
+    survey.stop()
+
+
+def test_survey_width_rejects_two_sided_lane_weave(tmp_path) -> None:
+    """Weaving a narrow lane with grass on BOTH sides must not be accepted:
+    left and right wheels cross different parallel boundaries, and solving
+    across them yields the lane separation, not the axle width."""
+    import math
+
+    from app.processing.survey import SurfaceSurvey
+
+    tw_true, wb, speed = 1.5, 2.6, 20.0
+    angle = math.radians(8)
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.7)
+    wheel_geometry = ((wb / 2, -1), (wb / 2, 1), (-wb / 2, -1), (-wb / 2, 1))
+
+    # Oscillate pz between ±0.8 on a lane with grass beyond |z| > 1.05:
+    # both LEFT wheels dip into the left grass at the top of each swing and
+    # both RIGHT wheels into the right grass at the bottom — two different
+    # parallel boundaries sharing one T<->G signature, never a full cross.
+    px = pz = 0.0
+    pid = 0
+    segments = [(angle, 17)] + [(-angle, 34), (angle, 34)] * 3
+    for heading, ticks in segments:
+        fx, fz = math.cos(heading), math.sin(heading)
+        for _ in range(ticks):
+            pid += 1
+            px += fx * speed / 60
+            pz += fz * speed / 60
+            surface = ""
+            for a, b in wheel_geometry:
+                cz = pz + a * fz + b * (tw_true / 2) * -fx
+                surface += "G" if abs(cz) > 1.05 else "T"
+            survey.feed(make_packet(
+                fmt="C", surface_types=surface, packet_id=pid,
+                position=(px, 0.0, pz), velocity=(speed * fx, 0.0, speed * fz),
+                speed_mps=speed, wheelbase_m=wb,
+            ))
+    status = survey.status()
+    assert status["transitions"] > 0  # the weave produced boundary evidence...
+    assert status["width_samples"] == 0  # ...but no width measurement
+    assert status["width_in_use_m"] == 1.7  # the assumption stays in force
+    survey.stop()
+
+
+def test_survey_track_set_mid_run_reaches_the_jsonl(tmp_path) -> None:
+    """A label identified after start must land in the log — the offline
+    artifact has to stay joinable to a circuit on its own."""
+    import json
+
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)  # circuit not yet identified
+    assert survey.track_locked is False
+    survey.set_track("Deep Forest Raceway")
+    survey.stop()
+    assert survey.log_path is not None
+    lines = [json.loads(line) for line in survey.log_path.read_text().splitlines()]
+    assert {"track": "Deep Forest Raceway"} in lines
+
+    # A user-typed label is locked; service wiring must not overwrite it.
+    survey2 = SurfaceSurvey()
+    survey2.start(tmp_path, track_width_m=1.6, track="My Circuit", track_user_set=True)
+    assert survey2.track_locked is True
+    survey2.stop()
+
+
+def test_survey_manual_marks_logged_even_past_memory_cap(tmp_path, monkeypatch) -> None:
+    import json
+
+    from app.processing import survey as survey_mod
+
+    monkeypatch.setattr(survey_mod, "EDGES_MAX_POINTS", 1)
+    survey = survey_mod.SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    survey.set_mark("L", "wall")
+    for i in range(13):  # 6 m of travel: several mark points past the cap
+        survey.feed(make_packet(
+            fmt="C", surface_types="TTTT", packet_id=i, position=(i * 0.5, 0.0, 0.0),
+            velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6,
+        ))
+    assert len(survey.edges) == 1  # memory capped...
+    survey.stop()
+    assert survey.log_path is not None
+    marks = [line for line in survey.log_path.read_text().splitlines()
+             if set(json.loads(line)) == {"mark"}]
+    assert len(marks) >= 3  # ...but the JSONL kept every manual point
+
+
+def test_survey_straddle_traces_border_continuously(tmp_path) -> None:
+    """A lap driven with one side's wheels held off the track must trace
+    that border the whole way, not only at the surface-flip moments."""
+    import json
+
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    common = dict(velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6)
+    # 20 m with both LEFT wheels (FL, RL) on grass, right side on tarmac.
+    for i in range(41):
+        survey.feed(make_packet(
+            fmt="C", surface_types="GTGT", packet_id=i,
+            position=(i * 0.5, 0.0, 0.0), **common,
+        ))
+    straddles = [e for e in survey.edges if e["kind"] == "straddle"]
+    # One point per >= 2 m of travel, on the LEFT wheel line: with f=(1,0)
+    # the right vector is (0,-1), so the left side sits at z = +0.8.
+    assert 9 <= len(straddles) <= 11
+    assert all(e["side"] == "L" and e["z"] == pytest.approx(0.8) for e in straddles)
+
+    # Fully off (all four on grass) is an excursion, not a border underneath.
+    for i in range(41, 61):
+        survey.feed(make_packet(
+            fmt="C", surface_types="GGGG", packet_id=i,
+            position=(i * 0.5, 0.0, 0.0), **common,
+        ))
+    assert len([e for e in survey.edges if e["kind"] == "straddle"]) == len(straddles)
+
+    # Mirrored: right wheels off -> right border at z = -0.8.
+    for i in range(61, 102):
+        survey.feed(make_packet(
+            fmt="C", surface_types="TGTG", packet_id=i,
+            position=(i * 0.5, 0.0, 0.0), **common,
+        ))
+    rights = [e for e in survey.edges if e["kind"] == "straddle" and e["side"] == "R"]
+    assert 9 <= len(rights) <= 11
+    assert all(e["z"] == pytest.approx(-0.8) for e in rights)
+
+    survey.stop()
+    # Straddle points are not reconstructable from transitions — they must
+    # be in the JSONL like manual marks. (Mark LINES are the single-key
+    # {"mark": {...}} wrappers; transition records also have a "mark" field.)
+    assert survey.log_path is not None
+    logged = [json.loads(line)["mark"]
+              for line in survey.log_path.read_text().splitlines()
+              if set(json.loads(line)) == {"mark"}]
+    assert len(logged) == len(straddles) + len(rights)
+    assert all(m["kind"] == "straddle" for m in logged)
+
+
+def test_survey_accumulates_edge_points(tmp_path) -> None:
+    """Border-tagged transitions grow the run-long edge list, lap after lap."""
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    common = dict(fmt="C", velocity=(20.0, 0.0, 0.0), speed_mps=20.0, wheelbase_m=2.6)
+    survey.feed(make_packet(surface_types="TTTT", packet_id=1,
+                            position=(0.0, 0.0, 0.0), **common))
+    survey.feed(make_packet(surface_types="CTTT", packet_id=2,  # FL on, L
+                            position=(5.0, 0.0, 0.0), **common))
+    survey.feed(make_packet(surface_types="TTTT", packet_id=3,  # FL off, L
+                            position=(10.0, 0.0, 0.0), **common))
+    status = survey.status()
+    assert status["edge_points"] == 2
+    # A repeat contact on the same meter of boundary is not new evidence.
+    survey.feed(make_packet(surface_types="CTTT", packet_id=4,
+                            position=(10.0, 0.0, 0.0), **common))
+    assert survey.status()["edge_points"] == 2
+    assert all(e["side"] == "L" and e["kind"] == "auto" for e in survey.edges)
+    # A deep excursion (both sides off) must add no bogus perimeter evidence.
+    survey.feed(make_packet(surface_types="GGGG", packet_id=4, **common))
+    assert survey.status()["edge_points"] == 2
+    survey.stop()
+
+
+def test_survey_manual_marking_traces_the_driven_line(tmp_path) -> None:
+    """Armed marking samples the boundary from the wheel line — the only way
+    to map walls and paved run-off, which surface chars cannot see."""
+    import json
+
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    survey.set_mark("R", "wall")
+    for i in range(31):  # 0.5 m per tick, 15 m of travel along +x
+        survey.feed(make_packet(
+            fmt="C", surface_types="TTTT", packet_id=i,
+            position=(i * 0.5, 0.0, 0.0), velocity=(30.0, 0.0, 0.0),
+            speed_mps=30.0, wheelbase_m=2.6,
+        ))
+    status = survey.status()
+    assert status["mark_side"] == "R"
+    assert status["mark_kind"] == "wall"
+    # One point per >= 2 m of travel, all on the right wheel line: with
+    # f=(1,0) the right vector is (0,-1), so right side sits at z = -0.8.
+    walls = [e for e in survey.edges if e["kind"] == "wall"]
+    assert 7 <= len(walls) <= 9
+    assert all(e["side"] == "R" and e["z"] == pytest.approx(-0.8) for e in walls)
+    survey.set_mark(None, "edge")
+    survey.feed(make_packet(
+        fmt="C", surface_types="TTTT", packet_id=40, position=(30.0, 0.0, 0.0),
+        velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6,
+    ))
+    assert survey.status()["edge_points"] == len(walls)  # disarmed: no growth
+    survey.stop()
+    # Manual points exist nowhere else, so they must be in the JSONL too.
+    assert survey.log_path is not None
+    marks = [json.loads(line)["mark"]
+             for line in survey.log_path.read_text().splitlines()
+             if set(json.loads(line)) == {"mark"}]
+    assert len(marks) == len(walls)
+    assert marks[0]["kind"] == "wall"
+
+
+def test_survey_locates_finish_line_from_lap_rollovers(tmp_path) -> None:
+    import json
+
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    common = dict(fmt="C", surface_types="TTTT", velocity=(40.0, 0.0, 0.0),
+                  speed_mps=40.0)
+
+    def cruise(pid: int, lap: int, x: float) -> None:
+        survey.feed(make_packet(packet_id=pid, current_lap=lap, position=(x, 0.0, 5.0),
+                                **common))
+
+    cruise(1, 1, 100.0)
+    assert survey.status()["finish"] is None  # no rollover seen yet
+    cruise(2, 2, 200.0)  # lap 1 -> 2: first crossing, provisional
+    finish = survey.status()["finish"]
+    assert finish is not None
+    assert finish["crossings"] == 1 and finish["confident"] is False
+    assert finish["x"] == pytest.approx(200.0)
+    cruise(3, 2, 300.0)
+    cruise(4, 3, 204.0)  # lap 2 -> 3 four meters from the first crossing
+    finish = survey.status()["finish"]
+    assert finish["crossings"] == 2
+    assert finish["confident"] is True
+    assert finish["x"] == pytest.approx(202.0)  # mean of the two
+    assert finish["hx"] == pytest.approx(1.0)
+
+    # Counter falling back (restart) and 0 -> 1 (grid start) must not count.
+    cruise(5, 1, 400.0)
+    cruise(6, 1, 401.0)
+    survey.feed(make_packet(packet_id=7, current_lap=0, position=(402.0, 0.0, 5.0), **common))
+    cruise(8, 1, 403.0)
+    assert survey.status()["finish"]["crossings"] == 2
+
+    survey.stop()
+    assert survey.log_path is not None
+    logged = [json.loads(line)["finish"]
+              for line in survey.log_path.read_text().splitlines()
+              if set(json.loads(line)) == {"finish"}]
+    assert len(logged) == 2
+
+
+def test_track_bundle_merge_dedups_on_grid() -> None:
+    from app.processing.track_bundle import merge_edges
+
+    a = {"x": 10.0, "z": 5.0, "hx": 1.0, "hz": 0.0, "side": "L", "kind": "auto"}
+    near_a = {**a, "x": 10.3}  # same 1 m cell -> duplicate evidence
+    far = {**a, "x": 14.0}
+    other_kind = {**a, "kind": "wall"}
+    other_side = {**a, "side": "R"}
+    merged = merge_edges([a], [near_a, far, other_kind, other_side])
+    assert a in merged and far in merged and other_kind in merged and other_side in merged
+    assert near_a not in merged
+    assert len(merged) == 4
+
+
+def test_survey_bundle_persists_track_knowledge_across_runs(tmp_path) -> None:
+    """Restarting the app or the session must not restart the map."""
+    from app.processing.survey import SurfaceSurvey
+    from app.processing.track_bundle import bundle_path, load
+
+    common = dict(fmt="C", velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6)
+
+    # Run 1: straddle-trace 20 m of left border, cross the line twice.
+    one = SurfaceSurvey()
+    one.start(tmp_path, track_width_m=1.6, track="Test Ring", track_user_set=True)
+    assert one.bundle_info is None  # fresh circuit
+    for i in range(41):
+        one.feed(make_packet(surface_types="GTGT", packet_id=i, current_lap=1,
+                             position=(i * 0.5, 0.0, 0.0), **common))
+    one.feed(make_packet(surface_types="TTTT", packet_id=50, current_lap=2,
+                         position=(30.0, 0.0, 0.0), **common))
+    one.feed(make_packet(surface_types="TTTT", packet_id=51, current_lap=3,
+                         position=(31.0, 0.0, 0.0), **common))
+    run1_edges = len(one.edges)
+    one.stop()
+    assert bundle_path(tmp_path, "Test Ring").exists()
+
+    # Run 2 (fresh process): the map opens with run 1's knowledge...
+    two = SurfaceSurvey()
+    two.start(tmp_path, track_width_m=1.6, track="Test Ring", track_user_set=True)
+    assert two.bundle_info is not None
+    assert two.bundle_info["runs"] == 1
+    assert len(two.edges) == run1_edges
+    assert two.status()["finish"] is not None  # crossings carried over too
+    # ...re-driving the same stretch does not grow it (grid dedup)...
+    for i in range(41):
+        two.feed(make_packet(surface_types="GTGT", packet_id=i, current_lap=1,
+                             position=(i * 0.5, 0.05, 0.0), **common))
+    assert len(two.edges) == run1_edges
+    # ...but new ground does.
+    for i in range(50, 91):
+        two.feed(make_packet(surface_types="TGTG", packet_id=i, current_lap=1,
+                             position=(i * 0.5, 0.0, 0.0), **common))
+    assert len(two.edges) > run1_edges
+    two.stop()
+    doc = load(tmp_path, "Test Ring")
+    assert doc is not None
+    assert doc["meta"]["runs"] == 2
+    assert len(doc["edges"]) == len(two.edges)
+
+
+def test_survey_autosaves_bundle_periodically(tmp_path, monkeypatch) -> None:
+    """A reload or hard kill mid-run must never lose more than ~a minute —
+    graceful shutdowns can't be relied on (dev reloads killed real runs)."""
+    from app.processing import survey as survey_mod
+    from app.processing.track_bundle import load
+
+    monkeypatch.setattr(survey_mod, "AUTOSAVE_PACKETS", 10)
+    survey = survey_mod.SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6, track="Auto Ring", track_user_set=True)
+    common = dict(fmt="C", velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6)
+    for i in range(15):  # crosses the autosave threshold with edges present
+        survey.feed(make_packet(surface_types="GTGT", packet_id=i,
+                                position=(i * 0.5, 0.0, 0.0), **common))
+    # NO stop() — simulating the process being killed.
+    doc = load(tmp_path, "Auto Ring")
+    assert doc is not None
+    assert len(doc["edges"]) > 0
+    assert doc["meta"]["runs"] == 0  # autosaves don't count as finished runs
+    survey.stop()
+    doc = load(tmp_path, "Auto Ring")
+    assert doc is not None and doc["meta"]["runs"] == 1
+
+
+def test_survey_circuit_change_never_pollutes_another_bundle(tmp_path) -> None:
+    from app.processing.survey import SurfaceSurvey
+    from app.processing.track_bundle import load
+
+    common = dict(fmt="C", velocity=(30.0, 0.0, 0.0), speed_mps=30.0, wheelbase_m=2.6)
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)  # unidentified at start
+    survey.set_track("Circuit A")
+    for i in range(21):
+        survey.feed(make_packet(surface_types="GTGT", packet_id=i,
+                                position=(i * 0.5, 0.0, 0.0), **common))
+    a_points = len(survey.edges)
+    assert a_points > 0
+    # Session restart -> label back to unknown -> a DIFFERENT circuit loads.
+    survey.set_track("")
+    assert survey.edges == []  # A's evidence flushed to A's bundle, not kept
+    survey.set_track("Circuit B")
+    for i in range(30, 51):
+        survey.feed(make_packet(surface_types="TGTG", packet_id=i,
+                                position=(1000 + i * 0.5, 0.0, 0.0), **common))
+    survey.stop()
+    doc_a = load(tmp_path, "Circuit A")
+    doc_b = load(tmp_path, "Circuit B")
+    assert doc_a is not None and len(doc_a["edges"]) == a_points
+    assert doc_b is not None
+    assert all(e["x"] >= 1000 for e in doc_b["edges"])  # nothing of A leaked
+
+
+def test_survey_watches_undocumented_flag_bits(tmp_path) -> None:
+    """No track-limits field is known; upper flag bits activating is a finding."""
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    survey.feed(make_packet(fmt="C", surface_types="TTTT", packet_id=1))
+    assert survey.status()["unknown_flag_bits"] == {}
+    flags = int(SimulatorFlags.CAR_ON_TRACK) | (1 << 13)
+    for pid in (2, 3):
+        survey.feed(make_packet(fmt="C", surface_types="TTTT", packet_id=pid, flags=flags))
+    assert survey.status()["unknown_flag_bits"] == {"13": 2}
+    survey.stop()

--- a/backend/tests/test_surface.py
+++ b/backend/tests/test_surface.py
@@ -727,6 +727,24 @@ def test_survey_circuit_change_never_pollutes_another_bundle(tmp_path) -> None:
     assert all(e["x"] >= 1000 for e in doc_b["edges"])  # nothing of A leaked
 
 
+def test_survey_transition_survives_speed_velocity_mismatch(tmp_path) -> None:
+    """speed_mps and the velocity vector are separate packet fields; a
+    packet reporting speed with a zero ground-plane velocity must degrade
+    to contacts=None, not divide by zero in the 60 Hz feed path."""
+    from app.processing.survey import SurfaceSurvey
+
+    survey = SurfaceSurvey()
+    survey.start(tmp_path, track_width_m=1.6)
+    common = dict(fmt="C", speed_mps=5.0, velocity=(0.0, 0.0, 0.0), wheelbase_m=2.6)
+    survey.feed(make_packet(surface_types="TTTT", packet_id=1, **common))
+    record = survey.feed(make_packet(surface_types="CTTT", packet_id=2, **common))
+    assert record is not None
+    assert record["contacts"] is None
+    assert record["heading_rad"] is None
+    assert record["border"] == "L"  # the transition itself is still recorded
+    survey.stop()
+
+
 def test_survey_watches_undocumented_flag_bits(tmp_path) -> None:
     """No track-limits field is known; upper flag bits activating is a finding."""
     from app.processing.survey import SurfaceSurvey

--- a/docs/internals/derived-channels.md
+++ b/docs/internals/derived-channels.md
@@ -28,6 +28,7 @@ One value per column per tick (~60/s):
 | `tt_fl/fr/rl/rr` | raw tire temps | °C |
 | `sus_fl/fr/rl/rr` | `suspension_travel × 1000` | mm |
 | `aids` | bitmask: TCS=1, ASM=2, handbrake=4, rev limiter=8 | mask |
+| `surface` | per-wheel surface codes, 4 bits each, FL in the lowest nibble (0 = no data, 1 = tarmac, 2 = kerb, 3 = dirt, 4 = grass, 5 = sand, 6 = snow, 7 = other) — packet C only | mask |
 
 **Wheel slip** is a slip-ratio proxy: wheel surface speed divided by car speed. `< 1`
 under braking means the wheel is locking; `> 1` under power means it's spinning. Below
@@ -47,6 +48,8 @@ Computed once when the lap is saved (`n` = number of samples):
 | Max speed | `max(speed)` km/h |
 | Min body height | `min(body_height)` mm |
 | TCS / ASM active % | `100 × count(aid bit set) ÷ n` |
+| Off-track count | excursions where ≥ 3 wheels sat on a loose surface for ≥ 6 ticks; `-1` = unknown (no surface data) |
+| Clean lap | `off_track_count == 0`; `null` = unknown — distinct from `counts_for_best`, which flags partial pit out-laps |
 
 **Engine health** is tracked as running per-lap extremes rather than per-tick columns
 (these values drift over minutes, not corners):

--- a/docs/internals/surface-survey.md
+++ b/docs/internals/surface-survey.md
@@ -1,0 +1,179 @@
+# Surface survey spike (findings note)
+
+Phase 0 of the track-survey work ([#35](https://github.com/jbhoorasingh/gt7-datalogger/issues/35),
+spike [#37](https://github.com/jbhoorasingh/gt7-datalogger/issues/37)): validate
+the `surface_types` encoding and the wheel-contact derivation on a **real PS5**
+before designing the per-track classification grid
+([#38](https://github.com/jbhoorasingh/gt7-datalogger/issues/38)). The bundled
+simulator proves nothing here — it only ever emits `T` and `C`.
+
+**Status: template — run the spike on real hardware and fill in the tables.**
+
+## How to run it
+
+Open the **Survey** tab in the app (with the console on packet format C, the
+default), pick the circuit being surveyed (defaults to the session's
+auto-identified track) and press **Start survey**. The capture runs
+server-side in the 60 Hz packet path (`app/processing/survey.py`) — the
+browser's ~30 Hz live stream would miss single-tick transitions — so any
+phone or tablet on the LAN works as the display while you drive. Lap
+recording continues alongside: laps saved during the run keep their per-tick
+surface column, and the JSONL records carry the session id and lap number so
+both datasets join up offline.
+
+Drive a few laps that deliberately touch every surface the track offers —
+kerbs on both sides, painted run-off, grass, gravel traps, sand if the track
+has it. The view shows the live per-wheel surface, the char histogram, a
+loud banner for any char the mapping doesn't know, and each transition's
+derived wheel-contact points on a scatter map. **Download JSONL** grabs the
+full transition log (position, velocity, raw orientation floats, per-wheel
+contact points) for offline analysis; the server also keeps it next to the
+database as `data/surface_survey_<timestamp>.jsonl`.
+
+Suggested tracks for coverage: one kerb-heavy road course (e.g. Suzuka or
+Interlagos), one with gravel traps (Monza / Red Bull Ring), one dirt track
+(Fisherman's Ranch) and, if snow chars are real, Lake Louise.
+
+## 1. Surface enum (fill in)
+
+The decoder ([`packet.py`](https://github.com/jbhoorasingh/gt7-datalogger/blob/main/backend/app/telemetry/packet.py))
+reads 4 ASCII chars, one per wheel, FL FR RL RR. Community docs claim
+`T / C / D / G / S / s`; `app/processing/surface.py` maps exactly those and
+flags anything else as `SURFACE_OTHER`.
+
+| Char | Assumed meaning | Confirmed on PS5? | Where seen (track / feature) |
+|------|-----------------|-------------------|------------------------------|
+| `T`  | tarmac          | ☐                 |                              |
+| `C`  | curb / kerb     | ☐                 |                              |
+| `D`  | dirt            | ☐                 |                              |
+| `G`  | grass           | ☐                 |                              |
+| `S`  | sand            | ☐                 |                              |
+| `s`  | snow            | ☐                 |                              |
+| ?    | *(new chars the spike reports)* | | |
+
+Open questions to answer while driving:
+
+- Does **painted** run-off / painted kerb flat report `T`, `C`, or something new?
+- Gravel trap vs dirt vs sand — distinct chars or all one?
+- Is the per-wheel ordering really FL FR RL RR? (Clip one specific wheel over
+  a kerb and check which position flips.)
+- **Does GT7 broadcast its own track-limits judgment anywhere?** No packet
+  field is documented for it; the only place one could hide is the four
+  undocumented upper bits of the 16-bit flags field. The survey raises a
+  banner if any of bits 12–15 ever activate, and every transition record
+  carries the raw flags — trigger an in-game track-limits warning (time
+  invalidated / penalty) during the run and check whether a bit correlates.
+
+## 2. Wheel-contact derivation (fill in)
+
+Contact point = car position + heading rotation of (±wheelbase/2, ±track/2).
+Wheelbase is broadcast in packet C; **track width is not** — the survey
+starts from an assumption (the input next to Start survey, default 1.6 m)
+and then **measures** it: ride all four wheels over one edge and back. The
+same wheel's out/back crossings pin the edge's direction, opposite-side
+crossings of the same line fix the width, and remaining same-side crossings
+must agree the points are collinear (which rejects two-edged strips, curved
+kerbs and mid-corner crossings). Once three rides agree, the measured median
+replaces the assumption for contact derivation — the status line shows which
+is in force, and every JSONL record carries the `tw_m` it was derived with.
+Heading comes from ground-plane velocity; the raw rotation floats +
+`rel_orientation_to_north` are logged for offline comparison.
+
+Method: drive slowly over a kerb whose edge is visible on the race-line map,
+one wheel at a time, from both directions. The transition record pins where
+GT7 thinks the wheel met the kerb; measure the offset between the derived
+contact point and the kerb edge across passes.
+
+| Question | Finding |
+|----------|---------|
+| Is the position field the car's midpoint (or an axle/CoG)? | |
+| Velocity-heading vs `rel_orientation_to_north` agreement | |
+| Right-vector sign `(f_z, -f_x)` correct, or mirrored? | |
+| Positional error at ~1.6 m assumed track width (narrow car) | ± __ m |
+| Positional error at ~1.6 m assumed track width (wide car, e.g. Gr.3) | ± __ m |
+| Lag between visible contact and the char flipping | __ ticks |
+
+## Border tagging and the paved-runoff problem
+
+Transitions where one side's wheels touch kerb/loose while the whole other
+side stays on tarmac are tagged `border: L/R` (relative to travel direction;
+left/right stays consistent lap after lap where inner/outer would swap at
+every corner). The survey map draws each border contact as a short edge
+tick along the local travel direction (blue = left, pink = right) — the two
+perimeters trace themselves — and wherever a left point has a right point
+directly across from it (perpendicular to travel, plausible road width
+apart, same direction of driving), the span between them is filled as
+confirmed road.
+
+Edge points accumulate **server-side for the whole run** and stream to the
+map incrementally, so the track genuinely appears lap by lap — reloading the
+page or surveying for an hour loses nothing (50k-point backstop; the JSONL
+always has everything).
+
+Track knowledge also outlives the run: each circuit's perimeter evidence and
+finish crossings merge into a **track bundle**
+(`data/track-bundles/<slug>.json`, grid-deduped to one point per meter so it
+converges instead of growing). A new survey on the same circuit resumes from
+its bundle — the map opens with everything ever mapped — and saves back on
+stop and on circuit changes (a run's evidence is flushed and cleared when
+the label changes, so one circuit can never pollute another's bundle).
+Bundles are versioned, self-describing documents downloadable via
+`/api/track-bundles/{slug}`, designed to graduate into their own repo and be
+imported at build time like `data/tracks.json`. Width calibration stays out:
+it belongs to the car, not the circuit.
+
+The **Track completeness** card answers "is it ready?": per-border coverage
+of the driven loop (percent + the largest remaining gap, i.e. where to
+drive next), road coverage where both borders are known, and the finish
+line — located from lap rollovers (GT7 increments the lap counter exactly
+on the line), drawn dashed after one crossing and solid once repeat
+crossings agree within meters.
+
+**Straddle tracing** is the workhorse: surface flips only pin the border at
+crossing moments, so a lap driven with one side's wheels HELD off the track
+would otherwise leave the border untraced between them. Instead, whenever
+both wheels of one side sit off the tarmac while the other side is fully on
+it, the survey samples a border point from the off-side wheel line every
+~2 m automatically. Survey recipe: one lap hugging the left edge with the
+left wheels just off, one lap mirrored on the right — both perimeters trace
+themselves continuously and the road fill appears between them.
+
+**Manual boundary marking** covers what surface chars cannot see: arm
+*Mark boundary: left/right* + a kind (*edge*, *run-off limit*, *wall*) and
+drive along the boundary — the survey records an edge point from that side's
+wheel line every ~2 m. Wall-lined track produces no surface transitions at
+all, and the outer limit of paved run-off reads as plain tarmac, so the
+driven line is the only reliable source for both. Marked points render in
+their own colors (purple = run-off limit, red = wall), are stamped into the
+JSONL as `mark` records, and run-off limits are excluded from the road fill
+(they bound the run-off, not the road).
+
+**Raw packet inspector**: the collapsible panel at the bottom of the Survey
+view shows every decoded packet field live (2 Hz), highlighting values that
+changed between samples — drive over anything interesting and call out what
+moves. Single-tick blips can slip between samples; the undocumented flag
+bits are watched server-side at 60 Hz regardless.
+
+**Paved runoff reads as plain `T`**, indistinguishable per tick from the
+racing surface. Things to establish on hardware, in order of leverage:
+
+1. **Does paint get its own char?** If the white boundary line or painted
+   run-off reports something other than `T`, the track edge is directly
+   observable and the problem mostly disappears. (Open question above.)
+2. If not: runoff tarmac is still *topologically* separated from racing
+   tarmac by the kerb/paint/loose band the border-tagged points trace. A
+   live per-wheel "crossed the band vs bounced back" verdict is genuinely
+   ambiguous (driving straight across an angled kerb produces zero lateral
+   displacement in the car frame — there is no local signal to project
+   against), so the honest solution is offline in the grid build (#38):
+   flood-fill tarmac cells from the racing corridor; tarmac regions
+   reachable only across a border band are runoff.
+
+## 3. Verdict → survey grid design (fill in)
+
+- Error bound on a wheel-contact sample: **± __ m** (lateral), **± __ m**
+  (longitudinal).
+- Recommended survey grid cell size for #38: **__ m** (expected 0.25–0.5 m —
+  it should comfortably exceed the error bound above).
+- Surface chars worth separate grid classes: ______
+- Encoding changes needed in `app/processing/surface.py`: ______

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -65,6 +65,25 @@ Delta values are milliseconds, **positive = slower than the reference**.
 | POST | `/api/control/recording` | `{"recording": bool}` — pause/resume lap recording |
 | POST | `/api/control/log-lap-now` | save the in-progress lap immediately (409 if none) |
 
+## Surface survey
+
+Runs the [surface survey](../internals/surface-survey.md) capture in the 60 Hz
+packet path (packet format C required for surface data).
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET | `/api/track-catalog` | official GT7 track/layout metadata (bundled `data/tracks.json`: 41 tracks, 85 layouts, lengths, corner counts, reverse configs) |
+| POST | `/api/survey/start` | `{track_width_m?, track?}` — start a run; resets counters, opens a new JSONL log; 409 if a run is already active. `track` labels which circuit the samples describe (default: the session's identified track; picked up mid-run if identification happens later, and a user-typed label is never auto-overwritten) |
+| POST | `/api/survey/stop` | stop and close the log |
+| GET | `/api/survey/status` | track/session the run is tied to, per-wheel char histogram, unknown chars, recent transitions, log path, undocumented flag-bit activity, the finish line located from lap rollovers (`finish`: mean crossing point/heading, crossing count, spread, confidence), and the track width in use — the entered assumption until enough out-and-back edge rides have measured the real axle width (`width_estimate_m`, `width_samples`) |
+| GET | `/api/survey/trail` | breadcrumb of the path driven (`since`/`epoch` for incremental fetch; the epoch bumps when the trail is decimated) |
+| GET | `/api/survey/edges` | every border-edge point of the run — the track taking shape (`since`/`epoch` incremental; append-only within a run). Kinds: `auto` (surface-flip contacts), `straddle` (sampled continuously while one side's wheels are held off the tarmac), `edge`/`runoff`/`wall` (manual marking) |
+| POST | `/api/survey/mark` | `{side: "L"\|"R"\|null, kind: "edge"\|"runoff"\|"wall"}` — arm manual boundary marking: while armed, the survey samples edge points from that side's wheel line every ~2 m, which is how walls and paved run-off limits (invisible to surface chars) get mapped |
+| GET | `/api/survey/packet` | the latest raw telemetry packet, fully decoded — the Survey view's field inspector polls this |
+| GET | `/api/track-bundles` | every circuit's accumulated survey bundle: track, slug, points, runs, finish crossings, updated_at |
+| GET | `/api/track-bundles/{slug}` | one bundle document (versioned `gt7-datalogger-track-bundle` JSON: perimeter edge points grid-deduped to 1 m, finish crossings) — the export unit for a future track-data repo |
+| GET | `/api/survey/export.jsonl` | full log of the current/last run (404 if none). First line is a `{"meta": ...}` header (track, session id, track-width assumption, wheel order); transition records carry the session id and lap, so they join back to the laps recorded during the same drive. Interleaved lines: `{"mark": ...}` for manually-marked boundary points and `{"track": ...}` when the circuit is identified mid-run |
+
 ## Admin
 
 | Method | Path | Purpose |
@@ -94,11 +113,16 @@ Server → browser:
   speed, RPM + redline, gear + suggested gear, throttle/brake %, boost, fuel level and
   capacity, lap counters, best/last lap, session best and previous best, race position,
   tire temps (FL/FR/RL/RR), tire slip, water/oil temps, oil pressure, driver-aids
-  bitmask (TCS=1, ASM=2, handbrake=4, rev limiter=8), car id/name, world position,
+  bitmask (TCS=1, ASM=2, handbrake=4, rev limiter=8), packed per-wheel surface
+  codes (4 bits per wheel, FL lowest; 0 = no data), car id/name, world position,
   in-game time of day, track name, on-track/paused flags.
 - **`lap`** — sent when a lap is saved: id, session, number, time, per-lap metrics, and
   event counts. The UI uses this to refresh lists live.
 - **`session`** — sent on new session, track identification, or track naming.
+- **`survey`** — one per-wheel surface transition while a survey is running:
+  from/to chars, changed wheels, position, velocity, heading, raw rotation
+  floats, and derived wheel-contact points (sent at full 60 Hz resolution —
+  these are single-tick events the throttled telemetry frames would miss).
 - **`status`** — sent on connect and whenever the source or console IP changes.
 - **`voice_callout`** — a Race Engineer callout: `id`, `event_type`, `text`,
   `category`, `priority` (0–100), `created_at_ms`, `expires_at_ms`, `ttl_ms`,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { EngineerView } from "@/views/EngineerView";
 import { LiveView } from "@/views/LiveView";
 import { OverlayView } from "@/views/OverlayView";
 import { SessionsView } from "@/views/SessionsView";
+import { SurveyView } from "@/views/SurveyView";
 import { useTelemetry } from "@/store/telemetry";
 
 function useRoute(): Route {
@@ -57,6 +58,7 @@ export default function App() {
           {route.view === "live" && <LiveView />}
           {route.view === "analysis" && <AnalysisView request={analysisRequest} />}
           {route.view === "sessions" && <SessionsView />}
+          {route.view === "survey" && <SurveyView />}
           {route.view === "admin" && <AdminView />}
         </main>
         <Toasts />

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -9,6 +9,7 @@ const TABS: { id: View; label: string }[] = [
   { id: "live", label: "Live" },
   { id: "analysis", label: "Analysis" },
   { id: "sessions", label: "Sessions" },
+  { id: "survey", label: "Survey" },
   { id: "admin", label: "Admin" },
 ];
 

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -8,9 +8,14 @@ import type * as echarts from "echarts";
 import type { EChartsOption, SeriesOption } from "echarts";
 import { useEffect, useMemo, useRef } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
-import type { CompareLapEntry } from "@/lib/types";
+import { type CompareLapEntry, kerbWheelCount, looseWheelCount } from "@/lib/types";
 
 const ZONE_COLORS = [CHART_COLORS.brake, CHART_COLORS.coast, CHART_COLORS.throttle];
+
+// Surface-contact halos under the reference line (packet-C recordings):
+// kerb strikes in yellow, wheels on grass/gravel/dirt in orange.
+const KERB_COLOR = "#eab308";
+const LOOSE_COLOR = "#f97316";
 
 // Numbered circles are readable up to about this many corners in view;
 // beyond that (or fully zoomed out on a long track) they collapse to dots.
@@ -133,6 +138,48 @@ export function RaceLineMap({
           },
         };
       });
+      // Surface halos, drawn beneath the input-zone dots. A kerb-only touch
+      // is routine; any loose-surface wheel is the interesting one, so loose
+      // wins when a sample has both (two wheels on the kerb, two on grass).
+      const surface = s.surface;
+      if (surface?.some((v) => v > 0)) {
+        const kerbPts: Array<{ value: number[]; itemStyle: { opacity: number } }> = [];
+        const loosePts: Array<{ value: number[]; itemStyle: { opacity: number } }> = [];
+        for (let i = 0; i < s.dist.length; i++) {
+          const v = surface[i] ?? 0;
+          const bucket =
+            looseWheelCount(v) > 0 ? loosePts : kerbWheelCount(v) > 0 ? kerbPts : null;
+          if (!bucket) continue;
+          const inZoom = zoomRange
+            ? s.dist[i] >= zoomRange[0] && s.dist[i] <= zoomRange[1]
+            : true;
+          bucket.push({
+            value: [s.pos_x[i], s.pos_z[i]],
+            itemStyle: { opacity: inZoom ? 0.55 : 0.1 },
+          });
+        }
+        series.push(
+          {
+            id: "surface-kerb",
+            type: "scatter",
+            data: kerbPts,
+            symbolSize: 8,
+            itemStyle: { color: KERB_COLOR },
+            silent: true,
+            z: 2.5,
+          },
+          {
+            id: "surface-loose",
+            type: "scatter",
+            data: loosePts,
+            symbolSize: 9,
+            itemStyle: { color: LOOSE_COLOR },
+            silent: true,
+            z: 2.6,
+          },
+        );
+      }
+
       const pv = ref.entry.peaks_valleys;
       const peaks = pv.peaks.filter(
         (p) => !zoomRange || (p.dist >= zoomRange[0] && p.dist <= zoomRange[1]),
@@ -252,6 +299,7 @@ export function RaceLineMap({
   }, [laps, cursorDist, step]);
 
   const others = laps.filter((lap) => !lap.isRef);
+  const hasSurface = !!ref?.entry.series.surface?.some((v) => v > 0);
 
   return (
     <div className="relative">
@@ -278,6 +326,24 @@ export function RaceLineMap({
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-coast" />coast</span>
         <span className="text-warn">▲ peak</span>
         <span className="text-[#c084fc]">▼ valley</span>
+        {hasSurface && (
+          <>
+            <span>
+              <i
+                className="mr-1 inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: KERB_COLOR }}
+              />
+              kerb
+            </span>
+            <span>
+              <i
+                className="mr-1 inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: LOOSE_COLOR }}
+              />
+              off-track
+            </span>
+          </>
+        )}
         {(ref?.entry.corners?.length ?? 0) > 0 && (
           <span>
             <i className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-ink-dim text-center align-middle text-[7px] leading-[9px]">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,7 +10,11 @@ import type {
   LogRecord,
   RaceEngineerDiagnostics,
   SessionSummary,
+  SurveyEdge,
+  SurveyStatus,
   Track,
+  TrackBundleInfo,
+  TrackCatalog,
   VoiceCallout,
 } from "./types";
 
@@ -85,7 +89,31 @@ export const api = {
     send<ConnectionStatus>("/api/control/recording", "POST", { recording }),
   logLapNow: () => send<{ id: number }>("/api/control/log-lap-now", "POST"),
 
+  survey: {
+    status: () => get<SurveyStatus>("/api/survey/status"),
+    start: (trackWidthM: number, track: string) =>
+      send<SurveyStatus>("/api/survey/start", "POST", {
+        track_width_m: trackWidthM,
+        track,
+      }),
+    stop: () => send<SurveyStatus>("/api/survey/stop", "POST"),
+    trail: (since: number, epoch: number) =>
+      get<{ epoch: number; since: number; points: [number, number][]; total: number }>(
+        `/api/survey/trail?since=${since}&epoch=${epoch}`,
+      ),
+    edges: (since: number, epoch: number) =>
+      get<{ epoch: number; since: number; points: SurveyEdge[]; total: number }>(
+        `/api/survey/edges?since=${since}&epoch=${epoch}`,
+      ),
+    mark: (side: "L" | "R" | null, kind: "edge" | "runoff" | "wall") =>
+      send<SurveyStatus>("/api/survey/mark", "POST", { side, kind }),
+    packet: () => get<{ packet: Record<string, unknown> | null }>("/api/survey/packet"),
+    exportUrl: "/api/survey/export.jsonl",
+  },
+
   tracks: () => get<Track[]>("/api/tracks"),
+  trackCatalog: () => get<TrackCatalog>("/api/track-catalog"),
+  trackBundles: () => get<TrackBundleInfo[]>("/api/track-bundles"),
   createTrack: (name: string, lapId: number) =>
     send<{ id: number; name: string }>("/api/tracks", "POST", { name, lap_id: lapId }),
   deleteTrack: (id: number) => send<{ status: string }>(`/api/tracks/${id}`, "DELETE"),

--- a/frontend/src/lib/demoFrame.ts
+++ b/frontend/src/lib/demoFrame.ts
@@ -57,6 +57,8 @@ export function demoFrame(nowMs: number): LiveFrame {
     oil_temp: 102,
     oil_pressure: 5.4,
     aids: exitSpin ? 1 : 0, // TCS bit flickers with the fake wheelspin
+    surface: 0x1111, // four wheels on tarmac
+
     car_id: 0,
     car_name: "Placeholder GT '26",
     session_best_ms: 111_410,

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -3,9 +3,9 @@
 // source of truth for cross-view handoff (Sessions/Live → Analysis) and makes
 // every view bookmarkable. The /overlay path is handled separately (lib/overlay).
 
-export type View = "live" | "analysis" | "sessions" | "admin";
+export type View = "live" | "analysis" | "sessions" | "survey" | "admin";
 
-const VIEWS: readonly View[] = ["live", "analysis", "sessions", "admin"];
+const VIEWS: readonly View[] = ["live", "analysis", "sessions", "survey", "admin"];
 
 export interface Route {
   view: View;

--- a/frontend/src/lib/surveyGeometry.ts
+++ b/frontend/src/lib/surveyGeometry.ts
@@ -1,0 +1,311 @@
+// Geometry for the survey map's forming track: the run's accumulated border
+// edge points pair up left↔right wherever they face each other across the
+// road, filling in the confirmed surface span by span. Matching is purely
+// local — no lap ordering or centerline needed — so partial coverage just
+// fills in as laps add evidence.
+
+import type { SurveyEdge } from "@/lib/types";
+
+// Matched pairs must look like a road cross-section: the line from the left
+// point to the right point should run along the car's right-normal, between
+// plausible road widths, with both contacts driven in the same direction.
+const ROAD_WIDTH_MIN_M = 3;
+const ROAD_WIDTH_MAX_M = 40;
+const ACROSS_MIN_DOT = 0.85; // L→R direction vs right-normal: cos ~32°
+const HEADING_MIN_DOT = 0.7; // both points from the same direction of travel
+const QUAD_HALF_LENGTH_M = 2.5; // along-track extent of one filled span
+// Spatial hash cell for the right-side candidates: one cell spans the whole
+// search radius, so scanning the 3×3 neighborhood covers every match. Keeps
+// the pairing near-linear as edge points accumulate into the thousands.
+const CELL_M = ROAD_WIDTH_MAX_M;
+
+// The trail is a time sequence, not a continuous path: pit returns, resets
+// and session restarts teleport the car, and naively connecting consecutive
+// points across such a jump draws chords through the middle of the map (and
+// inflated gap lengths by the jump distance). Steps longer than this are
+// treated as discontinuities everywhere the trail is walked.
+export const TRAIL_JUMP_M = 30;
+
+// --- travel-direction arrows ---------------------------------------------------
+
+// "Left border" means left OF TRAVEL, which on a map can sit on either
+// screen side — these arrows along the driven path are what make the
+// distinction readable at a glance.
+export interface DirectionArrow {
+  x: number;
+  z: number;
+  dx: number; // unit travel direction at this point
+  dz: number;
+}
+
+const ARROW_COUNT = 14;
+
+export function directionArrows(trail: [number, number][]): DirectionArrow[] {
+  if (trail.length < 10) return [];
+  const arrows: DirectionArrow[] = [];
+  const step = Math.max(1, Math.floor(trail.length / ARROW_COUNT));
+  for (let i = step; i < trail.length - 1; i += step) {
+    const [ax, az] = trail[i - 1];
+    const [bx, bz] = trail[i + 1];
+    const len = Math.hypot(bx - ax, bz - az);
+    if (len < 0.5 || len > 2 * TRAIL_JUMP_M) continue; // parked or teleport
+    arrows.push({
+      x: trail[i][0],
+      z: trail[i][1],
+      dx: (bx - ax) / len,
+      dz: (bz - az) / len,
+    });
+  }
+  return arrows;
+}
+
+// --- perimeter completeness --------------------------------------------------
+
+export interface SideCoverage {
+  pct: number; // % of the driven loop with this border evidenced nearby
+  largestGapM: number; // longest uncovered stretch — where to drive next
+  closed: boolean;
+  // Uncovered stretches as polylines, offset a few meters toward the side
+  // they belong to — drawn dashed on the map so gaps are findable, not
+  // just countable. Only stretches long enough to matter are included.
+  gapSegments: [number, number][][];
+  largestGapAt: [number, number] | null; // midpoint of the largest gap
+}
+
+export interface Coverage {
+  left: SideCoverage;
+  right: SideCoverage;
+  roadPct: number; // % of the loop where BOTH borders are known
+}
+
+// A trail point counts as covered when border evidence exists nearby, with
+// the reach depending on how the evidence's travel direction compares:
+//
+// - Aligned (within ~60°): full radius, spanning the whole road width — a
+//   lap hugging the right edge must not read as "left border missing" when
+//   the left border is mapped just across the road (that was a ghost gap).
+// - Rotated but not opposite: short radius only. A tight hairpin turns the
+//   heading ~180° across a few dozen meters, so the corner's own evidence
+//   is heavily rotated yet CLOSE — without this tier hairpins report
+//   eternal gaps in sections the driver plainly traced.
+// - Opposite (beyond ~120°): never — that's the other leg of the hairpin,
+//   which is the ghost the heading gate exists to prevent.
+const COVER_RADIUS_M = 30;
+const COVER_RADIUS_NEAR_M = 15;
+const HEADING_ALIGN_MIN_DOT = 0.5;
+const HEADING_OPPOSITE_DOT = -0.5;
+const COVER_MIN_TRAIL = 50; // too little driving to grade against
+const CLOSED_MIN_PCT = 97;
+const CLOSED_MAX_GAP_M = 40;
+const GAP_MIN_DRAW_M = 12; // don't clutter the map with sub-noise stretches
+const GAP_OFFSET_M = 4; // drawn beside the trail, toward the gap's side
+
+// Grade the border evidence against the driven loop: for every trail point,
+// is there border evidence of each side nearby? The trail is the reference
+// "lap loop", so the percentages read as how much of the track's perimeter
+// has been established — and the largest gap says where to go touch next.
+export function borderCoverage(
+  trail: [number, number][],
+  edges: SurveyEdge[],
+): Coverage | null {
+  if (trail.length < COVER_MIN_TRAIL) return null;
+  // Evidence bucketed by cell (cell size = radius, so scanning the 3×3
+  // neighborhood sees everything within COVER_RADIUS_M), matched by exact
+  // distance + travel-direction alignment.
+  const cellsBySide: Record<"L" | "R", Map<string, SurveyEdge[]>> = {
+    L: new Map(),
+    R: new Map(),
+  };
+  for (const e of edges) {
+    // Run-off limits are excluded from the road FILL (they bound the
+    // run-off, not the road) but they absolutely count as coverage: the
+    // driver traced that section's boundary on purpose, and grading it as
+    // a gap forever would send them back to re-drive finished work.
+    const key = `${Math.floor(e.x / COVER_RADIUS_M)}:${Math.floor(e.z / COVER_RADIUS_M)}`;
+    const bucket = cellsBySide[e.side].get(key);
+    if (bucket) bucket.push(e);
+    else cellsBySide[e.side].set(key, [e]);
+  }
+  const near = (
+    cells: Map<string, SurveyEdge[]>,
+    x: number,
+    z: number,
+    tdx: number,
+    tdz: number,
+  ): boolean => {
+    const cx = Math.floor(x / COVER_RADIUS_M);
+    const cz = Math.floor(z / COVER_RADIUS_M);
+    for (let gx = cx - 1; gx <= cx + 1; gx++) {
+      for (let gz = cz - 1; gz <= cz + 1; gz++) {
+        for (const e of cells.get(`${gx}:${gz}`) ?? []) {
+          const dot = e.hx * tdx + e.hz * tdz;
+          const reach =
+            dot >= HEADING_ALIGN_MIN_DOT
+              ? COVER_RADIUS_M
+              : dot >= HEADING_OPPOSITE_DOT
+                ? COVER_RADIUS_NEAR_M
+                : 0;
+          if (reach === 0) continue;
+          const dx = e.x - x;
+          const dz = e.z - z;
+          if (dx * dx + dz * dz > reach * reach) continue;
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  interface Gap {
+    start: number; // trail indices, inclusive
+    end: number;
+    lengthM: number;
+  }
+  const covered = { L: 0, R: 0 };
+  let both = 0;
+  const gaps: Record<"L" | "R", Gap[]> = { L: [], R: [] };
+  const open: Record<"L" | "R", Gap | null> = { L: null, R: null };
+  let prev: [number, number] | null = null;
+  trail.forEach(([x, z], i) => {
+    const stepM = prev ? Math.hypot(x - prev[0], z - prev[1]) : 0;
+    prev = [x, z];
+    // A teleport is not driven distance: close any open gap at it (the gap
+    // ended where the car vanished) and contribute nothing to gap lengths —
+    // otherwise gaps span the jump and draw as chords across the map.
+    const jump = stepM > TRAIL_JUMP_M;
+    if (jump) {
+      for (const side of ["L", "R"] as const) {
+        if (open[side]) {
+          gaps[side].push(open[side]);
+          open[side] = null;
+        }
+      }
+    }
+    const drivenStep = jump ? 0 : stepM;
+    // Direction of travel at this trail point, for the evidence heading gate.
+    const [ax, az] = trail[Math.max(0, i - 1)];
+    const [bx, bz] = trail[Math.min(trail.length - 1, i + 1)];
+    const dirLen = Math.hypot(bx - ax, bz - az) || 1;
+    const tdx = (bx - ax) / dirLen;
+    const tdz = (bz - az) / dirLen;
+    let onRoad = true;
+    for (const side of ["L", "R"] as const) {
+      if (near(cellsBySide[side], x, z, tdx, tdz)) {
+        covered[side]++;
+        if (open[side]) {
+          gaps[side].push(open[side]);
+          open[side] = null;
+        }
+      } else {
+        onRoad = false;
+        if (open[side]) {
+          open[side].end = i;
+          open[side].lengthM += drivenStep;
+        } else {
+          open[side] = { start: i, end: i, lengthM: 0 };
+        }
+      }
+    }
+    if (onRoad) both++;
+  });
+  for (const side of ["L", "R"] as const) {
+    if (open[side]) gaps[side].push(open[side]);
+  }
+
+  // A gap drawn ON the trail would be ambiguous between sides — offset each
+  // stretch a few meters toward the side whose border is missing there.
+  const offsetSegment = (start: number, end: number, sign: number): [number, number][] => {
+    const points: [number, number][] = [];
+    for (let i = start; i <= end; i++) {
+      const [x, z] = trail[i];
+      const [ax, az] = trail[Math.max(0, i - 1)];
+      const [bx, bz] = trail[Math.min(trail.length - 1, i + 1)];
+      const len = Math.hypot(bx - ax, bz - az) || 1;
+      const dx = (bx - ax) / len;
+      const dz = (bz - az) / len;
+      // Right normal is (dz, -dx); the left side sits along its negation.
+      points.push([x + sign * dz * GAP_OFFSET_M, z + sign * -dx * GAP_OFFSET_M]);
+    }
+    return points;
+  };
+
+  const grade = (side: "L" | "R"): SideCoverage => {
+    const pct = (covered[side] / trail.length) * 100;
+    const sign = side === "L" ? -1 : 1;
+    const drawable = gaps[side].filter((g) => g.lengthM >= GAP_MIN_DRAW_M && g.end > g.start);
+    const largestGapM = gaps[side].reduce((max, g) => Math.max(max, g.lengthM), 0);
+    let largestGapAt: [number, number] | null = null;
+    const largest = drawable.reduce<Gap | null>(
+      (best, g) => (g.lengthM > (best?.lengthM ?? 0) ? g : best),
+      null,
+    );
+    if (largest) {
+      const line = offsetSegment(largest.start, largest.end, sign);
+      largestGapAt = line[Math.floor(line.length / 2)];
+    }
+    return {
+      pct,
+      largestGapM,
+      closed: pct >= CLOSED_MIN_PCT && largestGapM <= CLOSED_MAX_GAP_M,
+      gapSegments: drawable.map((g) => offsetSegment(g.start, g.end, sign)),
+      largestGapAt,
+    };
+  };
+  return {
+    left: grade("L"),
+    right: grade("R"),
+    roadPct: (both / trail.length) * 100,
+  };
+}
+
+// Quads [x1,z1, x2,z2, x3,z3, x4,z4] spanning left→right wherever a left
+// border point has a right border point directly across from it. Run-off
+// limits bound the run-off, not the road, so they never contribute.
+export function roadQuads(edges: SurveyEdge[]): number[][] {
+  const usable = edges.filter((e) => e.kind !== "runoff");
+  const rights = new Map<string, SurveyEdge[]>();
+  for (const e of usable) {
+    if (e.side !== "R") continue;
+    const key = `${Math.floor(e.x / CELL_M)}:${Math.floor(e.z / CELL_M)}`;
+    const bucket = rights.get(key);
+    if (bucket) bucket.push(e);
+    else rights.set(key, [e]);
+  }
+  const quads: number[][] = [];
+  for (const l of usable) {
+    if (l.side !== "L") continue;
+    const rnx = l.hz; // right-normal of the left point's heading
+    const rnz = -l.hx;
+    let best: SurveyEdge | null = null;
+    let bestDist = ROAD_WIDTH_MAX_M;
+    const cx = Math.floor(l.x / CELL_M);
+    const cz = Math.floor(l.z / CELL_M);
+    for (let gx = cx - 1; gx <= cx + 1; gx++) {
+      for (let gz = cz - 1; gz <= cz + 1; gz++) {
+        for (const r of rights.get(`${gx}:${gz}`) ?? []) {
+          const dx = r.x - l.x;
+          const dz = r.z - l.z;
+          const dist = Math.hypot(dx, dz);
+          if (dist < ROAD_WIDTH_MIN_M || dist >= bestDist) continue;
+          if ((dx * rnx + dz * rnz) / dist < ACROSS_MIN_DOT) continue;
+          if (l.hx * r.hx + l.hz * r.hz < HEADING_MIN_DOT) continue;
+          best = r;
+          bestDist = dist;
+        }
+      }
+    }
+    if (!best) continue;
+    let ax = l.hx + best.hx;
+    let az = l.hz + best.hz;
+    const alen = Math.hypot(ax, az) || 1;
+    ax = (ax / alen) * QUAD_HALF_LENGTH_M;
+    az = (az / alen) * QUAD_HALF_LENGTH_M;
+    quads.push([
+      l.x - ax, l.z - az,
+      l.x + ax, l.z + az,
+      best.x + ax, best.z + az,
+      best.x - ax, best.z - az,
+    ]);
+  }
+  return quads;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -25,6 +25,7 @@ export interface LiveFrame {
   oil_temp: number;
   oil_pressure: number;
   aids: number; // AIDS_* bitmask
+  surface: number; // packed per-wheel SURFACE_* codes; 0 = no data (pre-C format)
   car_id: number;
   car_name: string;
   session_best_ms: number;
@@ -75,6 +76,8 @@ export interface LapSummary {
   max_oil_temp?: number;
   min_oil_pressure?: number; // -1 = unknown
   counts_for_best?: boolean; // false = partial lap (pit out-lap)
+  off_track_count?: number; // excursions past track limits; -1 = unknown
+  clean_lap?: boolean | null; // null = unknown (no surface data recorded)
   event_counts?: Record<string, number>;
 }
 
@@ -84,6 +87,132 @@ export const AIDS_TCS = 1;
 export const AIDS_ASM = 2;
 export const AIDS_HANDBRAKE = 4;
 export const AIDS_REV_LIMITER = 8;
+
+// Per-tick packed surface codes stored in the "surface" sample column:
+// 4 bits per wheel, FL in the lowest nibble (FL | FR<<4 | RL<<8 | RR<<12).
+// Mirrors backend app/processing/surface.py.
+export const SURFACE_NONE = 0; // recorded without packet-C surface data
+export const SURFACE_TARMAC = 1;
+export const SURFACE_KERB = 2;
+export const SURFACE_DIRT = 3;
+export const SURFACE_GRASS = 4;
+export const SURFACE_SAND = 5;
+export const SURFACE_SNOW = 6;
+export const SURFACE_OTHER = 7;
+
+export function surfaceWheelCodes(v: number): [number, number, number, number] {
+  return [v & 0xf, (v >> 4) & 0xf, (v >> 8) & 0xf, (v >> 12) & 0xf];
+}
+
+export function looseWheelCount(v: number): number {
+  return surfaceWheelCodes(v).filter((c) => c >= SURFACE_DIRT && c <= SURFACE_SNOW).length;
+}
+
+export function kerbWheelCount(v: number): number {
+  return surfaceWheelCodes(v).filter((c) => c === SURFACE_KERB).length;
+}
+
+// --- Surface survey (mirrors backend app/processing/survey.py) ---------------
+
+export const SURVEY_WHEELS = ["FL", "FR", "RL", "RR"] as const;
+
+// One per-wheel surface change, pushed over the WebSocket as it happens and
+// kept in the survey status' `recent` ring.
+export interface SurveyTransition {
+  n: number;
+  pid: number;
+  session_id: number | null;
+  lap: number;
+  from: string; // 4 surface chars, FL FR RL RR
+  to: string;
+  changed: string[]; // wheels whose char flipped
+  // Track border this contact belongs to, relative to travel direction:
+  // set when one side touched kerb/loose while the other stayed on tarmac.
+  border: "L" | "R" | null;
+  // Manual marking kind active when this transition happened, if any.
+  mark: string | null;
+  pos: [number, number, number]; // x, y, z
+  vel: [number, number, number];
+  speed_mps: number;
+  heading_rad: number | null; // null below ~3 m/s (velocity heading is noise)
+  rotation: [number, number, number];
+  rel_north: number;
+  wheelbase_m: number | null;
+  flags: number; // raw packet flags (undocumented-bit correlation)
+  tw_m: number | null; // track width used for this record's contacts
+  // Derived wheel-contact points [x, z]; null when heading was unavailable
+  contacts: Record<string, [number, number]> | null;
+}
+
+// One border-edge point — the unit of "the track taking shape". kind
+// "auto" comes from surface transitions; "straddle" is sampled continuously
+// while one side's wheels are held off the tarmac (the border traces itself
+// as you drive along it); "edge"/"runoff"/"wall" come from the driver
+// holding a marking button while driving the boundary.
+export interface SurveyEdge {
+  x: number;
+  z: number;
+  hx: number; // travel-direction unit at the moment of evidence
+  hz: number;
+  side: "L" | "R";
+  kind: "auto" | "straddle" | "edge" | "runoff" | "wall";
+}
+
+// Start/finish line located from lap rollovers (GT7 increments current_lap
+// exactly on the line). Provisional after one crossing; confident once
+// repeat crossings land within meters of each other.
+export interface SurveyFinish {
+  x: number;
+  z: number;
+  hx: number; // travel direction across the line
+  hz: number;
+  crossings: number;
+  spread_m: number;
+  confident: boolean;
+}
+
+// A circuit's persisted survey bundle, as listed by /api/track-bundles.
+export interface TrackBundleInfo {
+  track: string;
+  slug: string;
+  runs: number;
+  updated_at: string;
+  points: number;
+  finish_crossings: number;
+}
+
+export interface SurveyStatus {
+  active: boolean;
+  started_at: string | null;
+  track: string; // circuit label; picked at start or auto-identified mid-run
+  session_id: number | null; // session the transitions belong to
+  track_width_m: number; // the assumption entered at start
+  width_estimate_m: number | null; // median of measured edge crossings
+  width_samples: number; // accepted crossing measurements so far
+  width_in_use_m: number; // what contact derivation actually uses
+  trail_points: number;
+  trail_epoch: number;
+  edge_points: number;
+  edges_epoch: number;
+  finish: SurveyFinish | null;
+  // Persistent per-circuit knowledge this run resumed from / saves into
+  // (data/track-bundles/<slug>.json). null = fresh circuit.
+  bundle: { track: string; runs: number; updated_at: string; points: number } | null;
+  mark_side: "L" | "R" | null; // manual boundary marking armed on this side
+  mark_kind: "edge" | "runoff" | "wall";
+  packets: number;
+  no_surface_packets: number;
+  transitions: number;
+  histogram: Record<string, Record<string, number>>; // wheel -> char -> count
+  chars_seen: string[];
+  known_chars: string[];
+  unknown_chars: Record<string, number>;
+  // Undocumented packet-flag bits (12–15) seen active: bit -> tick count.
+  // GT7 has no known track-limits field; one ever activating is a finding.
+  unknown_flag_bits: Record<string, number>;
+  recent: SurveyTransition[];
+  log_path: string | null;
+}
 
 export type EventType = "lockup" | "wheelspin" | "bottoming" | "kerb";
 
@@ -118,6 +247,20 @@ export interface Track {
   name: string;
   length_m: number;
   created_at: string;
+}
+
+// Official GT7 track/layout metadata (bundled data/tracks.json — only the
+// fields the UI reads; the endpoint returns more).
+export interface TrackCatalog {
+  tracks: {
+    name: string;
+    layouts: {
+      name: string;
+      official_name: string;
+      length_m: number;
+      reverse: { official_id: string; turns: number } | null;
+    }[];
+  }[];
 }
 
 export type Samples = Record<string, number[]>;
@@ -348,6 +491,7 @@ export type WsMessage =
   | { type: "lap"; data: LapSummary }
   | { type: "status"; data: ConnectionStatus }
   | { type: "session"; data: ConnectionStatus }
+  | { type: "survey"; data: SurveyTransition }
   | { type: "voice_callout"; data: VoiceCallout }
   | { type: "voice_output_status"; data: { active_client_id: string } }
   | { type: "race_engineer_status"; data: RaceEngineerStatus };

--- a/frontend/src/store/telemetry.ts
+++ b/frontend/src/store/telemetry.ts
@@ -70,8 +70,10 @@ export const useTelemetry = create<TelemetryState>((set) => {
         case "voice_callout":
         case "voice_output_status":
         case "race_engineer_status":
-          // Handled by the Race Engineer client (store/engineer.ts) via the
-          // bus, so this store never has to know about speech.
+        case "survey":
+          // Handled elsewhere (Race Engineer in store/engineer.ts, survey
+          // transitions in SurveyView) via the bus, so this store never has
+          // to know about them.
           publishWs(msg);
           break;
         case "telemetry":

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -38,6 +38,10 @@ const CORNER_COLUMNS = [
   "throttle", "brake",
 ];
 
+// The race-line map shades where wheels touched kerb/grass/gravel whenever
+// the lap carries the per-tick surface column (packet C recordings).
+const MAP_COLUMNS = ["surface"];
+
 export function AnalysisView({ request }: { request: AnalysisRequest }) {
   const units = useSettings((s) => s.units);
   const lapEpoch = useTelemetry((s) => s.lapEpoch);
@@ -143,7 +147,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
   // The request always carries the per-corner columns for the Corner Detail
   // widget on top of whatever the picked panels need.
   const requestColumns = useMemo(
-    () => [...new Set([...columnsForChannels(channelKeys), ...CORNER_COLUMNS])],
+    () => [...new Set([...columnsForChannels(channelKeys), ...CORNER_COLUMNS, ...MAP_COLUMNS])],
     [channelKeys],
   );
   useEffect(() => {

--- a/frontend/src/views/SessionsView.tsx
+++ b/frontend/src/views/SessionsView.tsx
@@ -300,7 +300,7 @@ function LapTable({
       <table className="w-full font-tabular text-xs">
         <thead>
           <tr className="text-left text-ink-dim">
-            {["Lap", "Time", "Δ best", "Fuel", "Full thr.", "Full brake", "Coast", "Spin", "Events", "Max spd", ""].map(
+            {["Lap", "Time", "Δ best", "Fuel", "Full thr.", "Full brake", "Coast", "Spin", "Events", "Off-track", "Max spd", ""].map(
               (h) => (
                 <th key={h} className="px-2 py-2 font-normal">{h}</th>
               ),
@@ -340,6 +340,16 @@ function LapTable({
                 <td className="px-2 py-1.5">{lap.tire_spin_pct.toFixed(0)}%</td>
                 <td className="px-2 py-1.5 text-ink-dim" title="lockups · spins · bottoming · kerbs">
                   {formatEventCounts(lap.event_counts)}
+                </td>
+                <td
+                  className={`px-2 py-1.5 ${lap.clean_lap === false ? "text-brake" : "text-ink-dim"}`}
+                  title="Off-track excursions (3+ wheels on grass/gravel/dirt) — dash when the lap was recorded without surface data"
+                >
+                  {lap.off_track_count == null || lap.off_track_count < 0
+                    ? "–"
+                    : lap.clean_lap === false
+                      ? `${lap.off_track_count} ⚠`
+                      : "clean"}
                 </td>
                 <td className="px-2 py-1.5">{formatSpeed(lap.max_speed, units)}</td>
                 <td className="px-2 py-1.5 text-right whitespace-nowrap">

--- a/frontend/src/views/SurveyView.tsx
+++ b/frontend/src/views/SurveyView.tsx
@@ -1,0 +1,1203 @@
+// Surface survey view (issue #37, the seed of #38/#39): validate GT7's
+// per-wheel surface_types encoding and the wheel-contact derivation on real
+// hardware, from any browser on the LAN while driving.
+//
+// The capture itself runs server-side in the 60 Hz packet path
+// (backend/app/processing/survey.py) — surface transitions are single-tick
+// events the ~30 Hz live stream would miss. This view starts/stops a run,
+// shows the live per-wheel surface, the char histogram (with a loud banner
+// for chars the mapping doesn't know), and plots each transition's derived
+// wheel-contact points so a pass over a known kerb makes the positional
+// error visible immediately.
+
+import type * as echarts from "echarts";
+import type { EChartsOption, SeriesOption } from "echarts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EChart } from "@/components/EChart";
+import { api } from "@/lib/api";
+import {
+  borderCoverage,
+  directionArrows,
+  roadQuads,
+  TRAIL_JUMP_M,
+} from "@/lib/surveyGeometry";
+import {
+  SURVEY_WHEELS,
+  surfaceWheelCodes,
+  type SurveyEdge,
+  type SurveyStatus,
+  type SurveyTransition,
+  type TrackBundleInfo,
+} from "@/lib/types";
+import { subscribeWs } from "@/lib/wsBus";
+import { liveFrameRef, useTelemetry } from "@/store/telemetry";
+import { toast } from "@/store/toasts";
+
+const CHAR_TO_CODE: Record<string, number> = { T: 1, C: 2, D: 3, G: 4, S: 5, s: 6 };
+
+const CODE_META: Record<number, { label: string; color: string }> = {
+  0: { label: "no data", color: "#3a414c" },
+  1: { label: "tarmac", color: "#6b7280" },
+  2: { label: "kerb", color: "#eab308" },
+  3: { label: "dirt", color: "#b45309" },
+  4: { label: "grass", color: "#22c55e" },
+  5: { label: "sand", color: "#f59e0b" },
+  6: { label: "snow", color: "#e5e7eb" },
+  7: { label: "unknown", color: "#ef4444" },
+};
+
+function charMeta(ch: string): { label: string; color: string } {
+  return CODE_META[CHAR_TO_CODE[ch] ?? 7];
+}
+
+const MAX_TRANSITIONS = 500;
+
+// Perimeter rendering: border points draw as short edge ticks along the
+// local travel direction; matched left/right pairs fill the road between.
+const LEFT_BORDER_COLOR = "#60a5fa";
+const RIGHT_BORDER_COLOR = "#f472b6";
+const RUNOFF_COLOR = "#a855f7";
+const WALL_COLOR = "#ef4444";
+const ROAD_FILL = "rgba(148, 163, 184, 0.16)";
+const TICK_HALF_LENGTH_M = 2;
+// Tick stroke by encoded class: 0 = left, 1 = right, 2 = run-off limit,
+// 3 = wall (manual kinds override the side color so they stand out).
+const TICK_COLORS = [LEFT_BORDER_COLOR, RIGHT_BORDER_COLOR, RUNOFF_COLOR, WALL_COLOR];
+
+function tickClass(e: SurveyEdge): number {
+  if (e.kind === "runoff") return 2;
+  if (e.kind === "wall") return 3;
+  return e.side === "R" ? 1 : 0;
+}
+
+const MARK_KINDS = ["edge", "runoff", "wall"] as const;
+
+// The same transition can arrive twice — once in a status poll's `recent`
+// ring and once over the WebSocket, in either order — so state is always
+// merged by the run-unique record number instead of blindly appended.
+function mergeTransitions(
+  prev: SurveyTransition[],
+  incoming: SurveyTransition[],
+): SurveyTransition[] {
+  if (incoming.length === 0) return prev;
+  const byN = new Map<number, SurveyTransition>();
+  for (const t of prev) byN.set(t.n, t);
+  for (const t of incoming) byN.set(t.n, t);
+  return [...byN.values()].sort((a, b) => a.n - b.n).slice(-MAX_TRANSITIONS);
+}
+
+export function SurveyView() {
+  const wsConnected = useTelemetry((s) => s.wsConnected);
+  const connStatus = useTelemetry((s) => s.status);
+  const [status, setStatus] = useState<SurveyStatus | null>(null);
+  const [transitions, setTransitions] = useState<SurveyTransition[]>([]);
+  const [trackWidth, setTrackWidth] = useState("1.6");
+  const [track, setTrack] = useState("");
+  const [trackTouched, setTrackTouched] = useState(false);
+  const [knownTracks, setKnownTracks] = useState<string[]>([]);
+  const [bundles, setBundles] = useState<TrackBundleInfo[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [wheelValue, setWheelValue] = useState(0);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+
+  // Track picker suggestions: the user's own named tracks first (these match
+  // the session auto-identification labels), then every official GT7 layout
+  // (+ reverse configs) from the bundled catalog. The default value is the
+  // current session's identified circuit, until the user types their own.
+  useEffect(() => {
+    void (async () => {
+      const [named, catalog, bundleList] = await Promise.all([
+        api.tracks().catch(() => []),
+        api.trackCatalog().catch(() => null),
+        api.trackBundles().catch(() => []),
+      ]);
+      setBundles(bundleList);
+      const official =
+        catalog?.tracks.flatMap((t) =>
+          t.layouts.flatMap((l) => [
+            l.official_name,
+            ...(l.reverse ? [`${l.official_name} (Reverse)`] : []),
+          ]),
+        ) ?? [];
+      const names = [
+        ...new Set([...bundleList.map((b) => b.track), ...named.map((t) => t.name)]),
+      ];
+      setKnownTracks([...names, ...official.sort().filter((n) => !names.includes(n))]);
+    })();
+  }, []);
+  const identified = connStatus?.track_name ?? "";
+  useEffect(() => {
+    if (!trackTouched) setTrack(identified);
+  }, [identified, trackTouched]);
+
+  // Driven-path breadcrumb + the run's full border-edge set, both fetched
+  // incrementally from the server (the browser only ever holds a window of
+  // recent transitions, but edges are the track taking shape — every lap's
+  // evidence must stay on the map).
+  //
+  // All lengths/epochs live in refs so `refresh` keeps ONE identity: keying
+  // it on state would re-register the poll effect on every append and turn
+  // the 3 s interval into a continuous request loop against the Pi.
+  const [trail, setTrail] = useState<[number, number][]>([]);
+  const trailEpoch = useRef(-1);
+  const trailLen = useRef(0);
+  const trailBusy = useRef(false);
+  const [edges, setEdges] = useState<SurveyEdge[]>([]);
+  const edgesEpoch = useRef(-1);
+  const edgesLen = useRef(0);
+  const edgesBusy = useRef(false);
+  // Responses requested before the latest Start are a different run's data;
+  // the generation guard discards them wholesale.
+  const fetchGen = useRef(0);
+  const acceptAfter = useRef(0);
+  // Run identity: when the server's run changes (any client — a phone used
+  // as the pit display never clicks Start), local transitions are stale.
+  const runStartedAt = useRef<string | null>(null);
+
+  const applyStatus = useCallback((st: SurveyStatus) => {
+    setStatus(st);
+    if (st.started_at !== runStartedAt.current) {
+      runStartedAt.current = st.started_at;
+      setTransitions(st.recent); // new run: the server ring is the truth
+    } else {
+      setTransitions((prev) => mergeTransitions(prev, st.recent));
+    }
+    const gen = fetchGen.current;
+    if (
+      !trailBusy.current &&
+      (st.trail_epoch !== trailEpoch.current || st.trail_points > trailLen.current)
+    ) {
+      trailBusy.current = true;
+      const since = st.trail_epoch === trailEpoch.current ? trailLen.current : 0;
+      api.survey
+        .trail(since, trailEpoch.current)
+        .then((t) => {
+          if (gen <= acceptAfter.current) return;
+          trailEpoch.current = t.epoch;
+          setTrail((prev) => {
+            const next = t.since === 0 ? t.points : [...prev, ...t.points];
+            trailLen.current = next.length;
+            return next;
+          });
+        })
+        .catch(() => {})
+        .finally(() => {
+          trailBusy.current = false;
+        });
+    }
+    if (
+      !edgesBusy.current &&
+      (st.edges_epoch !== edgesEpoch.current || st.edge_points > edgesLen.current)
+    ) {
+      edgesBusy.current = true;
+      const since = st.edges_epoch === edgesEpoch.current ? edgesLen.current : 0;
+      api.survey
+        .edges(since, edgesEpoch.current)
+        .then((e) => {
+          if (gen <= acceptAfter.current) return;
+          edgesEpoch.current = e.epoch;
+          setEdges((prev) => {
+            const next = e.since === 0 ? e.points : [...prev, ...e.points];
+            edgesLen.current = next.length;
+            return next;
+          });
+        })
+        .catch(() => {})
+        .finally(() => {
+          edgesBusy.current = false;
+        });
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    const gen = ++fetchGen.current;
+    api.survey
+      .status()
+      .then((st) => {
+        if (gen <= acceptAfter.current) return; // requested before last Start
+        applyStatus(st);
+      })
+      .catch(() => {});
+  }, [applyStatus]);
+
+  useEffect(() => {
+    refresh();
+    const id = window.setInterval(refresh, 3000);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  useEffect(
+    () =>
+      subscribeWs((msg) => {
+        if (msg.type === "survey") {
+          setTransitions((prev) => mergeTransitions(prev, [msg.data]));
+        }
+      }),
+    [],
+  );
+
+  // Live per-wheel surface + car dot, off the 30 Hz frame ref (display only —
+  // detection happens server-side at 60 Hz).
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      const f = liveFrameRef.current;
+      setWheelValue(f?.surface ?? 0);
+      chartRef.current?.setOption(
+        { series: [{ id: "car", data: f ? [[f.pos_x, f.pos_z]] : [] } as SeriesOption] },
+        { notMerge: false, lazyUpdate: true },
+      );
+    }, 150);
+    return () => window.clearInterval(id);
+  }, []);
+
+  async function setMark(side: "L" | "R" | null, kind: "edge" | "runoff" | "wall") {
+    try {
+      setStatus(await api.survey.mark(side, kind));
+    } catch (e) {
+      toast(e instanceof Error ? e.message : "Could not set marking", "error");
+    }
+  }
+
+  // Raw packet inspector: poll the latest decoded packet while open and
+  // highlight fields that changed since the previous sample, so anything
+  // moving is easy to call out. (Single-tick blips can slip between the
+  // 500 ms samples — the undocumented flag bits are watched server-side.)
+  const [rawOpen, setRawOpen] = useState(false);
+  const [packet, setPacket] = useState<Record<string, unknown> | null>(null);
+  const [changedKeys, setChangedKeys] = useState<Set<string>>(new Set());
+  const prevPacket = useRef<Record<string, unknown> | null>(null);
+  useEffect(() => {
+    if (!rawOpen) return;
+    const id = window.setInterval(() => {
+      void api.survey
+        .packet()
+        .then(({ packet: p }) => {
+          if (!p) return;
+          const prev = prevPacket.current;
+          const diff = new Set<string>();
+          if (prev) {
+            for (const key of Object.keys(p)) {
+              if (JSON.stringify(p[key]) !== JSON.stringify(prev[key])) diff.add(key);
+            }
+          }
+          prevPacket.current = p;
+          setPacket(p);
+          setChangedKeys(diff);
+        })
+        .catch(() => {});
+    }, 500);
+    return () => window.clearInterval(id);
+  }, [rawOpen]);
+
+  async function start() {
+    const width = Number(trackWidth);
+    if (!Number.isFinite(width) || width <= 0.5 || width >= 3) {
+      toast("Track width must be between 0.5 and 3 m", "error");
+      return;
+    }
+    setBusy(true);
+    try {
+      const st = await api.survey.start(width, track.trim());
+      // Everything requested before this moment belongs to the old run.
+      acceptAfter.current = fetchGen.current;
+      setTrail([]);
+      trailLen.current = 0;
+      setEdges([]);
+      edgesLen.current = 0;
+      applyStatus(st); // new started_at resets transitions + refetches
+      toast("Survey started — go touch some kerbs", "success");
+    } catch (e) {
+      toast(e instanceof Error ? e.message : "Could not start survey", "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stop() {
+    setBusy(true);
+    try {
+      applyStatus(await api.survey.stop());
+      void api.trackBundles().then(setBundles).catch(() => {});
+      toast("Survey stopped — JSONL log saved on the server", "success");
+    } catch (e) {
+      toast(e instanceof Error ? e.message : "Could not stop survey", "error");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // How much of the driven loop has each border established — the "is the
+  // track ready?" answer, plus where the largest hole is.
+  const coverage = useMemo(() => borderCoverage(trail, edges), [trail, edges]);
+  const arrows = useMemo(() => directionArrows(trail), [trail]);
+  const finish = status?.finish ?? null;
+
+  // The map redraws from a snapshot of the transition feed taken at most
+  // every 2 s: kerb chatter delivers WS transitions in bursts (up to 60/s),
+  // and rebuilding the chart for each one kept the outline in a permanent
+  // redraw. The table below still consumes the live feed.
+  const [mapTransitions, setMapTransitions] = useState<SurveyTransition[]>([]);
+  const liveTransitions = useRef<SurveyTransition[]>([]);
+  liveTransitions.current = transitions;
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setMapTransitions((prev) =>
+        prev === liveTransitions.current ? prev : liveTransitions.current,
+      );
+    }, 2000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  // Teleports (pit returns, restarts) must break the trail polyline — a NaN
+  // point stops ECharts joining the two locations with a chord.
+  const trailPlot = useMemo(() => {
+    const out: [number, number][] = [];
+    let prev: [number, number] | null = null;
+    for (const p of trail) {
+      if (prev && Math.hypot(p[0] - prev[0], p[1] - prev[1]) > TRAIL_JUMP_M) {
+        out.push([NaN, NaN]);
+      }
+      out.push(p);
+      prev = p;
+    }
+    return out;
+  }, [trail]);
+
+  // Fixed, EQUAL x/z axis spans on the square canvas — the map's aspect
+  // ratio is true at every zoom level. Quantized generously so live data
+  // growth almost never moves the extents (auto-fitting axes remapped the
+  // zoom window on every 3 s update, which is what made zooming feel
+  // broken), and padded so quantizing the center can't clip the track.
+  const extents = useMemo(() => {
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+    const eat = (x: number, z: number) => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    };
+    for (const [x, z] of trail) eat(x, z);
+    for (const e of edges) eat(e.x, e.z);
+    if (!Number.isFinite(minX)) return null;
+    const QUANT = 250;
+    const cx = Math.round((minX + maxX) / 2 / QUANT) * QUANT;
+    const cz = Math.round((minZ + maxZ) / 2 / QUANT) * QUANT;
+    const reach = Math.max(
+      Math.abs(maxX - cx), Math.abs(minX - cx),
+      Math.abs(maxZ - cz), Math.abs(minZ - cz),
+    );
+    const half = Math.max(Math.ceil((reach * 1.15) / QUANT) * QUANT, QUANT);
+    return { x: [cx - half, cx + half], z: [cz - half, cz + half] };
+  }, [trail, edges]);
+
+  // Fly the map to a point — this is how an 88 m gap on a 4.5 km track
+  // stops being a needle in a haystack. Setting the windows via setOption
+  // (matched by dataZoom id) is the reliable path; later option merges
+  // carry no start/end so the window sticks until the user moves it.
+  const zoomTo = useCallback((x: number, z: number, windowM = 400) => {
+    chartRef.current?.setOption({
+      dataZoom: [
+        { id: "zoom-x", startValue: x - windowM / 2, endValue: x + windowM / 2 },
+        { id: "zoom-z", startValue: z - windowM / 2, endValue: z + windowM / 2 },
+      ],
+    });
+  }, []);
+
+  // Contact points of every transition, bucketed by the surface the wheel
+  // moved ONTO; the symbol marks which track border the point belongs to
+  // (circle = left, diamond = right, relative to travel direction). A pass
+  // over a known kerb should paint its outline.
+  const option = useMemo<EChartsOption>(() => {
+    type Point = { value: [number, number]; symbol: string; symbolSize: number };
+    const buckets = new Map<number, Point[]>();
+    for (const t of mapTransitions) {
+      const contacts = t.contacts;
+      if (!contacts) continue;
+      for (const w of t.changed) {
+        const wi = SURVEY_WHEELS.indexOf(w as (typeof SURVEY_WHEELS)[number]);
+        const point = contacts[w];
+        if (wi < 0 || !point) continue;
+        const code = CHAR_TO_CODE[t.to[wi]] ?? 7;
+        const bucket = buckets.get(code) ?? [];
+        bucket.push({
+          value: point,
+          symbol: t.border === "R" ? "diamond" : "circle",
+          symbolSize: t.border === "R" ? 6 : 5,
+        });
+        buckets.set(code, bucket);
+      }
+    }
+    const quads = roadQuads(edges);
+    const series: SeriesOption[] = [
+      {
+        // Paths driven so far — coverage forming under the contact points.
+        // progressive: 0 everywhere data can grow large: chunked rendering
+        // clears-then-repaints across frames, which reads as flashing.
+        id: "trail",
+        type: "line",
+        data: trailPlot,
+        showSymbol: false,
+        lineStyle: { color: "#3a414c", width: 1.2, opacity: 0.9 },
+        progressive: 0,
+        silent: true,
+        z: 1,
+      },
+      {
+        // Confirmed road: filled wherever a left border point has a right
+        // border point directly across from it.
+        id: "road-fill",
+        type: "custom",
+        data: quads,
+        renderItem: (_params, apiCustom) => ({
+          type: "polygon",
+          shape: {
+            points: [0, 1, 2, 3].map((i) =>
+              apiCustom.coord([
+                Number(apiCustom.value(i * 2)),
+                Number(apiCustom.value(i * 2 + 1)),
+              ]),
+            ),
+          },
+          style: { fill: ROAD_FILL },
+        }),
+        progressive: 0,
+        silent: true,
+        z: 1.5,
+      },
+      {
+        // Perimeter ticks: every edge point of the run drawn as a short
+        // segment along the travel direction — left/right borders in their
+        // side colors, manually-marked run-off limits and walls in theirs.
+        id: "border-ticks",
+        type: "custom",
+        data: edges.map((p) => [p.x, p.z, p.hx, p.hz, tickClass(p)]),
+        renderItem: (_params, apiCustom) => {
+          const x = Number(apiCustom.value(0));
+          const z = Number(apiCustom.value(1));
+          const hx = Number(apiCustom.value(2)) * TICK_HALF_LENGTH_M;
+          const hz = Number(apiCustom.value(3)) * TICK_HALF_LENGTH_M;
+          const p1 = apiCustom.coord([x - hx, z - hz]);
+          const p2 = apiCustom.coord([x + hx, z + hz]);
+          return {
+            type: "line",
+            shape: { x1: p1[0], y1: p1[1], x2: p2[0], y2: p2[1] },
+            style: {
+              stroke: TICK_COLORS[Number(apiCustom.value(4))] ?? LEFT_BORDER_COLOR,
+              lineWidth: 1.6,
+              opacity: 0.9,
+            },
+          };
+        },
+        progressive: 0,
+        silent: true,
+        z: 2,
+      },
+      // One series per surface class, ALWAYS present (empty when unused):
+      // the chart updates in place instead of tearing series down and
+      // recreating them, which made the whole map flicker every refresh.
+      ...[1, 2, 3, 4, 5, 6, 7].map(
+        (code): SeriesOption => ({
+          id: `contacts-${code}`,
+          type: "scatter",
+          data: buckets.get(code) ?? [],
+          symbolSize: 5,
+          itemStyle: { color: CODE_META[code].color, opacity: 0.85 },
+          silent: true,
+          z: 3,
+        }),
+      ),
+    ];
+    // Travel-direction arrows along the driven path: "left border" means
+    // left OF TRAVEL, which can sit on either screen side — without these,
+    // a correct gap marker can look like it's on the wrong border.
+    series.push({
+      id: "direction-arrows",
+      type: "custom",
+      data: arrows.map((_, i) => i),
+      renderItem: (params, apiCustom) => {
+        const a = arrows[params.dataIndex as number];
+        const c = apiCustom.coord([a.x, a.z]);
+        const t = apiCustom.coord([a.x + a.dx * 4, a.z + a.dz * 4]);
+        let vx = t[0] - c[0];
+        let vy = t[1] - c[1];
+        const len = Math.hypot(vx, vy) || 1;
+        vx = (vx / len) * 7;
+        vy = (vy / len) * 7;
+        const wx = -vy * 0.5;
+        const wy = vx * 0.5;
+        return {
+          type: "polygon",
+          shape: {
+            points: [
+              [c[0] + vx, c[1] + vy],
+              [c[0] - vx * 0.7 + wx, c[1] - vy * 0.7 + wy],
+              [c[0] - vx * 0.7 - wx, c[1] - vy * 0.7 - wy],
+            ],
+          },
+          style: { fill: "#8b93a1", opacity: 0.85 },
+        };
+      },
+      progressive: 0,
+      silent: true,
+      z: 1.9,
+    });
+
+    // Coverage gaps, drawn where they ARE: dashed stretches beside the
+    // trail in the missing border's color, with a labeled marker on each
+    // side's largest gap so "87%, gap ~200 m" is drivable-to, not a riddle.
+    // A closed border gets NO overlay — dashes on a finished perimeter are
+    // clutter — and every series exists regardless so updates merge in
+    // place instead of flickering.
+    for (const [side, data, color] of [
+      ["L", coverage?.left, LEFT_BORDER_COLOR],
+      ["R", coverage?.right, RIGHT_BORDER_COLOR],
+    ] as const) {
+      const segments = data == null || data.closed ? [] : data.gapSegments;
+      series.push({
+        id: `gaps-${side}`,
+        type: "custom",
+        data: segments.map((_, i) => i),
+        renderItem: (params, apiCustom) => ({
+          type: "polyline",
+          shape: {
+            points: segments[params.dataIndex as number].map((p) =>
+              apiCustom.coord(p),
+            ),
+          },
+          style: {
+            stroke: color,
+            fill: "none",
+            lineWidth: 2.5,
+            lineDash: [8, 6],
+            opacity: 0.8,
+          },
+        }),
+        progressive: 0,
+        silent: true,
+        z: 2.4,
+      });
+      const marker =
+        data != null && !data.closed && data.largestGapAt != null
+          ? [data.largestGapAt]
+          : [];
+      series.push({
+        // Rippling beacon — findable at full-track scale, where the gap
+        // itself may be a couple dozen pixels of dashes.
+        id: `gap-marker-${side}`,
+        type: "effectScatter",
+        data: marker,
+        symbolSize: 10,
+        rippleEffect: { scale: 3.5, brushType: "stroke" },
+        itemStyle: { color },
+        label: {
+          show: true,
+          position: side === "L" ? "top" : "bottom",
+          formatter: `gap ~${Math.round(data?.largestGapM ?? 0)} m`,
+          color,
+          fontSize: 10,
+          fontWeight: "bold",
+          backgroundColor: "#14171c",
+          padding: [2, 4],
+          borderRadius: 3,
+        },
+        silent: true,
+        z: 6,
+      });
+    }
+
+    {
+      // Start/finish line: perpendicular to the crossing direction, dashed
+      // until repeat crossings agree. Always present; empty until located.
+      const rx = finish?.hz ?? 0;
+      const rz = -(finish?.hx ?? 0);
+      const half = 15;
+      series.push({
+        id: "finish-line",
+        type: "custom",
+        data: finish
+          ? [[finish.x - rx * half, finish.z - rz * half,
+              finish.x + rx * half, finish.z + rz * half]]
+          : [],
+        renderItem: (_params, apiCustom) => {
+          const p1 = apiCustom.coord([Number(apiCustom.value(0)), Number(apiCustom.value(1))]);
+          const p2 = apiCustom.coord([Number(apiCustom.value(2)), Number(apiCustom.value(3))]);
+          return {
+            type: "line",
+            shape: { x1: p1[0], y1: p1[1], x2: p2[0], y2: p2[1] },
+            style: {
+              stroke: "#e5e7eb",
+              lineWidth: 3,
+              lineDash: finish?.confident ? undefined : [6, 4],
+              opacity: 0.95,
+            },
+          };
+        },
+        silent: true,
+        z: 5,
+      });
+    }
+    series.push({
+      id: "car",
+      type: "scatter",
+      data: [] as number[][],
+      symbolSize: 9,
+      itemStyle: { color: "#fff", borderColor: "#6b7280", borderWidth: 1.5 },
+      silent: true,
+      z: 10,
+    });
+    return {
+      animation: false,
+      grid: { left: 8, right: 8, top: 8, bottom: 8 },
+      xAxis: {
+        type: "value",
+        show: false,
+        ...(extents ? { min: extents.x[0], max: extents.x[1] } : { scale: true }),
+      },
+      yAxis: {
+        type: "value",
+        show: false,
+        inverse: true,
+        ...(extents ? { min: extents.z[0], max: extents.z[1] } : { scale: true }),
+      },
+      // Wheel zoom + drag pan; filterMode none keeps polylines continuous
+      // at the viewport edges. Stable ids let zoomTo() target the windows.
+      dataZoom: [
+        { id: "zoom-x", type: "inside", xAxisIndex: 0, filterMode: "none" },
+        { id: "zoom-z", type: "inside", yAxisIndex: 0, filterMode: "none" },
+      ],
+      tooltip: { show: false },
+      series,
+    };
+  }, [mapTransitions, trailPlot, edges, finish, coverage, arrows, extents]);
+
+  const wheels = surfaceWheelCodes(wheelValue);
+  const unknown = Object.keys(status?.unknown_chars ?? {});
+  const active = status?.active ?? false;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-3 p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="text-lg font-semibold">Surface survey</h2>
+        <div className="ml-auto flex items-center gap-2">
+          <label className="flex items-center gap-1.5 text-xs text-ink-dim">
+            track
+            <input
+              list="survey-tracks"
+              value={track}
+              disabled={active}
+              placeholder="unidentified"
+              onChange={(e) => {
+                setTrack(e.target.value);
+                setTrackTouched(true);
+              }}
+              className="w-40 rounded border border-edge bg-panel-2 px-1.5 py-1 text-xs text-ink"
+              title="Which circuit these samples describe — defaults to the session's identified track"
+            />
+            <datalist id="survey-tracks">
+              {knownTracks.map((name) => (
+                <option key={name} value={name} />
+              ))}
+            </datalist>
+          </label>
+          <label
+            className="flex items-center gap-1.5 text-xs text-ink-dim"
+            title="Starting assumption for the car's axle track width — replaced automatically once enough 4-wheel edge crossings have measured the real value"
+          >
+            width
+            <input
+              type="number"
+              step="0.05"
+              min="0.5"
+              max="3"
+              value={trackWidth}
+              disabled={active}
+              onChange={(e) => setTrackWidth(e.target.value)}
+              className="w-16 rounded border border-edge bg-panel-2 px-1.5 py-1 text-right font-tabular text-xs text-ink"
+            />
+            m
+          </label>
+          {active ? (
+            <button className="btn-danger" onClick={stop} disabled={busy}>
+              Stop survey
+            </button>
+          ) : (
+            <button className="btn" onClick={start} disabled={busy || !wsConnected}>
+              Start survey
+            </button>
+          )}
+          <a
+            className={`btn ${status?.log_path ? "" : "pointer-events-none opacity-40"}`}
+            href={api.survey.exportUrl}
+            download
+            title="Full transition log (positions, velocity, raw rotation floats, contact points)"
+          >
+            Download JSONL
+          </a>
+        </div>
+      </div>
+
+      {!active && bundles.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-ink-dim">
+          <span title="Persistent per-circuit survey bundles — pick one and start to resume exactly where you left off">
+            Mapped circuits:
+          </span>
+          {bundles.map((b) => (
+            <button
+              key={b.slug}
+              className="rounded-full border border-edge px-2 py-0.5 hover:border-accent hover:text-accent"
+              title={`Resume ${b.track}: ${b.points} points from ${b.runs} run${
+                b.runs === 1 ? "" : "s"
+              }`}
+              onClick={() => {
+                setTrack(b.track);
+                setTrackTouched(true);
+              }}
+            >
+              {b.track} · {b.points.toLocaleString()} pts
+            </button>
+          ))}
+        </div>
+      )}
+
+      {active && status != null && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg bg-panel px-3 py-2 text-xs">
+          <span
+            className="text-ink-dim"
+            title="Where surface data is silent — walls, paved run-off — declare the boundary you are driving along and the survey records it from your wheel line"
+          >
+            Mark boundary:
+          </span>
+          {([null, "L", "R"] as const).map((side) => (
+            <button
+              key={side ?? "off"}
+              className={`rounded border px-2 py-0.5 ${
+                status.mark_side === side
+                  ? "border-accent text-accent"
+                  : "border-edge text-ink-dim hover:text-ink"
+              }`}
+              onClick={() => setMark(side, status.mark_kind)}
+            >
+              {side === null ? "off" : side === "L" ? "left" : "right"}
+            </button>
+          ))}
+          <span className="ml-2 text-ink-dim">as</span>
+          {MARK_KINDS.map((kind) => (
+            <button
+              key={kind}
+              className={`rounded border px-2 py-0.5 ${
+                status.mark_kind === kind
+                  ? "border-accent text-accent"
+                  : "border-edge text-ink-dim hover:text-ink"
+              }`}
+              onClick={() => setMark(status.mark_side, kind)}
+            >
+              {kind === "runoff" ? "run-off limit" : kind}
+            </button>
+          ))}
+          {status.mark_side != null && (
+            <span className="ml-auto font-medium text-warn">
+              MARKING {status.mark_side === "L" ? "left" : "right"} {status.mark_kind} —
+              drive along the boundary
+            </span>
+          )}
+        </div>
+      )}
+
+      {active && status != null && (
+        <div className="text-xs text-ink-dim">
+          Surveying{" "}
+          <span className="text-ink">{status.track || "unidentified track"}</span>
+          {status.session_id != null && <> · session #{status.session_id}</>}
+          {status.bundle != null && (
+            <>
+              {" "}
+              ·{" "}
+              <span
+                className="text-accent"
+                title="Track knowledge persists per circuit — every run resumes from and improves the bundle"
+              >
+                resumed from bundle ({status.bundle.points} pts, {status.bundle.runs}{" "}
+                {status.bundle.runs === 1 ? "run" : "runs"})
+              </span>
+            </>
+          )}{" "}
+          · width
+          in use{" "}
+          <span className="text-ink">{status.width_in_use_m.toFixed(2)} m</span>{" "}
+          {status.width_samples >= 3 ? (
+            <span className="text-throttle">
+              (measured from {status.width_samples} edge crossings)
+            </span>
+          ) : (
+            <>
+              (assumed
+              {status.width_samples > 0 &&
+                ` — measuring: ${status.width_samples}/3 crossings`}
+              )
+            </>
+          )}{" "}
+          · lap recording continues alongside — laps saved during the run keep
+          their per-tick surface column
+        </div>
+      )}
+
+      {active && status != null && status.no_surface_packets > 0 && (
+        <div className="rounded-lg border border-brake/50 bg-brake/10 px-3 py-2 text-sm text-brake">
+          Packets carry no surface data — the console isn't answering on packet
+          format C. Check Admin → Connection (game v1.68+ required).
+        </div>
+      )}
+      {Object.keys(status?.unknown_flag_bits ?? {}).length > 0 && (
+        <div className="rounded-lg border border-warn/50 bg-warn/10 px-3 py-2 text-sm text-warn">
+          Undocumented packet flag bit(s) active:{" "}
+          {Object.entries(status?.unknown_flag_bits ?? {})
+            .map(([bit, n]) => `bit ${bit} (×${n})`)
+            .join(", ")}{" "}
+          — GT7 has no known track-limits field, so note what you were doing
+          when these flipped (the JSONL records carry the raw flags).
+        </div>
+      )}
+      {unknown.length > 0 && (
+        <div className="rounded-lg border border-brake/50 bg-brake/10 px-3 py-2 text-sm text-brake">
+          NEW surface chars seen: {unknown.map((c) => `'${c}'`).join(", ")} — not in
+          the known mapping (T/C/D/G/S/s). Note where they occurred and add them to
+          backend/app/processing/surface.py.
+        </div>
+      )}
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div className="rounded-xl bg-panel p-3">
+          <div className="mb-2 flex items-baseline justify-between text-xs text-ink-dim">
+            <span>
+              The track so far · scroll to zoom, drag to pan · arrows = travel
+              direction
+            </span>
+            <span className="flex items-center gap-2 font-tabular">
+              {status?.edge_points ?? 0} edge points · {status?.transitions ?? 0}{" "}
+              transitions · {status?.packets ?? 0} packets
+              <button
+                className="rounded border border-edge px-1.5 text-ink-dim hover:text-ink"
+                onClick={() => chartRef.current?.dispatchAction({ type: "restore" })}
+              >
+                reset view
+              </button>
+            </span>
+          </div>
+          {/* Merge mode keeps the zoom alive across the 3 s data refreshes
+              (full replace reset the dataZoom windows — zoom "snapped
+              back"), and because every series always exists (empty data
+              when unused) updates apply IN PLACE: replace-merge tore the
+              series down and rebuilt them each refresh, which flickered. */}
+          <EChart
+            option={option}
+            notMerge={false}
+            className="aspect-square w-full"
+            onInit={(chart) => {
+              chartRef.current = chart;
+            }}
+          />
+          <div className="mt-1 flex flex-wrap gap-3 text-[10px] text-ink-dim">
+            <span>
+              <i className="mr-1 inline-block h-0.5 w-4 bg-edge align-middle" />
+              driven
+            </span>
+            <span className="text-ink-dim">▸ travel direction</span>
+            <span title="Which track border a contact belongs to, relative to travel direction — follow the arrows">
+              <i
+                className="mr-1 inline-block h-0.5 w-4 align-middle"
+                style={{ backgroundColor: LEFT_BORDER_COLOR }}
+              />
+              left border
+            </span>
+            <span>
+              <i
+                className="mr-1 inline-block h-0.5 w-4 align-middle"
+                style={{ backgroundColor: RIGHT_BORDER_COLOR }}
+              />
+              right border
+            </span>
+            <span title="Unmapped stretch of that border, offset toward its side — drive it to close the loop">
+              <i className="mr-1 inline-block w-4 border-t-2 border-dashed border-ink-dim align-middle" />
+              gap
+            </span>
+            <span>
+              <i
+                className="mr-1 inline-block h-0.5 w-4 align-middle"
+                style={{ backgroundColor: RUNOFF_COLOR }}
+              />
+              run-off limit
+            </span>
+            <span>
+              <i
+                className="mr-1 inline-block h-0.5 w-4 align-middle"
+                style={{ backgroundColor: WALL_COLOR }}
+              />
+              wall
+            </span>
+            <span title="Filled where a left border point has a right border point directly across">
+              <i
+                className="mr-1 inline-block h-2.5 w-4 align-middle"
+                style={{ backgroundColor: ROAD_FILL }}
+              />
+              road
+            </span>
+            {finish != null && (
+              <span title="From lap rollovers; dashed until repeat crossings agree">
+                <i className="mr-1 inline-block h-0.5 w-4 bg-[#e5e7eb] align-middle" />
+                finish line
+              </span>
+            )}
+            {Object.entries(CODE_META)
+              .filter(([code]) => Number(code) >= 1)
+              .map(([code, meta]) => (
+                <span key={code}>
+                  <i
+                    className="mr-1 inline-block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: meta.color }}
+                  />
+                  {meta.label}
+                </span>
+              ))}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="rounded-xl bg-panel p-3">
+            <div
+              className="mb-2 text-xs text-ink-dim"
+              title="How much of the driven loop has each border established — closed means the perimeter is complete and the largest gap says where to drive next"
+            >
+              Track completeness
+            </div>
+            {coverage == null ? (
+              <div className="text-sm text-ink-dim">
+                Gathering data — drive a lap and touch the edges.
+              </div>
+            ) : (
+              <div className="space-y-1.5 font-tabular text-xs">
+                {(
+                  [
+                    ["Left border", coverage.left, LEFT_BORDER_COLOR],
+                    ["Right border", coverage.right, RIGHT_BORDER_COLOR],
+                  ] as const
+                ).map(([label, side, color]) => (
+                  <div key={label} className="flex items-center gap-2">
+                    <span
+                      className="w-20 shrink-0 text-ink-dim"
+                      title="Left/right of the DIRECTION OF TRAVEL, not of the screen — follow the arrows on the map"
+                    >
+                      {label}
+                    </span>
+                    <div className="h-1.5 flex-1 rounded bg-panel-2">
+                      <div
+                        className="h-full rounded"
+                        style={{
+                          width: `${Math.min(100, side.pct).toFixed(0)}%`,
+                          backgroundColor: color,
+                        }}
+                      />
+                    </div>
+                    <span className="w-9 shrink-0 text-right">{side.pct.toFixed(0)}%</span>
+                    {side.closed ? (
+                      <span className="w-28 shrink-0 text-throttle">closed ✓</span>
+                    ) : side.largestGapAt != null ? (
+                      <button
+                        className="w-28 shrink-0 text-left text-accent hover:underline"
+                        title="Zoom the map to this gap (it pulses)"
+                        onClick={() =>
+                          side.largestGapAt &&
+                          zoomTo(side.largestGapAt[0], side.largestGapAt[1])
+                        }
+                      >
+                        gap ~{Math.round(side.largestGapM)} m ⌖ zoom
+                      </button>
+                    ) : (
+                      <span className="w-28 shrink-0 text-ink-dim">
+                        gap ~{Math.round(side.largestGapM)} m
+                      </span>
+                    )}
+                  </div>
+                ))}
+                <div className="flex items-center gap-2">
+                  <span className="w-20 shrink-0 text-ink-dim">Road</span>
+                  <div className="h-1.5 flex-1 rounded bg-panel-2">
+                    <div
+                      className="h-full rounded bg-ink-dim"
+                      style={{ width: `${Math.min(100, coverage.roadPct).toFixed(0)}%` }}
+                    />
+                  </div>
+                  <span className="w-9 shrink-0 text-right">
+                    {coverage.roadPct.toFixed(0)}%
+                  </span>
+                  <span className="w-28 shrink-0 text-ink-dim">both borders</span>
+                </div>
+                <div className="flex items-center gap-2 pt-0.5">
+                  <span className="w-20 shrink-0 text-ink-dim">Finish line</span>
+                  {finish == null ? (
+                    <span className="text-ink-dim">not yet — complete a lap</span>
+                  ) : finish.confident ? (
+                    <span className="text-throttle">
+                      located ✓ ({finish.crossings} crossings, ±{finish.spread_m} m)
+                    </span>
+                  ) : (
+                    <span className="text-warn">
+                      provisional ({finish.crossings} crossing
+                      {finish.crossings === 1 ? "" : "s"}) — another lap confirms it
+                    </span>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl bg-panel p-3">
+            <div className="mb-2 text-xs text-ink-dim">Live wheel surface</div>
+            <div className="grid grid-cols-2 gap-2">
+              {SURVEY_WHEELS.map((w, i) => {
+                const meta = CODE_META[wheels[i]] ?? CODE_META[7];
+                return (
+                  <div
+                    key={w}
+                    className="flex items-center justify-between rounded-lg border border-edge px-3 py-2"
+                    style={{ backgroundColor: `${meta.color}22` }}
+                  >
+                    <span className="text-xs text-ink-dim">{w}</span>
+                    <span className="font-medium" style={{ color: meta.color }}>
+                      {meta.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="rounded-xl bg-panel p-3">
+            <div className="mb-2 text-xs text-ink-dim">Chars seen per wheel</div>
+            {status == null || status.chars_seen.length === 0 ? (
+              <div className="text-sm text-ink-dim">
+                Nothing yet — start a survey and get on track.
+              </div>
+            ) : (
+              <table className="w-full font-tabular text-xs">
+                <tbody>
+                  {SURVEY_WHEELS.map((w) => (
+                    <tr key={w} className="border-t border-edge/50 first:border-0">
+                      <td className="py-1 pr-2 text-ink-dim">{w}</td>
+                      <td className="py-1">
+                        {Object.entries(status.histogram[w] ?? {}).map(([ch, n]) => (
+                          <span key={ch} className="mr-3">
+                            <span style={{ color: charMeta(ch).color }}>{ch}</span>
+                            <span className="text-ink-dim"> ×{n}</span>
+                          </span>
+                        ))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          <div className="rounded-xl bg-panel p-3">
+            <div className="mb-2 text-xs text-ink-dim">
+              Latest transitions (newest first)
+            </div>
+            <div className="max-h-64 overflow-y-auto">
+              {transitions.length === 0 ? (
+                <div className="text-sm text-ink-dim">No transitions yet.</div>
+              ) : (
+                <table className="w-full font-tabular text-xs">
+                  <tbody>
+                    {[...transitions].reverse().slice(0, 100).map((t) => (
+                      <tr key={t.n} className="border-t border-edge/50 first:border-0">
+                        <td className="py-1 pr-2 text-ink-dim">#{t.n}</td>
+                        <td className="py-1 pr-2 text-ink-dim">L{t.lap}</td>
+                        <td className="py-1 pr-2">
+                          {t.from.split("").map((ch, i) => (
+                            <span key={i} style={{ color: charMeta(ch).color }}>{ch}</span>
+                          ))}
+                          <span className="text-ink-dim"> → </span>
+                          {t.to.split("").map((ch, i) => (
+                            <span key={i} style={{ color: charMeta(ch).color }}>{ch}</span>
+                          ))}
+                        </td>
+                        <td className="py-1 pr-2 text-ink-dim">{t.changed.join(" ")}</td>
+                        <td
+                          className="py-1 pr-2 text-ink-dim"
+                          title="Track border this contact belongs to (relative to travel direction) · manual marking active at the time"
+                        >
+                          {t.border ?? "–"}
+                          {t.mark ? ` · ${t.mark}` : ""}
+                        </td>
+                        <td className="py-1 text-right text-ink-dim">
+                          {(t.speed_mps * 3.6).toFixed(0)} km/h
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-xl bg-panel p-3">
+        <button
+          className="flex w-full items-center justify-between text-left text-xs text-ink-dim hover:text-ink"
+          onClick={() => setRawOpen((open) => !open)}
+          aria-expanded={rawOpen}
+        >
+          <span>
+            Raw packet inspector — every decoded field, live; changed values
+            highlight so anything reacting to what you do on track is easy to spot
+          </span>
+          <span>{rawOpen ? "▾" : "▸"}</span>
+        </button>
+        {rawOpen && packet == null && (
+          <div className="pt-2 text-sm text-ink-dim">Waiting for a packet…</div>
+        )}
+        {rawOpen && packet != null && (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 pt-2 font-tabular text-[11px] sm:grid-cols-3 lg:grid-cols-4">
+            {Object.keys(packet)
+              .sort()
+              .map((key) => (
+                <div
+                  key={key}
+                  className={`flex justify-between gap-2 rounded px-1 ${
+                    changedKeys.has(key) ? "bg-warn/15 text-warn" : "text-ink-dim"
+                  }`}
+                >
+                  <span className="truncate">{key}</span>
+                  <span className="truncate text-right text-ink">
+                    {formatPacketValue(key, packet[key])}
+                  </span>
+                </div>
+              ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Compact one-line rendering for the packet inspector; flags also show
+// binary so individual (possibly undocumented) bits are readable.
+function formatPacketValue(key: string, value: unknown): string {
+  if (key === "flags" && typeof value === "number") {
+    return `${value} (0b${value.toString(2).padStart(16, "0")})`;
+  }
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : value.toFixed(4);
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => (typeof v === "number" && !Number.isInteger(v) ? v.toFixed(3) : String(v)))
+      .join(", ");
+  }
+  if (value === null || value === undefined) return "–";
+  return String(value);
+}

--- a/frontend/src/views/SurveyView.tsx
+++ b/frontend/src/views/SurveyView.tsx
@@ -298,8 +298,11 @@ export function SurveyView() {
     setBusy(true);
     try {
       const st = await api.survey.start(width, track.trim());
-      // Everything requested before this moment belongs to the old run.
+      // Everything requested before this moment belongs to the old run —
+      // and the new run's own fetches must be a NEWER generation, or the
+      // guard discards them too and the resumed bundle waits a poll cycle.
       acceptAfter.current = fetchGen.current;
+      fetchGen.current += 1;
       setTrail([]);
       trailLen.current = 0;
       setEdges([]);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Track identification: internals/track-identification.md
       - Fuel & race strategy: internals/fuel-strategy.md
       - Race Engineer callouts: internals/race-engineer.md
+      - Surface survey spike: internals/surface-survey.md
   - Reference:
       - REST & WebSocket API: reference/api.md
       - Lap file format: reference/lap-file-format.md


### PR DESCRIPTION
## Summary

Implements #17 (persist `surface_types` per tick with real lap-validity data) and #37 (validate the surface encoding + wheel-contact derivation on a real PS5) — and grows the spike into a full in-app **track surveying system**, shaken down on real hardware at Autodrome Lago Maggiore.

### Hardware findings (#37)
- Chars `T`/`G`/`C` confirmed on all four wheels; wheel order **FL FR RL RR** verified; no unknown chars seen; none of the undocumented flag bits (12–15) ever activated — GT7 broadcasts no track-limits field, so surface-derived validity is the right approach.
- Paved run-off reads as plain `T` (as suspected) → handled via manual marking + the topology notes in `docs/internals/surface-survey.md` for the #38 grid.

### #17 — per-tick surface persistence
- Packed per-wheel `surface` sample column (4 bits/wheel), stored with every lap; CSV export channel; nearest-neighbor resampling for discrete channels.
- Per-lap **off_track_count** + **clean_lap** (tri-state — laps without packet C read *unknown*, never clean), distinct from `counts_for_best`. New DB columns + SQLite migrations.
- Analysis race-line map shades kerb/off-track contact on the reference lap; Sessions lap table gains an Off-track column.

### Survey tab (spike → tool, seeds #38/#39)
- **60 Hz server-side engine**: char histograms, transitions with derived wheel-contact points, border-side tagging, straddle tracing, manual boundary marking (edge / run-off limit / wall), driven trail, finish line from lap rollovers, axle-width auto-measurement from out-and-back edge rides. Everything logged to a self-describing JSONL.
- **Persistent per-circuit track bundles** (`data/track-bundles/*.json`): grid-deduped so they converge; resumed automatically; saved on stop/change/shutdown + ~60 s autosave; downloadable via API — designed to graduate into their own repo later.
- **The map**: track forms lap by lap — perimeters, road fill, gap beacons with zoom-to-gap, direction arrows, completeness grading (ghost-proof + hairpin-fair), finish line, equal-aspect zoom/pan, flicker-free updates.
- **Raw packet inspector**: every decoded field live with change highlighting.

### Quality
- Multi-agent adversarial review: 14 confirmed findings fixed (width-estimator geometry flaw, frontend polling loop, WS overflow-budget erosion, JSONL completeness, doc drift, etc.).
- 241 backend tests, mypy strict clean, frontend tsc/eslint/build clean. Docs: API reference, derived channels, and the #37 findings note.

Closes #17. Closes #37.