### PR TITLE
Surveyed road under the race line, a usable map, g-g diagram, and identification from bundles (#14, #15, #16, #18, #19, #41, #51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ Notable changes to GT7 Datalogger. The format follows
   across a whole circuit but as scattered dots exactly where you have zoomed in
   to look closely.
 
-    The map is also **no longer stretched**. Both axes now share one scale, so a
-  corner's shape on screen is its shape on the track; letting each axis fill
-  the box independently distorted it by the circuit's aspect ratio — 8 % at
-  Lago Maggiore Centre and nearly 3x at Deep Forest.
+    The map is also **no longer stretched**. A metre across is now a metre
+  down — the axis ranges follow the plotting area's pixel aspect, so the shape
+  holds in the rail and at full screen alike. Letting each axis fill the box
+  independently distorted it by the circuit's aspect ratio: 8 % at Lago
+  Maggiore Centre and nearly 3x at Deep Forest.
 - **A surveyed circuit now recognises itself.** Auto-identification only ever
   matched against signatures written by naming a track by hand, which left a
   hole big enough to make surveying feel broken: survey three circuits, never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Notable changes to GT7 Datalogger. The format follows
 
 ### Added
 
+- **The race-line map is something you can actually look at.** It was a
+  360-pixel thumbnail that only the charts could drive, which is not enough
+  map for a 5 km circuit. Now: **⤢ opens it full screen**, with scroll-to-zoom
+  and drag-to-pan (kept out of the rail, where a wheel that sometimes scrolls
+  the page and sometimes zooms is worse than one that always scrolls); a
+  **corner strip** under the map takes you to any corner in one click — as does
+  clicking the numbered circle on the map — and drives the *shared* zoom, so
+  the charts follow the map into the corner instead of the two disagreeing;
+  and the reference lap is drawn as a **continuous zone-coloured line** rather
+  than a dotted trail, because samples land every 5 m and that reads as a line
+  across a whole circuit but as scattered dots exactly where you have zoomed in
+  to look closely.
+
+    The map is also **no longer stretched**. Both axes now share one scale, so a
+  corner's shape on screen is its shape on the track; letting each axis fill
+  the box independently distorted it by the circuit's aspect ratio — 8 % at
+  Lago Maggiore Centre and nearly 3x at Deep Forest.
 - **A surveyed circuit now recognises itself.** Auto-identification only ever
   matched against signatures written by naming a track by hand, which left a
   hole big enough to make surveying feel broken: survey three circuits, never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ Notable changes to GT7 Datalogger. The format follows
 
 ### Added
 
+- **A surveyed circuit now recognises itself.** Auto-identification only ever
+  matched against signatures written by naming a track by hand, which left a
+  hole big enough to make surveying feel broken: survey three circuits, never
+  use *name track…*, and the app has a metre-accurate map of each while still
+  failing to recognise the next session driven there — so the track badge, the
+  outline under the race line, category bests and corner labels all stay empty
+  on a circuit it has mapped in detail. Having surveyed a track and having
+  named it were two separate facts and nothing joined them.
+
+    A lap with no matching signature is now compared against the survey
+  bundles, which are a strictly better fingerprint than a bounding box — they
+  are the road, not a rectangle around it. Matching asks the only question that
+  matters, *did this lap drive on this surveyed tarmac?*, and needs both a
+  coverage floor and a clear margin over the runner-up: two configurations of
+  one venue share tarmac, and a thin margin means the evidence does not
+  actually distinguish them, so the session stays unnamed rather than being
+  given a wrong name silently. Thresholds calibrated against 321 real sessions,
+  where the scores turn out sharply bimodal with an empty band to put the cut
+  in. A signature someone typed still wins outright. (#41)
+- **Sessions recorded before a circuit was surveyed can be named in bulk.**
+  New sessions identify themselves, but history already on disk never got the
+  chance — which, for anyone who surveyed a circuit before this shipped, is all
+  of it. **Tracks → Identify sessions** re-runs the match over every unlabelled
+  session, reading each one's *shortest* usable lap rather than a whole
+  session's telemetry. (#41)
+- **The surveyed road now sits under the race line in Analysis.** A racing line
+  only means something against the road it was driven on — whether the apex was
+  clipped, how much kerb was used, whether there was tarmac left on the exit —
+  and until now the map drew the lap floating in empty space. When the
+  session's circuit is named and surveyed, the map draws the track beneath
+  every lap: road surface, both borders, hand-marked walls in their own colour,
+  and the start/finish line. The geometry is compiled server-side
+  (`/api/track-outline`) and cached per bundle revision, because a bundle is up
+  to 50,000 border records and the browser has no business downloading a
+  circuit's whole survey history to draw a map. Circuits with no bundle answer
+  with an empty outline — never having been surveyed is the common case, not an
+  error — and the map falls back to exactly what it drew before. (#51, carved
+  out of #41)
+- **Traction circle (g-g diagram)** in the Analysis side rail, from the
+  accelerometer GT7 has been broadcasting and this app has been throwing away.
+  Every moment of the lap plotted as lateral against longitudinal g, coloured by
+  input zone: how much of the ring gets used is the reading, and an empty
+  middle-left/middle-right is a car that never brakes and turns at the same
+  time. Compared laps overlay as faint dots, the cursor is synced with the
+  charts and the map, and the peak g in each direction is called out.
+
+    **The scale is checked, not assumed.** GT7 documents neither a unit nor a
+    sign convention for `sway`/`heave`/`surge`, and a simulator cannot prove
+    what a real console sends — which is why #16 said to validate before
+    building any UI. So the app validates, per lap, against physics the same
+    lap already recorded: lateral against `v × ω` (with the signed yaw rate
+    taken from the driven path, since the stored yaw column is absolute),
+    longitudinal against `dv/dt`. A least-squares slope through the origin
+    recovers the unit *and* the sign at once, so the diagram comes out upright
+    whichever way the console counts. When a lap gave too little steady
+    cornering or braking to check, the panel says **scale unverified** rather
+    than drawing a confident-looking circle on an unproven scale. (#16)
+- **Steering-angle channel.** `wheel_rotation` has been decoded since packet B
+  support landed and dropped on the floor ever since. It is now a stored column
+  and a chart panel: next to the yaw-rate trace it is what makes understeer
+  legible — more lock, no more rotation — along with corrections and
+  catch-and-release oversteer. (#15)
+- **ABS and TCS intervention, measured instead of inferred.** The `~` packet
+  format carries the pedal positions *after* the aids acted on them; plotted
+  against the raw pedal the two lines separate exactly where an aid stepped in.
+  New channels: **Throttle applied**, **Brake applied**, and the two gaps on
+  their own — **TCS cut** and **ABS release**. The aids bitmask only ever said
+  *whether* an aid was active; this says how much it took. (#18)
+- **Car category as a real dimension** (#19). The class was already stored and
+  already filtered the Sessions list; it is now a server-side filter
+  (`/api/sessions?category=Gr.3`), it survives a session whose first packet
+  arrived in a narrower format (the session inherits its laps' class rather than
+  sitting outside its own filter), and Analysis shows the **class benchmark** —
+  the fastest full lap ever recorded at this circuit in the same category, the
+  gap to the reference lap, and a link to open it (`/api/laps/best`). Scoped by
+  class deliberately: a Gr.3 time and an N100 time around the same corners are
+  not the same achievement.
 - **Tracks view** (new tab): the three sources of track knowledge, joined —
   the DB's named tracks (which is what makes auto-identification work), the
   survey bundles, and the bundled official GT7 catalog. Having one is not
@@ -162,6 +239,12 @@ Notable changes to GT7 Datalogger. The format follows
 
 ### Fixed
 
+- **Dropping a channel no longer leaves its panel title behind.** The
+  Analysis charts merge their new layout into the old one, replacing only
+  the series — so picking fewer channels left the removed panels' titles
+  painted on top of the ones that remained (and orphaned grids and axes
+  behind them). Everything whose count follows the panel list is now
+  replaced wholesale.
 - **Survey coverage no longer invents gaps on ground that is already
   mapped.** Border evidence recorded travelling the opposite direction was
   ignored at any distance, on the theory that it had to belong to the other
@@ -188,6 +271,33 @@ Notable changes to GT7 Datalogger. The format follows
 
 ### Changed
 
+- **Schema changes are Alembic revisions now, not a growing list of
+  `ALTER TABLE ADD COLUMN`.** The old mechanism could only ever *add* a
+  column, was SQLite-only, and grew by one entry per feature; nearly
+  everything on the roadmap adds columns. Alembic was adopted while the
+  schema is still small, with the existing list folded into a baseline
+  revision. **Existing databases upgrade in place and lose nothing**: a
+  database that predates migrations is brought to the baseline shape by the
+  old list — now frozen, and kept for exactly this — and then stamped, so an
+  install from the first release and a fresh one converge on the same schema
+  and everything after this is an ordinary revision. `init_db` runs
+  migrations to head on every startup; the test suite asserts the upgrade
+  path against a first-release database, lap rows and all. (#14)
+- **The simulator's car is now internally consistent.** Its broadcast yaw
+  rate is the actual turn rate of the line it draws, its accelerometer is
+  `v × ω` and the real speed delta rather than arbitrary multiples, and its
+  filtered pedals differ from the raw ones only while an aid is
+  intervening. Features that check one channel against another — the g-g
+  calibration, the intervention traces — could otherwise never be exercised
+  without a console, because the synthetic data would fail the same check
+  real data has to pass. (#16, #18)
+- **Optional sample columns are absent rather than zero-filled.** The
+  channels that need an extended packet format (steering, accelerometer,
+  filtered pedals) are only recorded on the ticks that carried them, and a
+  lap that did not carry one from start to finish drops it entirely. A
+  zero-filled steering trace reads as "the driver never turned"; a missing
+  panel says nothing false. This also covers a recording whose packet format
+  changed mid-lap. (#15, #16, #18)
 - **Track bundles are now format v3: one voted record per meter of border.**
   Kinds observed at a meter are votes on what it is, resolved with
   hand-marked kinds beating inferred ones (the surface chars cannot see a

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,51 @@
+# Alembic CLI config (#14). The application does NOT read this file — it
+# builds its own Config in app/storage/db.py and upgrades to head at startup.
+# This exists so `alembic revision --autogenerate -m "..."`, `alembic history`
+# and `alembic upgrade --sql head` work from backend/.
+#
+# Point it at a real database when autogenerating:
+#   cd backend && .venv/bin/alembic -x db=../data/gt7.db revision --autogenerate -m "..."
+# or just edit sqlalchemy.url below.
+
+[alembic]
+script_location = app/migrations
+prepend_sys_path = .
+file_template = %%(rev)s_%%(slug)s
+
+# Synchronous driver on purpose: the CLI has no event loop. The app uses
+# sqlite+aiosqlite through the same revisions.
+sqlalchemy.url = sqlite:///../data/gt7.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -43,8 +43,13 @@ async def status(request: Request) -> dict[str, Any]:
 
 
 @router.get("/sessions")
-async def sessions(request: Request) -> list[dict[str, Any]]:
-    return await svc(request).repo.list_sessions()
+async def sessions(
+    request: Request,
+    category: str = Query(
+        "", max_length=16, description="car category (packet C), e.g. Gr.3 — all when blank"
+    ),
+) -> list[dict[str, Any]]:
+    return await svc(request).repo.list_sessions(category.strip() or None)
 
 
 @router.delete("/sessions/{session_id}", dependencies=[Depends(require_admin)])
@@ -69,6 +74,20 @@ async def laps(request: Request) -> list[dict[str, Any]]:
     for lap in laps:
         lap["car_name"] = cars.name(lap["car_id"])
     return laps
+
+
+@router.get("/laps/best")
+async def best_lap(
+    request: Request,
+    track: str = Query(..., min_length=1, max_length=80),
+    category: str = Query(..., min_length=1, max_length=16),
+) -> dict[str, Any] | None:
+    """Fastest full lap at a circuit in one car category (#19).
+
+    Declared BEFORE /laps/{lap_id}: FastAPI matches in declaration order, and
+    "best" would otherwise be handed to the lap-id route as a path parameter.
+    """
+    return await svc(request).repo.best_lap_in(track.strip(), category.strip())
 
 
 @router.get("/laps/{lap_id}")
@@ -128,6 +147,14 @@ CSV_CHANNELS = (
     ("sus_rr", "Susp Travel RR", "mm"),
     ("aids", "Driver Aids", ""),
     ("surface", "Surface Mask", ""),
+    ("steer", "Steering Angle", "rad"),
+    # Raw broadcast units — see analysis.accel_calibration for what they turn
+    # out to be. Exported unconverted so an external tool calibrates its own way.
+    ("acc_lat", "Accel Lateral", ""),
+    ("acc_long", "Accel Longitudinal", ""),
+    ("acc_vert", "Accel Vertical", ""),
+    ("throttle_f", "Throttle Applied", "%"),
+    ("brake_f", "Brake Applied", "%"),
 )
 
 
@@ -361,7 +388,16 @@ async def compare(
     track = await svc(request).repo.track_for_lap(ref)
     authored = await asyncio.to_thread(svc(request).authored_corners, track)
 
-    out: dict[str, Any] = {"ref": ref, "step": step, "channels": list(columns), "laps": {}}
+    out: dict[str, Any] = {
+        "ref": ref,
+        "step": step,
+        "channels": list(columns),
+        # Unit + sign calibration for the broadcast accelerometer, fitted on
+        # the REFERENCE lap and applied to every lap in the comparison, so the
+        # g-g diagram plots them all on one axis (#16).
+        "accel": analysis.accel_calibration(samples_by_id[ref]),
+        "laps": {},
+    }
     for lap_id, samples in samples_by_id.items():
         present = tuple(c for c in columns if c in samples)
         entry: dict[str, Any] = {
@@ -369,6 +405,11 @@ async def compare(
             "peaks_valleys": analysis.speed_peaks_valleys(samples),
             "events": events_by_id.get(lap_id, []),
         }
+        if out["accel"]["available"] and "acc_lat" in samples:
+            # Peaks come from the RAW ticks, not the resampled series the
+            # scatter draws: distance resampling smooths exactly the moments a
+            # traction-circle readout is about.
+            entry["gg"] = analysis.gg_extremes(samples, out["accel"])
         if lap_id == ref:
             # Corner numbering comes from the reference lap only, so every
             # overlaid lap shares one consistent set of map markers — and from

--- a/backend/app/api/tracks.py
+++ b/backend/app/api/tracks.py
@@ -22,18 +22,22 @@ that is a join, not a list.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app.api.auth import require_admin
-from app.processing import survey_log, track_bundle, track_catalog
+from app.processing import survey_log, track_bundle, track_catalog, track_outline, tracks
 
 if TYPE_CHECKING:
     from app.service import TelemetryService
+
+log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api")
 
@@ -146,6 +150,89 @@ async def overview(request: Request) -> dict[str, Any]:
         "tracks": sorted(rows.values(), key=lambda r: r["name"].lower()),
         "logs": survey_log.list_logs(directory),
         "catalog_configs": len(configs),
+    }
+
+
+# --- the surveyed road, compiled for drawing (#51) -----------------------------
+
+
+@router.get("/track-outline")
+async def outline(
+    request: Request,
+    lap_id: int | None = Query(None, description="resolve the circuit from this lap"),
+    track: str = Query("", max_length=track_bundle.MAX_TRACK_NAME),
+) -> dict[str, Any]:
+    """The road a lap was driven on, ready to draw under a race line.
+
+    Answers with an EMPTY outline rather than a 404 when the circuit has no
+    bundle — "this track has never been surveyed" is the common case, not an
+    error, and the map simply falls back to drawing the lap on its own.
+
+    Compiling parses the bundle (multiple megabytes) and pairs thousands of
+    border cells, so it runs off the event loop; repeat calls hit the cache in
+    `track_outline` and cost nothing.
+    """
+    name = track.strip()
+    if not name and lap_id is not None:
+        name = await svc(request).repo.track_for_lap(lap_id)
+    if not name:
+        return track_outline.EMPTY
+    return await asyncio.to_thread(track_outline.for_track, data_dir(request), name)
+
+
+# --- naming sessions from the survey bundles (#41) -----------------------------
+
+
+def _match_blob(
+    raw: str | None, prints: list[tracks.Fingerprint]
+) -> tuple[str, float] | None:
+    """Decode one lap's samples and score it. Runs on a worker thread: the
+    JSON decode is the entire cost of identifying a session."""
+    if not raw:
+        return None
+    try:
+        samples = json.loads(raw)
+    except ValueError:
+        return None
+    return tracks.match_bundles(samples, prints)
+
+
+@router.post("/tracks/identify", dependencies=[Depends(require_admin)])
+async def identify_sessions(request: Request) -> dict[str, Any]:
+    """Name every unlabelled session that was driven on a surveyed circuit.
+
+    New sessions identify themselves as they are recorded; this is for the
+    history that was already on disk before the bundles existed — which, for
+    anyone who surveyed a circuit before this shipped, is all of it.
+
+    Sessions with no confident match are left alone rather than given a
+    best guess: an unlabelled session is honest, a mislabelled one is not.
+    """
+    service = svc(request)
+    directory = data_dir(request)
+    prints = await asyncio.to_thread(tracks.load_fingerprints, directory)
+    if not prints:
+        raise HTTPException(409, "no circuits have been surveyed yet")
+
+    candidates = await service.repo.unnamed_sessions_with_lap()
+    named: dict[str, int] = {}
+    for session_id, lap_id in candidates:
+        raw = await service.repo.lap_samples_json(lap_id)
+        hit = await asyncio.to_thread(_match_blob, raw, prints)
+        if hit is None:
+            continue
+        track, _coverage = hit
+        await service.repo.set_session_track(session_id, track)
+        named[track] = named.get(track, 0) + 1
+        if session_id == service.session_id:
+            # The session being driven right now is in this list too.
+            service.track_name = track
+    if named:
+        log.info("identified %d sessions from survey bundles: %s", sum(named.values()), named)
+    return {
+        "checked": len(candidates),
+        "identified": sum(named.values()),
+        "tracks": dict(sorted(named.items())),
     }
 
 

--- a/backend/app/migrations/__init__.py
+++ b/backend/app/migrations/__init__.py
@@ -1,0 +1,8 @@
+"""Alembic migration environment (#14).
+
+Lives inside the `app` package rather than beside it so `script_location`
+can be resolved from `__file__` — the app builds its Alembic Config in
+Python (see `app.storage.db`) and never reads `alembic.ini` at runtime. The
+ini at the repo's `backend/alembic.ini` exists only for the CLI
+(`alembic revision --autogenerate`, `alembic history`).
+"""

--- a/backend/app/migrations/env.py
+++ b/backend/app/migrations/env.py
@@ -33,10 +33,24 @@ if config.config_file_name is not None:
 target_metadata = Base.metadata
 
 
+def _url() -> str:
+    """The database to work against: `-x db=<path-or-url>` wins over the ini.
+
+    Autogenerating a revision means diffing the models against a REAL database,
+    and the one worth diffing against is rarely the one the ini happens to name
+    — so the flag has to actually do something. A bare path is taken as SQLite,
+    because that is what every database this project makes is.
+    """
+    given = context.get_x_argument(as_dictionary=True).get("db")
+    if not given:
+        return config.get_main_option("sqlalchemy.url") or ""
+    return given if "://" in given else f"sqlite:///{given}"
+
+
 def run_migrations_offline() -> None:
     """Emit SQL to stdout without a database (`alembic upgrade --sql`)."""
     context.configure(
-        url=config.get_main_option("sqlalchemy.url"),
+        url=_url(),
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
@@ -59,7 +73,7 @@ def run_migrations_online() -> None:
         return
 
     engine = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
+        {**config.get_section(config.config_ini_section, {}), "sqlalchemy.url": _url()},
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/backend/app/migrations/env.py
+++ b/backend/app/migrations/env.py
@@ -1,0 +1,77 @@
+"""Alembic environment.
+
+Two entry paths, and both matter:
+
+* **In-process** — `app.storage.db.init_db` hands us a live connection through
+  `config.attributes["connection"]`. The app's engine is async, and Alembic is
+  synchronous, so the connection arrives already unwrapped by
+  `AsyncConnection.run_sync`. Nothing here may open its own engine in that
+  case, or SQLite would be asked for a second writer on the same file.
+* **CLI** — `alembic upgrade head` from `backend/`, which reads the URL from
+  `alembic.ini` (or `-x db=<path>`). Used to generate revisions and to inspect
+  a database by hand; the app never depends on it.
+
+`render_as_batch` is on because SQLite cannot ALTER a column in place: batch
+mode rewrites the table instead, which is the whole reason the hand-rolled
+`ADD COLUMN` list this replaces could only ever add.
+"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.storage.db import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Emit SQL to stdout without a database (`alembic upgrade --sql`)."""
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connection = config.attributes.get("connection")
+    if connection is not None:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+        return
+
+    engine = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with engine.connect() as conn:
+        context.configure(
+            connection=conn, target_metadata=target_metadata, render_as_batch=True
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/app/migrations/script.py.mako
+++ b/backend/app/migrations/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/app/migrations/versions/0001_baseline.py
+++ b/backend/app/migrations/versions/0001_baseline.py
@@ -1,0 +1,112 @@
+"""Baseline schema (#14).
+
+The schema as it stood when migrations were adopted — everything the
+hand-rolled `ALTER TABLE ADD COLUMN` list in `init_db` used to build up one
+release at a time. A database created before this revision existed is
+brought to this exact shape by `app.storage.db._catch_up_legacy` and then
+stamped, so the two paths converge here and every change after this one is
+an ordinary revision.
+
+Revision ID: 0001_baseline
+Revises:
+Create Date: 2026-08-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0001_baseline"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sessions",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.String(), nullable=False),
+        sa.Column("car_id", sa.Integer(), nullable=False),
+        sa.Column("car_name", sa.String(), nullable=False),
+        sa.Column("car_category", sa.String(), nullable=False),
+        sa.Column("note", sa.String(), nullable=False),
+        sa.Column("track_name", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "tracks",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("length_m", sa.Float(), nullable=False),
+        sa.Column("min_x", sa.Float(), nullable=False),
+        sa.Column("max_x", sa.Float(), nullable=False),
+        sa.Column("min_z", sa.Float(), nullable=False),
+        sa.Column("max_z", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_table(
+        "settings",
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("key"),
+    )
+    op.create_table(
+        "layouts",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("kind", sa.String(), nullable=False),
+        sa.Column("config_json", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_table(
+        "laps",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("session_id", sa.Integer(), nullable=False),
+        sa.Column("number", sa.Integer(), nullable=False),
+        sa.Column("time_ms", sa.Integer(), nullable=False),
+        sa.Column("finished_at", sa.String(), nullable=False),
+        sa.Column("car_id", sa.Integer(), nullable=False),
+        sa.Column("car_category", sa.String(), nullable=False),
+        sa.Column("fuel_start", sa.Float(), nullable=False),
+        sa.Column("fuel_end", sa.Float(), nullable=False),
+        sa.Column("fuel_consumed", sa.Float(), nullable=False),
+        sa.Column("full_throttle_pct", sa.Float(), nullable=False),
+        sa.Column("full_brake_pct", sa.Float(), nullable=False),
+        sa.Column("coasting_pct", sa.Float(), nullable=False),
+        sa.Column("tire_spin_pct", sa.Float(), nullable=False),
+        sa.Column("max_speed", sa.Float(), nullable=False),
+        sa.Column("min_body_height", sa.Float(), nullable=False),
+        sa.Column("total_ticks", sa.Integer(), nullable=False),
+        sa.Column("tod_ms", sa.Integer(), nullable=False),
+        sa.Column("tcs_active_pct", sa.Float(), nullable=False),
+        sa.Column("asm_active_pct", sa.Float(), nullable=False),
+        sa.Column("max_water_temp", sa.Float(), nullable=False),
+        sa.Column("max_oil_temp", sa.Float(), nullable=False),
+        sa.Column("min_oil_pressure", sa.Float(), nullable=False),
+        sa.Column("counts_for_best", sa.Boolean(), nullable=False),
+        sa.Column("off_track_count", sa.Integer(), nullable=False),
+        sa.Column("clean_lap", sa.Boolean(), nullable=True),
+        sa.Column("events_json", sa.Text(), nullable=False),
+        sa.Column("gearing_json", sa.Text(), nullable=False),
+        sa.Column("samples_json", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["session_id"], ["sessions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_laps_session", "laps", ["session_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_laps_session", table_name="laps")
+    op.drop_table("laps")
+    op.drop_table("layouts")
+    op.drop_table("settings")
+    op.drop_table("tracks")
+    op.drop_table("sessions")

--- a/backend/app/migrations/versions/__init__.py
+++ b/backend/app/migrations/versions/__init__.py
@@ -1,0 +1,2 @@
+"""Revision scripts. Alembic skips this file when scanning for revisions;
+it exists so setuptools ships the revisions with the package."""

--- a/backend/app/processing/analysis.py
+++ b/backend/app/processing/analysis.py
@@ -607,6 +607,199 @@ def _apex_index(a: _Arc, curv: list[float]) -> int:
     return idx0 if t0 >= t1 else idx1
 
 
+# --- Accelerometer calibration (#16) -----------------------------------------
+#
+# GT7 broadcasts `sway`/`heave`/`surge` (packet B) with no documented unit and
+# no documented sign convention, and the simulator source cannot prove what a
+# real console sends — which is exactly why #16 said "validate before building
+# UI". So the app validates them against physics it already records, per lap:
+#
+#   lateral       a = v * omega      omega = signed heading rate from the path
+#   longitudinal  a = dv/dt          from the speed trace
+#
+# Both references are in m/s^2 and both are signed, so a least-squares slope
+# through the origin recovers the broadcast channel's UNIT (slope ~1 means it
+# is m/s^2, ~0.102 means it is already g) and its SIGN at the same time. What
+# comes back is a multiplier to g, so a g-g diagram reads correctly whichever
+# convention the console turns out to use — and says so when the fit is too
+# weak to trust.
+
+GRAVITY = 9.80665
+
+# A lap has thousands of ticks; a fit resting on a handful of them is noise.
+ACC_MIN_SAMPLES = 150
+# Share of the channel's magnitude the scaled reference has to explain. This
+# is R² about ZERO, not about the mean: the model is forced through the origin
+# (see _fit_through_origin), and a mean-centred correlation collapses on
+# exactly the cleanest case there is — a long constant-rate braking zone,
+# where both series are near-constant and Pearson r becomes numerical noise.
+ACC_MIN_R2 = 0.75
+# Only fit where the reference itself is large enough to have a meaningful
+# ratio: near zero the quotient is dominated by jitter in both series.
+ACC_MIN_REF = 1.5  # m/s^2
+ACC_MIN_SPEED = 8.0  # m/s — below this, heading from position is noise
+# A slope this small would mean the channel is ~flat against the reference;
+# inverting it produces an absurd scale rather than a calibration.
+ACC_MIN_SLOPE = 1e-3
+
+
+def _fit_through_origin(xs: list[float], ys: list[float]) -> tuple[float, float]:
+    """(slope, R² about zero) for y = slope * x, forced through the origin.
+
+    The intercept is fixed at zero on purpose: zero reference acceleration
+    must mean zero broadcast acceleration, and a free intercept would happily
+    absorb a systematic offset that is the very thing worth seeing. The
+    goodness measure is taken about zero for the same reason — how much of the
+    channel's own magnitude the scaled reference accounts for. It is 1 for a
+    perfect fit and goes negative for a channel the reference does not
+    describe at all.
+    """
+    if len(xs) < 2:
+        return 0.0, 0.0
+    sxx = sum(x * x for x in xs)
+    syy = sum(y * y for y in ys)
+    if sxx <= 0 or syy <= 0:
+        return 0.0, 0.0
+    slope = sum(x * y for x, y in zip(xs, ys, strict=True)) / sxx
+    sse = sum((y - slope * x) ** 2 for x, y in zip(xs, ys, strict=True))
+    return slope, 1.0 - sse / syy
+
+
+# Half-window for the path heading, in METRES of track rather than ticks.
+# Positions are stored rounded to a centimetre, so heading resolution is
+# 0.01 / chord: over the ~1 m a tick covers at speed that is 0.01 rad, which
+# swamps the 0.002 rad/tick a real corner turns, and differencing consecutive
+# ticks yields a staircase of quantisation noise rather than a yaw rate. Over
+# 8 m the same rounding is 0.001 rad, two orders below what a 46 m radius
+# turns across that distance. Distance-based because the tick spacing itself
+# varies with speed by a factor of five.
+HEADING_SPAN_M = 8.0
+
+
+def _heading_rate(samples: Samples) -> list[float]:
+    """Signed yaw rate (rad/s) from the driven path, per tick.
+
+    The stored `yaw_rate` column is an ABSOLUTE value, so it cannot settle
+    which way `sway` counts positive. Positive here is the same convention
+    corner detection uses: a positive heading delta in raw x/z, which the map
+    (z inverted, as GT7 draws it) renders as a right-hander.
+
+    The chord-heading-difference scheme is the one `detect_corners` uses, for
+    the same reason: it measures the turn over a fixed length of road instead
+    of a fixed number of samples.
+    """
+    t = samples.get("t") or []
+    xs = samples.get("pos_x") or []
+    zs = samples.get("pos_z") or []
+    dist = samples.get("dist") or []
+    n = min(len(t), len(xs), len(zs), len(dist))
+    out = [0.0] * n
+    if n < 5:
+        return out
+    for i in range(n):
+        lo = bisect_left(dist, dist[i] - HEADING_SPAN_M, 0, i)
+        hi = bisect_left(dist, dist[i] + HEADING_SPAN_M, i, n)
+        hi = min(hi, n - 1)
+        if hi - i < 1 or i - lo < 1:
+            continue
+        before = math.atan2(zs[i] - zs[lo], xs[i] - xs[lo])
+        after = math.atan2(zs[hi] - zs[i], xs[hi] - xs[i])
+        # The two chords represent the heading at their own midpoints in time.
+        dt = (t[hi] - t[lo]) / 2
+        if dt > 0:
+            out[i] = _wrap_angle(after - before) / dt
+    return out
+
+
+def _axis(
+    raw: list[float], reference: list[float], mask: list[bool]
+) -> dict[str, Any]:
+    """Calibrate one accelerometer axis against a physical reference."""
+    xs = [reference[i] for i, ok in enumerate(mask) if ok]
+    ys = [raw[i] for i, ok in enumerate(mask) if ok]
+    slope, r2 = _fit_through_origin(xs, ys)
+    ok = len(xs) >= ACC_MIN_SAMPLES and r2 >= ACC_MIN_R2 and abs(slope) >= ACC_MIN_SLOPE
+    return {
+        "slope": round(slope, 5),  # broadcast units per m/s^2
+        "r2": round(r2, 4),
+        "samples": len(xs),
+        "fitted": ok,
+        # What a consumer multiplies the raw channel by to get g. Carries the
+        # sign, so a channel that counts the other way comes out upright.
+        "g_per_unit": round(1.0 / (slope * GRAVITY), 6) if ok else round(1.0 / GRAVITY, 6),
+    }
+
+
+def accel_calibration(samples: Samples) -> dict[str, Any]:
+    """Unit + sign calibration for a lap's broadcast accelerometer channels.
+
+    Returns `available: False` for a recording made on packet A (no
+    accelerometer at all). When a fit is too weak the axis falls back to
+    assuming m/s^2 and reports `fitted: False`, so the UI can show the
+    diagram and still say the calibration is unproven.
+    """
+    lat_raw = samples.get("acc_lat") or []
+    long_raw = samples.get("acc_long") or []
+    t = samples.get("t") or []
+    speed = samples.get("speed") or []
+    heading = _heading_rate(samples)
+    n = min(len(t), len(speed), len(lat_raw), len(long_raw), len(heading))
+    if n < ACC_MIN_SAMPLES:
+        return {"available": False}
+
+    v = [speed[i] / 3.6 for i in range(n)]  # km/h -> m/s
+    lat_ref = [v[i] * heading[i] for i in range(n)]
+    long_ref = [0.0] * n
+    for i in range(1, n - 1):
+        dt = t[i + 1] - t[i - 1]
+        if dt > 0:
+            long_ref[i] = (v[i + 1] - v[i - 1]) / dt
+
+    moving = [v[i] >= ACC_MIN_SPEED for i in range(n)]
+    lat = _axis(
+        lat_raw[:n], lat_ref, [moving[i] and abs(lat_ref[i]) >= ACC_MIN_REF for i in range(n)]
+    )
+    lon = _axis(
+        long_raw[:n], long_ref, [moving[i] and abs(long_ref[i]) >= ACC_MIN_REF for i in range(n)]
+    )
+    return {
+        "available": True,
+        "lateral": lat,
+        "longitudinal": lon,
+        # One line a human can read: what the broadcast unit appears to be.
+        "unit": _unit_guess(lat, lon),
+    }
+
+
+def _unit_guess(lat: dict[str, Any], lon: dict[str, Any]) -> str:
+    slopes = [abs(a["slope"]) for a in (lat, lon) if a["fitted"]]
+    if not slopes:
+        return "unverified"
+    mean = sum(slopes) / len(slopes)
+    if 0.7 <= mean <= 1.4:
+        return "m/s^2"
+    if 0.07 <= mean <= 0.14:
+        return "g"
+    return f"1 unit = {round(1 / mean, 3)} m/s^2"
+
+
+def gg_extremes(samples: Samples, calibration: dict[str, Any]) -> dict[str, float]:
+    """Peak g actually used, in each direction — the corners of the envelope."""
+    lat_k = calibration.get("lateral", {}).get("g_per_unit", 1 / GRAVITY)
+    long_k = calibration.get("longitudinal", {}).get("g_per_unit", 1 / GRAVITY)
+    lat = [v * lat_k for v in samples.get("acc_lat") or []]
+    lon = [v * long_k for v in samples.get("acc_long") or []]
+    # Clamped at zero: a direction the lap never went in used no g at all, and
+    # an oval driven one way round would otherwise report a negative peak for
+    # the side it never turned to.
+    return {
+        "lat_right": round(max(0.0, max(lat, default=0.0)), 3),
+        "lat_left": round(max(0.0, -min(lat, default=0.0)), 3),
+        "accel": round(max(0.0, max(lon, default=0.0)), 3),
+        "braking": round(max(0.0, -min(lon, default=0.0)), 3),
+    }
+
+
 # --- Fuel map ---------------------------------------------------------------
 
 # GT7's fuel map setting (1..6 in some cars, modeled here as -5..+5 relative

--- a/backend/app/processing/laps.py
+++ b/backend/app/processing/laps.py
@@ -50,6 +50,24 @@ SPANS_FOR_MEDIAN = 3
 # and the real partials sat at 88 %, 88 %, 81 %, 65 % and 40 %.
 PROVISIONAL_SPAN_RATIO = 0.93
 
+# Columns only the extended packet formats can fill (#15, #16, #18). Unlike
+# every other column these are NOT appended on ticks that lack them, and a lap
+# that did not carry one from start to finish drops it entirely — see
+# prune_optional for why zero-filling would be worse than absence.
+#
+#   steer                       packet B  wheel_rotation, radians as broadcast
+#   acc_lat/acc_long/acc_vert   packet B  sway/surge/heave, raw accelerometer
+#                                         units (calibrated in analysis.py —
+#                                         GT7 documents no unit for these)
+#   throttle_f/brake_f          packet ~  pedal AFTER the aids acted on it, %;
+#                                         the gap to throttle/brake is the
+#                                         intervention, measured not inferred
+OPTIONAL_COLUMNS = (
+    "steer",
+    "acc_lat", "acc_long", "acc_vert",
+    "throttle_f", "brake_f",
+)
+
 # Columnar per-tick series kept for each lap. Column order matters for the
 # frontend; keep in sync with frontend/src/lib/types.ts.
 SAMPLE_COLUMNS = (
@@ -61,11 +79,32 @@ SAMPLE_COLUMNS = (
     "sus_fl", "sus_fr", "sus_rl", "sus_rr",  # suspension compression, mm
     "aids",  # AidsBits mask: TCS | ASM | handbrake | rev limiter
     "surface",  # packed per-wheel surface codes (see processing/surface.py)
+    *OPTIONAL_COLUMNS,
 )
 
 
 def new_sample_store() -> dict[str, list[float]]:
     return {c: [] for c in SAMPLE_COLUMNS}
+
+
+def prune_optional(samples: dict[str, list[float]]) -> list[str]:
+    """Drop optional columns this lap did not carry all the way through.
+
+    An optional column is only appended on the ticks that actually supplied
+    it, so a lap recorded on packet A leaves `steer` empty and a lap that
+    switched format mid-way leaves it short. Both are dropped whole rather
+    than padded: a zero-filled steering trace reads as "the driver never
+    turned", and a flat zero g-g scatter reads as "the car never gripped" —
+    lies that an absent panel does not tell. Consumers already treat a
+    missing column as "this recording has no such channel".
+
+    Mutates `samples` and returns what it removed.
+    """
+    n = len(samples.get("t") or [])
+    dropped = [c for c in OPTIONAL_COLUMNS if c in samples and len(samples[c]) != n]
+    for column in dropped:
+        del samples[column]
+    return dropped
 
 
 def _time_weights(t: list[float]) -> list[float]:
@@ -142,6 +181,11 @@ class CompletedLap:
         s = self.samples
         n = len(s["t"])
         self.total_ticks = n
+        # Before anything reads them: a half-populated optional column would
+        # otherwise be persisted and then silently mis-align with `dist`.
+        dropped = prune_optional(s)
+        if dropped:
+            log.debug("lap %d: dropped incomplete channels %s", self.number, dropped)
         if n == 0:
             return
         # Percentages are time-weighted: after a dropped-frame gap a sample
@@ -433,6 +477,21 @@ class LapProcessor:
         s["sus_rr"].append(round(p.suspension_rr * 1000, 1))
         s["aids"].append(float(p.aids_bits))
         s["surface"].append(float(encode_surface(p.surface_types)))
+        # Optional columns: appended only on the ticks that carried them, so a
+        # recording made on a narrower packet format ends up without the
+        # column rather than with a column of invented zeros (prune_optional).
+        if p.wheel_rotation is not None:
+            s["steer"].append(round(p.wheel_rotation, 4))
+        if p.sway is not None:
+            s["acc_lat"].append(round(p.sway, 3))
+        if p.surge is not None:
+            s["acc_long"].append(round(p.surge, 3))
+        if p.heave is not None:
+            s["acc_vert"].append(round(p.heave, 3))
+        if p.throttle_filtered is not None:
+            s["throttle_f"].append(round(p.throttle_filtered / 2.55, 1))
+        if p.brake_filtered is not None:
+            s["brake_f"].append(round(p.brake_filtered / 2.55, 1))
         # Engine-health aggregates (per-lap, not per-tick)
         self._max_water = max(self._max_water, p.water_temp)
         self._max_oil = max(self._max_oil, p.oil_temp)

--- a/backend/app/processing/track_outline.py
+++ b/backend/app/processing/track_outline.py
@@ -1,0 +1,205 @@
+"""The surveyed road, compiled into something a lap can be drawn on (#51).
+
+A racing line only means something against the road it was driven on: whether
+the apex was clipped, how much kerb was used, whether there was tarmac left on
+the exit. The survey bundles hold that road — but as up to 50,000 voted border
+cells, which is several megabytes, and the Analysis view must not download a
+circuit's whole survey history to draw a map behind one lap.
+
+So the road is compiled here instead: border cells are paired across the
+carriageway into quads, borders are reduced to short direction-carrying
+segments, and the finish line is resolved from the recorded crossings. What
+comes out is a few hundred kilobytes of geometry with no votes, no provenance
+and no elevation — everything the map draws and nothing it doesn't.
+
+The pairing rule is the Survey view's, moved server-side (it lives in
+`frontend/src/lib/surveyGeometry.ts` as `roadQuads`, where it runs on a single
+run's evidence as it accumulates). It is deliberately LOCAL: a left border
+point pairs with the right border point directly across from it, judged by the
+travel direction each was recorded under. Nothing here reconstructs a
+centerline or an ordering, which is what lets a partially surveyed circuit
+draw the parts it knows and leave the rest blank rather than drawing a
+confident wrong loop through them.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+from app.processing import track_bundle
+
+log = logging.getLogger(__name__)
+
+# Cross-section plausibility, mirroring frontend/src/lib/surveyGeometry.ts.
+ROAD_WIDTH_MIN_M = 3.0
+ROAD_WIDTH_MAX_M = 40.0
+ACROSS_MIN_DOT = 0.85  # L->R direction vs the left point's right-normal (~32°)
+HEADING_MIN_DOT = 0.7  # both contacts recorded travelling the same way
+QUAD_HALF_LENGTH_M = 2.5  # along-track extent of one filled span
+CELL_M = ROAD_WIDTH_MAX_M  # spatial-hash cell = the whole search radius
+
+# Half-length of the drawn start/finish line, and of a border tick.
+FINISH_HALF_M = 12.0
+TICK_HALF_M = 0.9
+
+# Compiled outlines, keyed by bundle file identity (path + mtime + size) so a
+# re-survey or an import invalidates it without anyone having to remember to.
+# Small: the cost being avoided is parsing a multi-megabyte document and
+# pairing thousands of cells, per Analysis page load.
+_CACHE: dict[tuple[str, int, int], dict[str, Any]] = {}
+_CACHE_MAX = 8
+
+
+def _round_pairs(values: list[float]) -> list[float]:
+    return [round(v, 1) for v in values]
+
+
+def road_quads(edges: list[dict[str, Any]]) -> list[list[float]]:
+    """Filled road spans wherever a left border cell faces a right one.
+
+    Every kind contributes, "runoff" included: those marks are track edges
+    that happen to have pavement beyond them, and excluding them drew no road
+    at all through the corners someone took the trouble to survey.
+    """
+    rights: dict[tuple[int, int], list[dict[str, Any]]] = {}
+    for e in edges:
+        if e["side"] != "R":
+            continue
+        key = (math.floor(e["x"] / CELL_M), math.floor(e["z"] / CELL_M))
+        rights.setdefault(key, []).append(e)
+
+    quads: list[list[float]] = []
+    for left in edges:
+        if left["side"] != "L":
+            continue
+        # Right-normal of the left point's heading: the direction the road
+        # should lie in from here.
+        rnx, rnz = left["hz"], -left["hx"]
+        best: dict[str, Any] | None = None
+        best_dist = ROAD_WIDTH_MAX_M
+        cx = math.floor(left["x"] / CELL_M)
+        cz = math.floor(left["z"] / CELL_M)
+        for gx in (cx - 1, cx, cx + 1):
+            for gz in (cz - 1, cz, cz + 1):
+                for right in rights.get((gx, gz), ()):
+                    dx = right["x"] - left["x"]
+                    dz = right["z"] - left["z"]
+                    dist = math.hypot(dx, dz)
+                    if dist < ROAD_WIDTH_MIN_M or dist >= best_dist:
+                        continue
+                    if (dx * rnx + dz * rnz) / dist < ACROSS_MIN_DOT:
+                        continue
+                    if left["hx"] * right["hx"] + left["hz"] * right["hz"] < HEADING_MIN_DOT:
+                        continue
+                    best, best_dist = right, dist
+        if best is None:
+            continue
+        ax = left["hx"] + best["hx"]
+        az = left["hz"] + best["hz"]
+        alen = math.hypot(ax, az) or 1.0
+        ax = ax / alen * QUAD_HALF_LENGTH_M
+        az = az / alen * QUAD_HALF_LENGTH_M
+        quads.append(_round_pairs([
+            left["x"] - ax, left["z"] - az,
+            left["x"] + ax, left["z"] + az,
+            best["x"] + ax, best["z"] + az,
+            best["x"] - ax, best["z"] - az,
+        ]))
+    return quads
+
+
+def _tick(e: dict[str, Any]) -> list[float]:
+    """One border cell as a short segment [x1, z1, x2, z2] along travel."""
+    hx = e["hx"] * TICK_HALF_M
+    hz = e["hz"] * TICK_HALF_M
+    return _round_pairs([e["x"] - hx, e["z"] - hz, e["x"] + hx, e["z"] + hz])
+
+
+def finish_line(crossings: list[dict[str, float]]) -> list[float] | None:
+    """The start/finish line across the road, from recorded lap rollovers.
+
+    Averaged over every crossing the bundle holds: GT7 increments the lap
+    counter exactly on the line, but the car crosses it at a different point
+    of the road each lap, so one crossing places the line and several agree on
+    where the middle of it is.
+    """
+    if not crossings:
+        return None
+    n = len(crossings)
+    x = sum(c["x"] for c in crossings) / n
+    z = sum(c["z"] for c in crossings) / n
+    hx = sum(c["hx"] for c in crossings) / n
+    hz = sum(c["hz"] for c in crossings) / n
+    length = math.hypot(hx, hz)
+    if length < 1e-6:
+        return None
+    # The line lies across the direction of travel.
+    rx = hz / length * FINISH_HALF_M
+    rz = -hx / length * FINISH_HALF_M
+    return _round_pairs([x - rx, z - rz, x + rx, z + rz])
+
+
+def build(doc: dict[str, Any]) -> dict[str, Any]:
+    """Compile one bundle document into the map's drawing geometry."""
+    edges = doc["edges"]
+    walls = [e for e in edges if e["kind"] == "wall"]
+    borders = [e for e in edges if e["kind"] != "wall"]
+    return {
+        "track": doc["meta"]["track"],
+        "slug": track_bundle.slugify(doc["meta"]["track"]),
+        "road": road_quads(edges),
+        # Walls are drawn apart from the rest: hitting one ends a lap, and a
+        # line that ran wide over a run-off limit reads very differently from
+        # one that ran wide into a barrier.
+        "edges": [_tick(e) for e in borders],
+        "walls": [_tick(e) for e in walls],
+        "finish": finish_line(doc["finish_crossings"]),
+        "runs": doc["meta"]["runs"],
+        "updated_at": doc["meta"]["updated_at"],
+    }
+
+
+EMPTY: dict[str, Any] = {
+    "track": "",
+    "slug": None,
+    "road": [],
+    "edges": [],
+    "walls": [],
+    "finish": None,
+    "runs": 0,
+    "updated_at": "",
+}
+
+
+def for_track(data_dir: Path, track: str) -> dict[str, Any]:
+    """A circuit's compiled outline, or EMPTY when it has never been surveyed.
+
+    Blocking (parses the bundle on a cache miss): callers run it off the event
+    loop.
+    """
+    if not track:
+        return EMPTY
+    path = track_bundle.bundle_path(data_dir, track)
+    try:
+        stat = path.stat()
+    except OSError:
+        return EMPTY
+    key = (str(path), stat.st_mtime_ns, stat.st_size)
+    cached = _CACHE.get(key)
+    if cached is not None:
+        return cached
+    doc = track_bundle.load(data_dir, track)
+    if doc is None:
+        return EMPTY
+    outline = build(doc)
+    if len(_CACHE) >= _CACHE_MAX:
+        _CACHE.clear()  # a handful of circuits; no need for true LRU accounting
+    _CACHE[key] = outline
+    log.info(
+        "compiled track outline for %r: %d road spans, %d border ticks",
+        outline["track"], len(outline["road"]), len(outline["edges"]) + len(outline["walls"]),
+    )
+    return outline

--- a/backend/app/processing/tracks.py
+++ b/backend/app/processing/tracks.py
@@ -58,6 +58,20 @@ BUNDLE_SAMPLES = 600
 # all. The cut goes in the middle of that empty band: twice the noise floor,
 # and still low enough that a half-finished survey identifies its own circuit.
 BUNDLE_MIN_COVERAGE = 0.60
+# How close a lap must come back to where it started to count as having gone
+# all the way round (see is_whole_lap), as an absolute distance OR a share of
+# the lap's own length — whichever is more forgiving. Both terms earn their
+# place. Measured over 1,635 of the author's recorded laps: 1,583 of the 1,618
+# full ones close within 10 m (median 1 m) and not one of the 17 partial laps
+# closes within 50 m, so a flat threshold separates them cleanly. But the tail
+# of full laps that end 100-200 m out are real laps missing their last second
+# to dropped packets, and 120 m means nothing on a 4 km lap while meaning
+# everything on a 500 m one. Together these keep 99.6 % of full laps and turn
+# away 15 of the 17 partials.
+ROUTE_CLOSE_M = 60.0
+ROUTE_CLOSE_FRACTION = 0.05
+ROUTE_MIN_M = 400.0  # ...and a car parked on the line closes perfectly
+
 # Shortest lap worth identifying a session from. Deliberately not the
 # lap-detection minimum: that one exists to reject phantom laps, while this one
 # only asks whether there is enough driven geometry to score — a couple of
@@ -167,16 +181,43 @@ def coverage(samples: dict[str, list[float]], print_: Fingerprint) -> float:
     return hit / tested if tested else 0.0
 
 
+def is_whole_lap(samples: dict[str, list[float]]) -> bool:
+    """Did this lap go all the way round, ending where it started?
+
+    Coverage is a share of whatever samples it is handed, so a FRAGMENT can
+    score 100 % on a stretch of tarmac two layouts share while saying nothing
+    about which of them was driven — and the piece that would have settled it
+    is the piece that is missing. The layouts of one venue diverge somewhere;
+    a lap that closes has been through wherever that is.
+
+    Cheap and self-contained, which matters because the first lap of a session
+    is the one that gets to name it, and at that point there are no other laps
+    to compare a span against.
+    """
+    xs = samples.get("pos_x") or []
+    zs = samples.get("pos_z") or []
+    dist = samples.get("dist") or []
+    if len(xs) < 2 or len(zs) < 2 or not dist:
+        return False
+    if dist[-1] < ROUTE_MIN_M:
+        return False  # too little driving to be a lap of anything
+    closes_within = max(ROUTE_CLOSE_M, dist[-1] * ROUTE_CLOSE_FRACTION)
+    return math.hypot(xs[-1] - xs[0], zs[-1] - zs[0]) <= closes_within
+
+
 def match_bundles(
     samples: dict[str, list[float]], prints: list[Fingerprint]
 ) -> tuple[str, float] | None:
     """Which surveyed circuit this lap was driven on, if the evidence is clear.
 
-    Returns (track, coverage) or None. None covers both "no bundle describes
-    this lap" and "two of them describe it about equally well" — the second is
-    a real case (a venue's configurations overlap) and guessing between them
+    Returns (track, coverage) or None. None covers three things: the lap is
+    not a whole lap and so cannot be trusted to distinguish layouts, no bundle
+    describes it, or two of them describe it about equally well. The last is a
+    real case (a venue's configurations overlap) and guessing between them
     would put the wrong name on a session silently.
     """
+    if not is_whole_lap(samples):
+        return None
     scored = sorted(
         ((coverage(samples, p), p.track) for p in prints), reverse=True
     )

--- a/backend/app/processing/tracks.py
+++ b/backend/app/processing/tracks.py
@@ -1,18 +1,74 @@
 """Track auto-identification from lap geometry.
 
-A track is fingerprinted by its lap length and the bounding box of the racing
-line. GT7 world coordinates are fixed per track, so a stored signature matches
-future sessions on the same circuit regardless of car or lap time.
+Two fingerprints, tried in that order:
+
+**A stored signature** — lap length plus the bounding box of the racing line,
+written when a human names a circuit. GT7 world coordinates are fixed per
+track, so it matches future sessions regardless of car or lap time. It is
+tried first because a name a person typed outranks anything inferred.
+
+**A survey bundle** — the surveyed road itself (#41). This exists because the
+signature path has a bootstrapping hole that made the whole feature useless
+in practice: a signature only exists once somebody has named a circuit, so a
+driver who surveys three tracks and never uses "name track…" gets no
+identification at all, and everything hanging off the circuit name — the
+outline under the race line, category bests, corner labels — silently stays
+empty. Having surveyed a track and having named it were two separate facts,
+and nothing joined them.
+
+A bundle is also a strictly better fingerprint than a bounding box: it is the
+road, not a rectangle around it. Matching asks the only question that
+matters — *did this lap drive on this surveyed tarmac?* — by counting how
+many of the lap's positions have border evidence beside them. On the author's
+own recordings the correct circuit scores 100 % and the runners-up 50 % or
+less, including between two configurations of the same venue that share a
+bounding box entirely.
 """
 
 from __future__ import annotations
 
+import logging
+import math
 from dataclasses import dataclass
-from typing import Protocol
+from pathlib import Path
+from typing import Any, Protocol
+
+from app.processing import track_bundle
+
+log = logging.getLogger(__name__)
 
 LENGTH_TOLERANCE = 0.04  # 4 % lap-length difference (racing line varies)
 CENTER_TOLERANCE_M = 120.0
 EXTENT_TOLERANCE = 0.20
+
+# --- bundle matching ----------------------------------------------------------
+
+# Occupancy grid for border evidence. Coarse on purpose: the question is "was
+# the car on this road", and a cell wide enough to span a carriageway answers
+# it whichever line through the corner the driver took.
+BUNDLE_CELL_M = 20.0
+# Lap positions tested. A lap is thousands of ticks and the answer does not
+# improve past a few hundred well-spread points.
+BUNDLE_SAMPLES = 600
+# Share of those points that must sit on surveyed road. Calibrated against 321
+# of the author's recorded sessions scored over three bundles: the result is
+# sharply bimodal — 13 sessions at 100 %, 5 more at 0.65-0.85 (all of them on
+# the circuit with the thinnest survey, 406 border records), then NOTHING until
+# 0.33, below which sit the 302 sessions driven at circuits with no bundle at
+# all. The cut goes in the middle of that empty band: twice the noise floor,
+# and still low enough that a half-finished survey identifies its own circuit.
+BUNDLE_MIN_COVERAGE = 0.60
+# Shortest lap worth identifying a session from. Deliberately not the
+# lap-detection minimum: that one exists to reject phantom laps, while this one
+# only asks whether there is enough driven geometry to score — a couple of
+# seconds of it is plenty, and picking the shortest usable lap is what keeps a
+# whole-history backfill from reading every sample blob on disk.
+IDENTIFY_MIN_TICKS = 120
+# ...and it must beat the runner-up by this much. Two configurations of one
+# venue share tarmac, so the loser is never at zero; what separates them is
+# the margin, and a thin one means the evidence does not actually distinguish
+# them. Refusing to guess is the right answer there.
+BUNDLE_MIN_MARGIN = 0.25
 
 
 @dataclass(slots=True)
@@ -62,3 +118,112 @@ def matches(sig: TrackSignature, track: TrackLike) -> bool:
         if trk_ext > 0 and abs(sig_ext - trk_ext) / trk_ext > EXTENT_TOLERANCE:
             return False
     return True
+
+
+# --- matching a lap against the survey bundles (#41) ---------------------------
+
+
+@dataclass(slots=True)
+class Fingerprint:
+    """One circuit's surveyed road as an occupancy grid."""
+
+    track: str
+    cells: frozenset[tuple[int, int]]
+    points: int  # border records behind it, for reporting
+
+
+def fingerprint(doc: dict[str, Any]) -> Fingerprint:
+    return Fingerprint(
+        track=doc["meta"]["track"],
+        cells=frozenset(
+            (math.floor(e["x"] / BUNDLE_CELL_M), math.floor(e["z"] / BUNDLE_CELL_M))
+            for e in doc["edges"]
+        ),
+        points=len(doc["edges"]),
+    )
+
+
+def coverage(samples: dict[str, list[float]], print_: Fingerprint) -> float:
+    """Share of the lap's positions with border evidence beside them.
+
+    The 3x3 cell neighbourhood is checked rather than the exact cell, so a
+    lap running down the middle of a wide road still counts as on it.
+    """
+    xs = samples.get("pos_x") or []
+    zs = samples.get("pos_z") or []
+    n = min(len(xs), len(zs))
+    if n == 0 or not print_.cells:
+        return 0.0
+    step = max(1, n // BUNDLE_SAMPLES)
+    tested = hit = 0
+    for i in range(0, n, step):
+        cx = math.floor(xs[i] / BUNDLE_CELL_M)
+        cz = math.floor(zs[i] / BUNDLE_CELL_M)
+        tested += 1
+        if any(
+            (cx + a, cz + b) in print_.cells for a in (-1, 0, 1) for b in (-1, 0, 1)
+        ):
+            hit += 1
+    return hit / tested if tested else 0.0
+
+
+def match_bundles(
+    samples: dict[str, list[float]], prints: list[Fingerprint]
+) -> tuple[str, float] | None:
+    """Which surveyed circuit this lap was driven on, if the evidence is clear.
+
+    Returns (track, coverage) or None. None covers both "no bundle describes
+    this lap" and "two of them describe it about equally well" — the second is
+    a real case (a venue's configurations overlap) and guessing between them
+    would put the wrong name on a session silently.
+    """
+    scored = sorted(
+        ((coverage(samples, p), p.track) for p in prints), reverse=True
+    )
+    if not scored:
+        return None
+    best, track = scored[0]
+    runner_up = scored[1][0] if len(scored) > 1 else 0.0
+    if best < BUNDLE_MIN_COVERAGE or best - runner_up < BUNDLE_MIN_MARGIN:
+        return None
+    return track, best
+
+
+# Fingerprints are derived from bundles that are multiple megabytes each, so
+# they are cached against the files' identity (path + mtime + size) — a
+# re-survey, an import or a rename invalidates them without anyone having to
+# remember to.
+_PRINTS: dict[tuple[tuple[str, int, int], ...], list[Fingerprint]] = {}
+
+
+def load_fingerprints(data_dir: Path) -> list[Fingerprint]:
+    """Every surveyed circuit's fingerprint. Blocking: parses the bundles."""
+    directory = data_dir / track_bundle.BUNDLE_DIR
+    if not directory.is_dir():
+        return []
+    key: list[tuple[str, int, int]] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            stat = path.stat()
+        except OSError:  # pragma: no cover - vanished between glob and stat
+            continue
+        key.append((path.name, stat.st_mtime_ns, stat.st_size))
+    cached = _PRINTS.get(tuple(key))
+    if cached is not None:
+        return cached
+    prints = []
+    for name, _mtime, _size in key:
+        doc = track_bundle.load_slug(data_dir, Path(name).stem)
+        if doc is not None:
+            prints.append(fingerprint(doc))
+    _PRINTS.clear()  # one installation, one bundle set; no need for true LRU
+    _PRINTS[tuple(key)] = prints
+    log.info("track fingerprints built: %s", [p.track for p in prints])
+    return prints
+
+
+def identify_from_bundles(
+    data_dir: Path, samples: dict[str, list[float]]
+) -> tuple[str, float] | None:
+    """Name the circuit a lap was driven on from the survey bundles."""
+    return match_bundles(samples, load_fingerprints(data_dir))

--- a/backend/app/service.py
+++ b/backend/app/service.py
@@ -15,7 +15,7 @@ from fastapi import WebSocket
 from app.config import Settings
 from app.models import TelemetryPacket
 from app.notify import Notifier
-from app.processing import track_bundle
+from app.processing import track_bundle, tracks
 from app.processing.analysis import Samples, time_delta_at
 from app.processing.cars import CarDatabase
 from app.processing.laps import CompletedLap, LapProcessor, SessionInfo
@@ -357,7 +357,18 @@ class TelemetryService:
         sig = signature_from_samples(lap.samples)
         if sig is None or self.session_id is None:
             return
+        # A signature a human created outranks anything inferred; the survey
+        # bundles answer when there is no signature, which is the normal state
+        # for someone who has surveyed circuits but never named one (#41).
         name = await self.repo.find_track(sig)
+        source = "signature"
+        if not name:
+            hit = await asyncio.to_thread(
+                tracks.identify_from_bundles, self.settings.db_path.parent, lap.samples
+            )
+            if hit is not None:
+                name, cover = hit
+                source = f"survey bundle, {cover:.0%} of the lap on mapped road"
         if name:
             self.track_name = name
             await self.repo.set_session_track(self.session_id, name)
@@ -365,7 +376,7 @@ class TelemetryService:
             # up now; an explicit user-picked label is never overwritten.
             if self.survey.active and not self.survey.track_locked:
                 self.survey.set_track(name)
-            log.info("track identified: %s", name)
+            log.info("track identified: %s (%s)", name, source)
             self._publish({"type": "session", "data": await self.status()})
 
     # --- live stream --------------------------------------------------------

--- a/backend/app/storage/db.py
+++ b/backend/app/storage/db.py
@@ -207,9 +207,17 @@ def _catch_up_legacy(conn: Connection) -> bool:
     if "alembic_version" in tables or "sessions" not in tables:
         return False
     log.info("pre-Alembic database found — bringing it to %s", BASELINE_REVISION)
+    # Whole tables first, then columns. Baseline gained TABLES as well as
+    # columns — `layouts` arrived with the overlay builder — and the hand-rolled
+    # list below only ever knew how to ALTER, because the startup path used to
+    # run create_all before it. Dropping that left a first-release database
+    # stamped at baseline with no `layouts` table and no revision that would
+    # ever create one, so every layout request 500s. create_all only touches
+    # what is missing, which is exactly the old behaviour.
+    Base.metadata.create_all(conn, checkfirst=True)
     for table, column, ddl in _LEGACY_SQLITE_COLUMNS:
         if table not in tables:
-            continue
+            continue  # just created from the models, so already at baseline
         if column not in {c["name"] for c in inspector.get_columns(table)}:
             conn.exec_driver_sql(ddl)
     return True

--- a/backend/app/storage/db.py
+++ b/backend/app/storage/db.py
@@ -1,10 +1,18 @@
-"""Database engine + ORM models. SQLite by default; any SQLAlchemy async URL works."""
+"""Database engine + ORM models. SQLite by default; any SQLAlchemy async URL works.
+
+Schema changes go through Alembic (`app/migrations/`), not through this file:
+`init_db` upgrades to head at startup. See `docs/internals/architecture.md`.
+"""
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
-from sqlalchemy import ForeignKey, Index, Text
+from alembic import command
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy import Connection, ForeignKey, Index, Text, inspect
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -12,6 +20,12 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+log = logging.getLogger(__name__)
+
+# The revision every pre-Alembic database is stamped at once it has been
+# brought up to that shape (see _catch_up_legacy).
+BASELINE_REVISION = "0001_baseline"
 
 
 class Base(DeclarativeBase):
@@ -126,8 +140,11 @@ def make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession
     return async_sessionmaker(engine, expire_on_commit=False)
 
 
-# Columns added after the initial release; applied to existing SQLite files.
-_SQLITE_MIGRATIONS = (
+# Columns added between the initial release and the adoption of Alembic, kept
+# ONLY to carry a pre-Alembic SQLite file up to the baseline revision before it
+# is stamped. This list is frozen: every schema change from here on is a
+# revision under app/migrations/versions/. (#14)
+_LEGACY_SQLITE_COLUMNS = (
     (
         "sessions",
         "track_name",
@@ -161,11 +178,57 @@ _SQLITE_MIGRATIONS = (
 )
 
 
+def alembic_config() -> Config:
+    """Alembic Config built in Python — no ini file involved at runtime.
+
+    `script_location` is resolved from the package so it works from any
+    working directory (the app is started from the repo root as often as from
+    backend/) and survives an editable install. No URL: the app always hands
+    Alembic a live connection instead (see `_upgrade`), so a second engine
+    against the same SQLite file never exists.
+    """
+    cfg = Config()
+    cfg.set_main_option("script_location", str(Path(__file__).resolve().parents[1] / "migrations"))
+    return cfg
+
+
+def _catch_up_legacy(conn: Connection) -> bool:
+    """Bring a pre-Alembic SQLite database up to the baseline shape.
+
+    Returns True when this database predates migrations and was (or already
+    was) at baseline — the caller stamps it rather than running the baseline
+    revision, which would try to CREATE tables that are sitting right there.
+
+    A database with no `sessions` table at all is simply new: it gets the
+    baseline revision like any fresh install.
+    """
+    inspector = inspect(conn)
+    tables = set(inspector.get_table_names())
+    if "alembic_version" in tables or "sessions" not in tables:
+        return False
+    log.info("pre-Alembic database found — bringing it to %s", BASELINE_REVISION)
+    for table, column, ddl in _LEGACY_SQLITE_COLUMNS:
+        if table not in tables:
+            continue
+        if column not in {c["name"] for c in inspector.get_columns(table)}:
+            conn.exec_driver_sql(ddl)
+    return True
+
+
+def _upgrade(conn: Connection) -> None:
+    """Run migrations on an already-open (sync) connection."""
+    cfg = alembic_config()
+    cfg.attributes["connection"] = conn
+    if _catch_up_legacy(conn):
+        command.stamp(cfg, BASELINE_REVISION)
+    before = MigrationContext.configure(conn).get_current_revision()
+    command.upgrade(cfg, "head")
+    after = MigrationContext.configure(conn).get_current_revision()
+    if before != after:
+        log.info("database schema %s -> %s", before or "empty", after)
+
+
 async def init_db(engine: AsyncEngine) -> None:
+    """Create or upgrade the schema. Safe to call on every startup."""
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-        if engine.dialect.name == "sqlite":
-            for table, column, ddl in _SQLITE_MIGRATIONS:
-                info = await conn.exec_driver_sql(f"PRAGMA table_info({table})")
-                if column not in {row[1] for row in info}:
-                    await conn.exec_driver_sql(ddl)
+        await conn.run_sync(_upgrade)

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -333,10 +333,17 @@ class Repository:
     async def unnamed_sessions_with_lap(self) -> list[tuple[int, int]]:
         """(session_id, lap_id) for every session with no circuit label.
 
-        The lap chosen is the SHORTEST usable one: identification only needs
-        the driven positions, and every lap is a sample blob of a few hundred
-        kilobytes, so this is the difference between reading a gigabyte and
-        reading a fraction of it.
+        The lap chosen is the shortest FULL one. Full matters: a bundle match
+        is a share of whatever samples it is given, so a pit out-lap covering
+        only tarmac two layouts share can score 100 % while saying nothing
+        about which was driven. Shortest matters too, for a duller reason —
+        every lap is a sample blob of a few hundred kilobytes, and this is the
+        difference between reading a gigabyte and reading a fraction of it.
+        Being full costs nothing on top: a lap that covers the route is the
+        route however quickly it was driven.
+
+        Sessions with no full lap fall back to their longest, which is the best
+        evidence they have; the matcher then decides whether it is enough.
         """
         async with self._sf() as db:
             shortest = (
@@ -345,7 +352,13 @@ class Repository:
                     LapRow.session_id == SessionRow.id,
                     LapRow.total_ticks >= IDENTIFY_MIN_TICKS,
                 )
-                .order_by(LapRow.total_ticks)
+                .order_by(
+                    LapRow.counts_for_best.desc(),
+                    case(
+                        (LapRow.counts_for_best, LapRow.total_ticks),
+                        else_=-LapRow.total_ticks,
+                    ),
+                )
                 .limit(1)
                 .correlate(SessionRow)
                 .scalar_subquery()

--- a/backend/app/storage/repository.py
+++ b/backend/app/storage/repository.py
@@ -10,7 +10,7 @@ from sqlalchemy import case, delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.processing.laps import CompletedLap, SessionInfo
-from app.processing.tracks import TrackSignature, matches
+from app.processing.tracks import IDENTIFY_MIN_TICKS, TrackSignature, matches
 from app.storage.db import LapRow, LayoutRow, SessionRow, SettingRow, TrackRow
 
 # v2 (Tier 1): per-corner sample columns, events, aid/engine metrics, gearing.
@@ -110,35 +110,89 @@ class Repository:
             await db.commit()
             return row.id
 
-    async def list_sessions(self) -> list[dict[str, Any]]:
+    async def list_sessions(self, category: str | None = None) -> list[dict[str, Any]]:
         # One aggregate query for all sessions; the outer join keeps lap-less
         # sessions and only touches LapRow ids/times (never samples_json).
         async with self._sf() as db:
             # Best excludes partial laps (pit out-laps, counts_for_best=0):
             # their GT7-reported "times" aren't full-lap times.
             best_expr = func.min(case((LapRow.counts_for_best, LapRow.time_ms)))
+            # The session row's category comes from the FIRST packet of the
+            # session, which is packet A/B often enough — a heartbeat format
+            # that carries no category at all, or one sent before the console
+            # switched. The laps know better, and max() over them picks the
+            # non-empty value ('' sorts lowest). Without this, a session whose
+            # laps are all plainly Gr.3 sits outside the Gr.3 filter (#19).
             rows = (
                 await db.execute(
-                    select(SessionRow, func.count(LapRow.id), best_expr)
+                    select(
+                        SessionRow,
+                        func.count(LapRow.id),
+                        best_expr,
+                        func.max(LapRow.car_category),
+                    )
                     .outerjoin(LapRow, LapRow.session_id == SessionRow.id)
                     .group_by(SessionRow.id)
                     .order_by(SessionRow.id.desc())
                 )
             ).all()
-            return [
+            sessions = [
                 {
                     "id": s.id,
                     "started_at": s.started_at,
                     "car_id": s.car_id,
                     "car_name": s.car_name,
-                    "car_category": s.car_category,
+                    "car_category": s.car_category or lap_category or "",
                     "note": s.note,
                     "track_name": s.track_name,
                     "lap_count": count,
                     "best_lap_time_ms": best,
                 }
-                for s, count, best in rows
+                for s, count, best, lap_category in rows
             ]
+            if category:
+                sessions = [s for s in sessions if s["car_category"] == category]
+            return sessions
+
+    async def best_lap_in(self, track: str, category: str) -> dict[str, Any] | None:
+        """Fastest full lap ever recorded at a circuit in a car category.
+
+        Scoped by category because a Gr.3 lap and an N100 lap around the same
+        circuit are not the same achievement, and one leaderboard over both is
+        a leaderboard about the car (#19). Partial out-laps are excluded for
+        the same reason they never own a session best.
+        """
+        if not track or not category:
+            return None
+        async with self._sf() as db:
+            row = (
+                await db.execute(
+                    select(LapRow, SessionRow.car_name, SessionRow.started_at)
+                    .join(SessionRow, SessionRow.id == LapRow.session_id)
+                    .where(
+                        SessionRow.track_name == track,
+                        LapRow.car_category == category,
+                        LapRow.counts_for_best,
+                    )
+                    .order_by(LapRow.time_ms)
+                    .limit(1)
+                )
+            ).first()
+            if row is None:
+                return None
+            lap, car_name, started_at = row
+            return {
+                "lap_id": lap.id,
+                "session_id": lap.session_id,
+                "number": lap.number,
+                "time_ms": lap.time_ms,
+                "car_id": lap.car_id,
+                "car_name": car_name,
+                "car_category": lap.car_category,
+                "track_name": track,
+                "clean_lap": lap.clean_lap,
+                "finished_at": lap.finished_at or started_at,
+            }
 
     async def session_lap_stats(self, session_id: int) -> dict[str, Any]:
         """Aggregates for a session without materializing lap rows.
@@ -275,6 +329,45 @@ class Repository:
         async with self._sf() as db:
             await db.execute(delete(TrackRow).where(TrackRow.id == track_id))
             await db.commit()
+
+    async def unnamed_sessions_with_lap(self) -> list[tuple[int, int]]:
+        """(session_id, lap_id) for every session with no circuit label.
+
+        The lap chosen is the SHORTEST usable one: identification only needs
+        the driven positions, and every lap is a sample blob of a few hundred
+        kilobytes, so this is the difference between reading a gigabyte and
+        reading a fraction of it.
+        """
+        async with self._sf() as db:
+            shortest = (
+                select(LapRow.id)
+                .where(
+                    LapRow.session_id == SessionRow.id,
+                    LapRow.total_ticks >= IDENTIFY_MIN_TICKS,
+                )
+                .order_by(LapRow.total_ticks)
+                .limit(1)
+                .correlate(SessionRow)
+                .scalar_subquery()
+            )
+            rows = (
+                await db.execute(
+                    select(SessionRow.id, shortest)
+                    .where(SessionRow.track_name == "")
+                    .order_by(SessionRow.id.desc())
+                )
+            ).all()
+            return [(sid, lid) for sid, lid in rows if lid is not None]
+
+    async def lap_samples_json(self, lap_id: int) -> str | None:
+        """A lap's raw sample blob, unparsed — the caller decodes it off the
+        event loop, which is the whole cost of reading one."""
+        async with self._sf() as db:
+            return (
+                await db.execute(
+                    select(LapRow.samples_json).where(LapRow.id == lap_id)
+                )
+            ).scalar_one_or_none()
 
     async def track_for_lap(self, lap_id: int) -> str:
         """The circuit label of the session a lap belongs to, if it has one."""

--- a/backend/app/telemetry/simulator.py
+++ b/backend/app/telemetry/simulator.py
@@ -3,11 +3,19 @@
 Lets the whole stack (lap detection, storage, live dashboard) run without a
 PlayStation. The track is a rounded-rectangle circuit with two hard braking
 zones; laps vary slightly so comparison/deviation charts have real content.
+
+The car is deliberately **self-consistent**: it advances along the circuit at
+the speed it reports, turns at the rate its own line demands, and its
+accelerometer is that motion rather than a decorative sine. Features that check
+one broadcast channel against another — the g-g diagram's calibration, the
+ABS/TCS intervention traces — can only be exercised without a console if the
+synthetic data would pass the same check real data has to.
 """
 
 from __future__ import annotations
 
 import asyncio
+import bisect
 import logging
 import math
 import random
@@ -56,6 +64,104 @@ SCENARIOS: dict[str, SimScenario] = {
 
 def scenario_for(name: str) -> SimScenario:
     return SCENARIOS.get(name, SCENARIOS["practice"])
+
+
+# --- the circuit ---------------------------------------------------------------
+#
+# A closed parametric curve, re-parameterised by ARC LENGTH and scaled so one
+# lap of it measures exactly TRACK_LENGTH. Walking the parameter at a constant
+# rate instead — which is what this used to do — makes the car cover ground
+# faster through the tight parts than the speed it reports, and every quantity
+# derived from the path then disagrees with the telemetry: the yaw rate comes
+# out several times too high, and a lateral acceleration built from it is not a
+# number any real car produces. Arc length costs one table at import.
+
+_PATH_STEPS = 4096
+
+
+def _build_path() -> tuple[list[float], list[float], list[float]]:
+    xs: list[float] = []
+    zs: list[float] = []
+    for i in range(_PATH_STEPS + 1):
+        a = i / _PATH_STEPS * 2 * math.pi
+        xs.append(500 * math.cos(a) + 80 * math.cos(3 * a))
+        zs.append(300 * math.sin(a) + 40 * math.sin(2 * a))
+    cumulative = [0.0]
+    for i in range(_PATH_STEPS):
+        cumulative.append(
+            cumulative[-1] + math.hypot(xs[i + 1] - xs[i], zs[i + 1] - zs[i])
+        )
+    scale = TRACK_LENGTH / cumulative[-1]
+    return (
+        [c * scale for c in cumulative],
+        [x * scale for x in xs],
+        [z * scale for z in zs],
+    )
+
+
+_PATH_S, _PATH_X, _PATH_Z = _build_path()
+
+# How hard the simulated car may corner. Whatever the driver model wants to do
+# is capped at sqrt(GRIP / curvature), because a target speed picked from lap
+# fraction alone knows nothing about the shape of the corner it is entering —
+# and a car taken through this circuit's 46 m radius at 260 km/h broadcasts an
+# eleven-g accelerometer, which is not data any feature should be tuned on.
+GRIP_M_S2 = 14.0
+
+
+def _build_curvature() -> list[float]:
+    """Signed curvature (1/m) at each path sample.
+
+    Measured over a window rather than between neighbouring samples: the path
+    is a table of straight segments, so a one-segment difference is a staircase
+    whose steps land wherever the sampling happens to fall. Curvature is what
+    the whole driver model rests on — the yaw rate it broadcasts is `v × k`,
+    which is exact and smooth where differencing consecutive positions each
+    tick is neither.
+    """
+    n = _PATH_STEPS
+    window = max(2, n // 256)  # ~12 m of track
+    curvature = [0.0] * (n + 1)
+    for i in range(n):
+        a, b, c = i, (i + window) % n, (i + 2 * window) % n
+        h0 = math.atan2(_PATH_Z[b] - _PATH_Z[a], _PATH_X[b] - _PATH_X[a])
+        h1 = math.atan2(_PATH_Z[c] - _PATH_Z[b], _PATH_X[c] - _PATH_X[b])
+        ds = math.hypot(_PATH_X[b] - _PATH_X[a], _PATH_Z[b] - _PATH_Z[a])
+        turn = math.remainder(h1 - h0, math.tau)
+        curvature[(i + window) % n] = turn / ds if ds > 0 else 0.0
+    curvature[n] = curvature[0]
+    return curvature
+
+
+_PATH_K = _build_curvature()
+
+
+def _sample_index(distance: float) -> tuple[int, float]:
+    d = distance % TRACK_LENGTH
+    i = min(max(bisect.bisect_right(_PATH_S, d) - 1, 0), _PATH_STEPS - 1)
+    span = _PATH_S[i + 1] - _PATH_S[i]
+    return i, (d - _PATH_S[i]) / span if span > 0 else 0.0
+
+
+def _position_at(distance: float) -> tuple[float, float]:
+    """World position this many meters into the lap."""
+    i, f = _sample_index(distance)
+    return (
+        _PATH_X[i] + (_PATH_X[i + 1] - _PATH_X[i]) * f,
+        _PATH_Z[i] + (_PATH_Z[i + 1] - _PATH_Z[i]) * f,
+    )
+
+
+def _curvature_at(distance: float) -> float:
+    i, f = _sample_index(distance)
+    return _PATH_K[i] + (_PATH_K[i + 1] - _PATH_K[i]) * f
+
+
+def _grip_limit(distance: float) -> float:
+    """Fastest this corner can be taken (m/s), looking a little way ahead so
+    the driver is already slowing when it arrives rather than in it."""
+    k = abs(_curvature_at(distance + 25.0))
+    return math.sqrt(GRIP_M_S2 / k) if k > 1e-6 else 1e6
 
 
 def _speed_profile(s: float, jitter: float) -> float:
@@ -125,9 +231,15 @@ class SimTelemetrySource:
         lap_jitter = rng.uniform(-1.5, 1.5)
 
         while True:
+            previous_speed = speed
             s = (distance % TRACK_LENGTH) / TRACK_LENGTH
-            target = _speed_profile(s, lap_jitter)
-            ahead = _speed_profile((s + 0.006) % 1.0, lap_jitter)
+            # The profile says how fast the driver WANTS to go here; the
+            # circuit's own radius says how fast the car can.
+            target = min(_speed_profile(s, lap_jitter), _grip_limit(distance))
+            ahead = min(
+                _speed_profile((s + 0.006) % 1.0, lap_jitter),
+                _grip_limit(distance + 0.006 * TRACK_LENGTH),
+            )
             # Driver model: brake into corners, lift-and-coast just before the
             # brake point, full throttle on straights, hold speed otherwise.
             if target < speed - 2.0:
@@ -143,6 +255,14 @@ class SimTelemetrySource:
                 throttle = 255 if target > 55 else int(140 + rng.uniform(-30, 30))
                 brake = 0
                 speed = target
+            # Rate limit whatever the branches decided. Each of them can snap
+            # straight onto `target` when it is close, and a 2 m/s step inside
+            # one 60 Hz tick is 120 m/s² — a twelve-g spike in the broadcast
+            # longitudinal accelerometer, from a car that never braked harder
+            # than 2.2 g.
+            speed = min(
+                max(speed, previous_speed - 22.0 * TICK), previous_speed + 9.0 * TICK
+            )
             distance += speed * TICK
             fuel -= FUEL_PER_LAP * sim.fuel_rate * (speed * TICK) / TRACK_LENGTH
             if fuel <= 0:
@@ -164,10 +284,15 @@ class SimTelemetrySource:
                 if position > 1 and lap % 2 == 0:
                     position -= 1
 
-            # Position on a rounded-rectangle circuit
-            angle = s * 2 * math.pi
-            px = 500 * math.cos(angle) + 80 * math.cos(3 * angle)
-            pz = 300 * math.sin(angle) + 40 * math.sin(2 * angle)
+            px, pz = _position_at(distance)
+
+            # Yaw rate the circuit itself demands at this speed, rather than
+            # an arbitrary sine. Everything downstream that claims to describe
+            # the car's rotation — the broadcast angular velocity, the
+            # accelerometer, the steering angle, body roll — comes from this
+            # one number, so the simulated car turns exactly as fast as its own
+            # line says it does.
+            yaw_rate = speed * _curvature_at(distance)
 
             gear = min(6, max(1, int(speed / 11) + 1))
             rpm = 2000 + (speed * 3.6 % 60) / 60 * 5500 + gear * 100
@@ -192,7 +317,7 @@ class SimTelemetrySource:
 
             # Suspension compression (m): braking loads the front axle,
             # cornering loads the outside; corner 1 apex adds a kerb strike.
-            lat = math.sin(angle * 2) * 0.3  # matches angular velocity below
+            lat = yaw_rate  # the car's actual rotation, see above
             front = 0.030 + (0.028 if brake > 100 else 0.0)
             rear = 0.030 + (0.012 if throttle > 200 else 0.0)
             roll = lat * 0.02
@@ -247,10 +372,20 @@ class SimTelemetrySource:
                 # Packet C extension: exercises the full parse path in dev.
                 fmt="C",
                 wheel_rotation=lat * 1.2,
-                sway=lat * 6.0,
-                surge=(throttle - brake) / 255 * 5.0,
-                throttle_filtered=throttle,
-                brake_filtered=brake,
+                # Accelerations consistent with the motion actually simulated
+                # (m/s^2): lateral is v*omega with omega the yaw rate sent
+                # above, longitudinal is the real speed delta. They used to be
+                # arbitrary multiples, which meant the g-g diagram's
+                # calibration correctly refused to trust them and the panel
+                # could never be exercised in dev (#16).
+                sway=speed * lat,
+                surge=(speed - previous_speed) / TICK,
+                # Applied pedal, i.e. after the aids acted. TCS trims throttle
+                # while the rears spin, ABS bleeds brake while the fronts
+                # lock — without this the two channels were byte-identical to
+                # the raw ones and the intervention traces (#18) drew nothing.
+                throttle_filtered=int(throttle * 0.55) if spinning else throttle,
+                brake_filtered=int(brake * 0.7) if locking else brake,
                 surface_types="CTTT" if kerb else "TTTT",
                 lap_time_ms=int((tick - lap_start_tick) * TICK * 1000),
                 wheel_steering_rad=(lat * 0.3, lat * 0.3),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic-settings>=2.3",
     "pycryptodome>=3.20",
     "sqlalchemy[asyncio]>=2.0",
+    "alembic>=1.13",
     "aiosqlite>=0.20",
     "websockets>=12.0",
     "httpx>=0.27",
@@ -27,6 +28,11 @@ dev = [
 
 [tool.setuptools.packages.find]
 include = ["app*"]
+
+# Alembic loads env.py and the revision files by path, so they have to ship
+# with the package, not just be importable.
+[tool.setuptools.package-data]
+"app.migrations" = ["script.py.mako"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/tests/test_category.py
+++ b/backend/tests/test_category.py
@@ -1,0 +1,138 @@
+"""Car category as a grouping key (#19): filtering sessions by it, and the
+class benchmark at a circuit."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.main import create_app
+from app.models import SimulatorFlags
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+
+
+@pytest.fixture
+async def client(tmp_path):
+    settings = Settings(source="udp", db_path=tmp_path / "test.db", ws_rate=1000)
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
+
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, service
+    await engine.dispose()
+
+
+async def drive(
+    service: TelemetryService,
+    car_id: int,
+    category: str,
+    lap_ms: int,
+    *,
+    first_packet_fmt: str = "C",
+) -> None:
+    """One recorded lap in a given car and class.
+
+    `first_packet_fmt` exists because the session row's category is taken from
+    the FIRST packet of the session — which is often a narrower format than
+    the rest of the session runs on.
+    """
+    for tick in range(30):
+        await service._on_packet(
+            parse_packet(
+                build_packet(
+                    packet_id=car_id * 10_000 + tick,
+                    current_lap=1,
+                    speed_mps=40.0,
+                    flags=ON_TRACK,
+                    car_id=car_id,
+                    fmt=first_packet_fmt if tick == 0 else "C",
+                    car_category=category,
+                )
+            )
+        )
+    await service._on_packet(
+        parse_packet(
+            build_packet(
+                packet_id=car_id * 10_000 + 99, current_lap=2, last_lap_time_ms=lap_ms,
+                speed_mps=40.0, flags=ON_TRACK, car_id=car_id, fmt="C",
+                car_category=category,
+            )
+        )
+    )
+
+
+async def test_sessions_filter_by_category(client) -> None:
+    c, service = client
+    await drive(service, car_id=1, category="Gr.3", lap_ms=90_000)
+    await drive(service, car_id=2, category="Gr.4", lap_ms=95_000)
+
+    everything = (await c.get("/api/sessions")).json()
+    assert {s["car_category"] for s in everything} == {"Gr.3", "Gr.4"}
+
+    gr3 = (await c.get("/api/sessions?category=Gr.3")).json()
+    assert [s["car_category"] for s in gr3] == ["Gr.3"]
+    # Blank means everything, which is also the only way to reach recordings
+    # made before packet C.
+    assert len((await c.get("/api/sessions?category=")).json()) == 2
+    assert (await c.get("/api/sessions?category=Gr.1")).json() == []
+
+
+async def test_session_category_falls_back_to_its_laps(client) -> None:
+    """A session whose first packet was packet A has no category of its own —
+    but its laps do, and filtering on the class must still find it."""
+    c, service = client
+    await drive(service, car_id=1, category="Gr.3", lap_ms=90_000, first_packet_fmt="A")
+
+    sessions = (await c.get("/api/sessions")).json()
+    assert sessions[0]["car_category"] == "Gr.3"
+    assert len((await c.get("/api/sessions?category=Gr.3")).json()) == 1
+
+
+async def test_category_best_is_scoped_to_circuit_and_class(client) -> None:
+    c, service = client
+    await drive(service, car_id=1, category="Gr.3", lap_ms=90_000)
+    await drive(service, car_id=2, category="Gr.3", lap_ms=88_000)
+    await drive(service, car_id=3, category="Gr.4", lap_ms=85_000)
+    for session in (await c.get("/api/sessions")).json():
+        await service.repo.set_session_track(session["id"], "Suzuka")
+
+    best = (await c.get("/api/laps/best?track=Suzuka&category=Gr.3")).json()
+    assert best["time_ms"] == 88_000
+    assert best["car_id"] == 2 and best["track_name"] == "Suzuka"
+
+    # The quicker Gr.4 lap is a different achievement, not a better one.
+    assert (await c.get("/api/laps/best?track=Suzuka&category=Gr.4")).json()["time_ms"] == 85_000
+    assert (await c.get("/api/laps/best?track=Monza&category=Gr.3")).json() is None
+    assert (await c.get("/api/laps/best?track=Suzuka&category=N100")).json() is None
+
+
+async def test_category_best_ignores_partial_laps(client) -> None:
+    """A pit out-lap carries a GT7 lap time that is short because it is not a
+    lap — the same reason it never owns a session best."""
+    c, service = client
+    await drive(service, car_id=1, category="Gr.3", lap_ms=90_000)
+    sessions = (await c.get("/api/sessions")).json()
+    await service.repo.set_session_track(sessions[0]["id"], "Suzuka")
+    lap = (await c.get("/api/laps")).json()[0]
+    await service.repo.mark_session_laps_partial(sessions[0]["id"], [lap["number"]])
+
+    assert (await c.get("/api/laps/best?track=Suzuka&category=Gr.3")).json() is None
+
+
+async def test_best_route_is_not_swallowed_by_the_lap_id_route(client) -> None:
+    c, _service = client
+    r = await c.get("/api/laps/best?track=Suzuka&category=Gr.3")
+    assert r.status_code == 200  # not 422 "best is not an integer"

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1,0 +1,310 @@
+"""Extended-format channels: steering (#15), accelerometer (#16), filtered
+pedals (#18) — and the rule that binds them, which is that a column the
+recording never carried is ABSENT rather than zero-filled."""
+
+import math
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.main import create_app
+from app.models import SimulatorFlags
+from app.processing import analysis
+from app.processing.cars import CarDatabase
+from app.processing.laps import (
+    OPTIONAL_COLUMNS,
+    CompletedLap,
+    new_sample_store,
+    prune_optional,
+)
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+G = analysis.GRAVITY
+
+
+# --- the absence rule --------------------------------------------------------
+
+
+def test_prune_drops_short_optional_columns() -> None:
+    s = new_sample_store()
+    for i in range(10):
+        for column in s:
+            if column not in OPTIONAL_COLUMNS:
+                s[column].append(float(i))
+        s["steer"].append(0.1)  # complete
+        if i < 4:
+            s["acc_lat"].append(0.5)  # started late / stopped early
+
+    dropped = prune_optional(s)
+    assert "acc_lat" in dropped and "acc_long" in dropped
+    assert "steer" not in dropped
+    assert "steer" in s and "acc_lat" not in s
+    # Never touches a column that isn't optional, whatever its length.
+    assert "speed" in s
+
+
+def test_compute_metrics_prunes_before_measuring() -> None:
+    s = new_sample_store()
+    for i in range(120):
+        for column in s:
+            if column in OPTIONAL_COLUMNS:
+                continue
+            s[column].append(0.0)
+        s["t"][-1] = i / 60
+        s["dist"][-1] = float(i)
+        s["speed"][-1] = 100.0
+        s["tire_slip"][-1] = 1.0
+    lap = CompletedLap(
+        number=1, time_ms=2000, finished_at="", car_id=1,
+        samples=s, fuel_start=1.0, fuel_end=1.0,
+    )
+    lap.compute_metrics()
+    assert not any(column in lap.samples for column in OPTIONAL_COLUMNS)
+    assert lap.total_ticks == 120
+
+
+# --- end to end through the packet pipeline ----------------------------------
+
+
+@pytest.fixture
+async def client(tmp_path):
+    settings = Settings(source="udp", db_path=tmp_path / "test.db", ws_rate=1000)
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
+
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, service
+    await engine.dispose()
+
+
+async def drive(service: TelemetryService, fmt: str, laps: int = 2) -> None:
+    """Two laps of a constant-radius corner, so the physics references the
+    calibration fits against (v·ω and dv/dt) are non-trivial."""
+    radius = 120.0
+    speed = 30.0
+    omega = speed / radius  # rad/s
+    for lap in range(1, laps + 1):
+        for tick in range(400):
+            angle = omega * tick / 60
+            braking = 200 <= tick < 260
+            v = speed - (tick - 200) * 0.15 if braking else speed
+            await service._on_packet(
+                parse_packet(
+                    build_packet(
+                        packet_id=lap * 1000 + tick,
+                        current_lap=lap,
+                        last_lap_time_ms=59_000 if lap > 1 else -1,
+                        position=(radius * math.cos(angle), 0.0, radius * math.sin(angle)),
+                        angular_velocity=(0.0, omega, 0.0),
+                        speed_mps=v,
+                        throttle=0 if braking else 255,
+                        brake=255 if braking else 0,
+                        flags=ON_TRACK,
+                        fmt=fmt,
+                        # sway/surge in m/s^2, sway positive to the right of
+                        # travel — which on this CCW-in-x/z path is negative.
+                        wheel_rotation=0.42,
+                        sway=-(v * omega),
+                        surge=-9.0 if braking else 0.0,
+                        heave=0.3,
+                        throttle_filtered=0 if braking else 140,
+                        brake_filtered=180 if braking else 0,
+                    )
+                )
+            )
+    await service._on_packet(
+        parse_packet(
+            build_packet(
+                packet_id=99_999, current_lap=laps + 1, last_lap_time_ms=59_000,
+                speed_mps=speed, flags=ON_TRACK, fmt=fmt,
+            )
+        )
+    )
+
+
+async def test_packet_a_records_no_optional_columns(client) -> None:
+    c, service = client
+    await drive(service, fmt="A")
+    lap = (await c.get("/api/laps")).json()[0]
+    detail = (await c.get(f"/api/laps/{lap['id']}")).json()
+    for column in OPTIONAL_COLUMNS:
+        assert column not in detail["samples"], column
+
+
+async def test_packet_c_records_every_optional_column(client) -> None:
+    c, service = client
+    await drive(service, fmt="C")
+    lap = (await c.get("/api/laps")).json()[0]
+    detail = (await c.get(f"/api/laps/{lap['id']}")).json()
+    samples = detail["samples"]
+    n = len(samples["t"])
+    for column in OPTIONAL_COLUMNS:
+        assert column in samples, column
+        assert len(samples[column]) == n, column
+    assert samples["steer"][0] == pytest.approx(0.42)
+    # Filtered pedals arrive as percentages, like their raw counterparts.
+    assert max(samples["throttle_f"]) == pytest.approx(140 / 2.55, abs=0.1)
+    assert max(samples["brake_f"]) == pytest.approx(180 / 2.55, abs=0.1)
+
+
+async def test_packet_b_stops_at_the_accelerometer(client) -> None:
+    """Packet B has steering and motion but no filtered pedals — and the lap
+    should carry exactly that, not a half-filled throttle_f."""
+    c, service = client
+    await drive(service, fmt="B")
+    lap = (await c.get("/api/laps")).json()[0]
+    samples = (await c.get(f"/api/laps/{lap['id']}")).json()["samples"]
+    assert {"steer", "acc_lat", "acc_long", "acc_vert"} <= samples.keys()
+    assert "throttle_f" not in samples and "brake_f" not in samples
+
+
+async def test_csv_export_carries_the_new_channels(client) -> None:
+    c, service = client
+    await drive(service, fmt="C")
+    lap = (await c.get("/api/laps")).json()[0]
+    body = (await c.get(f"/api/laps/{lap['id']}/export.csv")).text
+    header = body.splitlines()[7]
+    for name in ("Steering Angle", "Accel Lateral", "Throttle Applied", "Brake Applied"):
+        assert name in header
+
+
+# --- accelerometer calibration (#16) -----------------------------------------
+
+
+def _synthetic(scale_lat: float, scale_long: float, n: int = 1200) -> dict[str, list[float]]:
+    """A lap driving a constant-radius circle while braking and accelerating,
+    whose accelerometer channels are a known multiple of the true value.
+
+    The speed oscillates rather than stepping: a constant braking rate makes
+    both the reference and the channel near-constant, which is degenerate for
+    any goodness-of-fit measure and unlike anything a driver produces.
+    """
+    radius = 120.0
+    period = 6.0  # s
+    s: dict[str, list[float]] = {
+        "t": [], "dist": [], "speed": [], "pos_x": [], "pos_z": [],
+        "acc_lat": [], "acc_long": [],
+    }
+    angle = 0.0
+    dist = 0.0
+    for i in range(n):
+        t = i / 60
+        v = 30.0 + 10.0 * math.sin(2 * math.pi * t / period)
+        dv = 10.0 * (2 * math.pi / period) * math.cos(2 * math.pi * t / period)
+        omega = v / radius
+        angle += omega / 60
+        dist += v / 60
+        s["t"].append(t)
+        s["dist"].append(round(dist, 2))
+        s["speed"].append(round(v * 3.6, 2))
+        # Rounded exactly as LapProcessor stores them. Not incidental: at a
+        # centimetre, position quantisation is larger than the heading change
+        # one 60 Hz tick covers, and a yaw rate differenced tick-to-tick comes
+        # out a staircase of noise instead of a curve.
+        s["pos_x"].append(round(radius * math.cos(angle), 2))
+        s["pos_z"].append(round(radius * math.sin(angle), 2))
+        # True lateral accel is v*omega; its SIGN in the x/z frame is what the
+        # fit has to recover, so feed the channel the opposite sign on purpose.
+        s["acc_lat"].append(-(v * omega) * scale_lat)
+        s["acc_long"].append(dv * scale_long)
+    return s
+
+
+def test_heading_rate_survives_stored_position_rounding() -> None:
+    """The yaw rate the calibration fits against comes from positions rounded
+    to a centimetre. Measured over one tick that rounding is larger than the
+    turn itself; the estimate has to hold up anyway."""
+    s = _synthetic(scale_lat=1.0, scale_long=1.0)
+    omega = analysis._heading_rate(s)
+    # Constant radius: v/R at every point, whatever the speed is doing.
+    expected = [(s["speed"][i] / 3.6) / 120.0 for i in range(len(omega))]
+    middle = range(120, len(omega) - 120)
+    ratios = [omega[i] / expected[i] for i in middle if expected[i] > 0.05]
+    assert len(ratios) > 500
+    assert min(ratios) > 0.9 and max(ratios) < 1.1
+
+
+def test_calibration_recovers_metres_per_second_squared() -> None:
+    cal = analysis.accel_calibration(_synthetic(scale_lat=1.0, scale_long=1.0))
+    assert cal["available"]
+    assert cal["lateral"]["fitted"] and cal["longitudinal"]["fitted"]
+    # Fed the negated true lateral, the fit reports a negative slope — and the
+    # multiplier it hands the UI carries that sign, so the diagram comes out
+    # upright whichever way the console counts.
+    assert cal["lateral"]["slope"] == pytest.approx(-1.0, abs=0.05)
+    assert cal["lateral"]["g_per_unit"] == pytest.approx(-1 / G, rel=0.05)
+    assert cal["longitudinal"]["slope"] == pytest.approx(1.0, abs=0.05)
+    assert cal["unit"] == "m/s^2"
+
+
+def test_calibration_recognises_a_channel_already_in_g() -> None:
+    cal = analysis.accel_calibration(_synthetic(scale_lat=1 / G, scale_long=1 / G))
+    assert cal["unit"] == "g"
+    # 1 raw unit is 1 g, so the multiplier to g is 1.
+    assert abs(cal["lateral"]["g_per_unit"]) == pytest.approx(1.0, rel=0.05)
+
+
+def test_calibration_declines_when_the_lap_proves_nothing() -> None:
+    """A channel that does not track the reference must not be 'calibrated'
+    at whatever slope least squares happens to land on."""
+    s = _synthetic(scale_lat=1.0, scale_long=1.0)
+    s["acc_lat"] = [((i * 37) % 11) - 5.0 for i in range(len(s["t"]))]  # noise
+    cal = analysis.accel_calibration(s)
+    assert not cal["lateral"]["fitted"]
+    assert cal["lateral"]["g_per_unit"] == pytest.approx(1 / G, rel=1e-4)  # assumes m/s^2
+
+
+def test_calibration_unavailable_without_the_channels() -> None:
+    s = _synthetic(1.0, 1.0)
+    del s["acc_lat"]
+    assert analysis.accel_calibration(s) == {"available": False}
+
+
+def test_gg_extremes_clamp_directions_the_lap_never_used() -> None:
+    s = _synthetic(scale_lat=1.0, scale_long=1.0)
+    cal = analysis.accel_calibration(s)
+    peaks = analysis.gg_extremes(s, cal)
+    # The circle turns one way only, so the other lateral direction saw no g
+    # at all — 0, never the smallest value on the used side negated.
+    assert peaks["lat_right"] > 0.5
+    assert peaks["lat_left"] == 0.0
+    assert peaks["braking"] == pytest.approx(10.0 * (2 * math.pi / 6) / G, rel=0.1)
+    assert peaks["accel"] == pytest.approx(10.0 * (2 * math.pi / 6) / G, rel=0.1)
+
+
+async def test_compare_exposes_calibration_and_peaks(client) -> None:
+    c, service = client
+    await drive(service, fmt="C")
+    laps = (await c.get("/api/laps")).json()
+    ids = [laps[0]["id"], laps[1]["id"]]
+    r = (
+        await c.get(
+            f"/api/analysis/compare?laps={ids[0]},{ids[1]}&ref={ids[1]}"
+            "&channels=acc_lat,acc_long,speed"
+        )
+    ).json()
+    assert r["accel"]["available"]
+    assert r["laps"][str(ids[0])]["gg"]["braking"] > 0
+    assert "acc_lat" in r["laps"][str(ids[0])]["series"]
+
+
+async def test_compare_reports_no_accelerometer_on_packet_a(client) -> None:
+    c, service = client
+    await drive(service, fmt="A")
+    laps = (await c.get("/api/laps")).json()
+    r = (await c.get(f"/api/analysis/compare?laps={laps[0]['id']}&ref={laps[0]['id']}")).json()
+    assert r["accel"] == {"available": False}
+    assert "gg" not in r["laps"][str(laps[0]["id"])]

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -56,6 +56,14 @@ def _columns(path, table) -> set[str]:
         con.close()
 
 
+def _tables(path) -> set[str]:
+    con = sqlite3.connect(path)
+    try:
+        return {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        con.close()
+
+
 def _revision(path) -> str | None:
     con = sqlite3.connect(path)
     try:
@@ -108,10 +116,18 @@ async def test_pre_alembic_database_is_caught_up_and_stamped(tmp_path) -> None:
     await init_db(engine)
 
     assert _revision(path) == BASELINE_REVISION
-    # Every column a fresh install would have, on a file that had none of them.
+    # Every TABLE a fresh install would have. `layouts` arrived after the first
+    # release and V1_SCHEMA has none, so a catch-up that could only ALTER left
+    # it missing for good — stamped at baseline, with no revision left to
+    # create it.
+    assert _tables(path) >= {t.name for t in Base.metadata.sorted_tables}
+    # ...and every column, on a file that had none of them.
     assert _columns(path, "laps") == {c.name for c in Base.metadata.tables["laps"].columns}
     assert _columns(path, "sessions") == {
         c.name for c in Base.metadata.tables["sessions"].columns
+    }
+    assert _columns(path, "layouts") == {
+        c.name for c in Base.metadata.tables["layouts"].columns
     }
 
     # And the recorded lap is still there, readable through the ORM.

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,168 @@
+"""Schema migrations (#14).
+
+The interesting case is not the fresh database — it is the one that already
+exists on somebody's Raspberry Pi, was built one hand-rolled `ADD COLUMN` at a
+time, and must arrive at the same schema as a fresh install without losing a
+single recorded lap.
+"""
+
+import sqlite3
+
+import pytest
+from alembic.script import ScriptDirectory
+from sqlalchemy import inspect
+
+from app.storage.db import (
+    BASELINE_REVISION,
+    Base,
+    alembic_config,
+    init_db,
+    make_engine,
+    make_session_factory,
+)
+from app.storage.repository import Repository
+
+# A database as the very first release wrote it: no track_name, no aid
+# metrics, no events, no category — and no alembic_version.
+V1_SCHEMA = """
+CREATE TABLE sessions (
+  id INTEGER NOT NULL PRIMARY KEY, started_at VARCHAR NOT NULL,
+  car_id INTEGER NOT NULL, car_name VARCHAR NOT NULL, note VARCHAR NOT NULL);
+CREATE TABLE tracks (
+  id INTEGER NOT NULL PRIMARY KEY, name VARCHAR NOT NULL, length_m FLOAT NOT NULL,
+  min_x FLOAT NOT NULL, max_x FLOAT NOT NULL, min_z FLOAT NOT NULL,
+  max_z FLOAT NOT NULL, created_at VARCHAR NOT NULL);
+CREATE TABLE settings (key VARCHAR NOT NULL PRIMARY KEY, value VARCHAR NOT NULL);
+CREATE TABLE laps (
+  id INTEGER NOT NULL PRIMARY KEY, session_id INTEGER NOT NULL, number INTEGER NOT NULL,
+  time_ms INTEGER NOT NULL, finished_at VARCHAR NOT NULL, car_id INTEGER NOT NULL,
+  fuel_start FLOAT NOT NULL, fuel_end FLOAT NOT NULL, fuel_consumed FLOAT NOT NULL,
+  full_throttle_pct FLOAT NOT NULL, full_brake_pct FLOAT NOT NULL,
+  coasting_pct FLOAT NOT NULL, tire_spin_pct FLOAT NOT NULL, max_speed FLOAT NOT NULL,
+  min_body_height FLOAT NOT NULL, total_ticks INTEGER NOT NULL, samples_json TEXT NOT NULL,
+  FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE);
+CREATE INDEX ix_laps_session ON laps (session_id);
+INSERT INTO sessions VALUES (1, '2024-01-01T00:00:00Z', 42, 'Mazda Roadster', '');
+INSERT INTO laps VALUES
+  (1, 1, 1, 91234, '2024-01-01T00:01:31Z', 42, 50, 49, 1, 61, 12, 27, 3, 214, 78, 5400, '{}');
+"""
+
+
+def _columns(path, table) -> set[str]:
+    con = sqlite3.connect(path)
+    try:
+        return {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+    finally:
+        con.close()
+
+
+def _revision(path) -> str | None:
+    con = sqlite3.connect(path)
+    try:
+        row = con.execute("SELECT version_num FROM alembic_version").fetchone()
+        return row[0] if row else None
+    except sqlite3.OperationalError:
+        return None
+    finally:
+        con.close()
+
+
+def test_migration_history_has_one_head() -> None:
+    """Two heads means `upgrade head` is ambiguous and startup would fail on
+    somebody else's machine, not on the one that added the second branch."""
+    heads = ScriptDirectory.from_config(alembic_config()).get_heads()
+    assert len(heads) == 1, heads
+
+
+async def test_fresh_database_is_created_and_stamped(tmp_path) -> None:
+    path = tmp_path / "fresh.db"
+    engine = make_engine(path)
+    await init_db(engine)
+    async with engine.connect() as conn:
+        tables = set(await conn.run_sync(lambda c: inspect(c).get_table_names()))
+    await engine.dispose()
+
+    assert {t.name for t in Base.metadata.sorted_tables} <= tables
+    assert "alembic_version" in tables
+    assert _revision(path) is not None
+
+
+async def test_init_db_is_idempotent(tmp_path) -> None:
+    path = tmp_path / "twice.db"
+    engine = make_engine(path)
+    await init_db(engine)
+    await init_db(engine)
+    await init_db(engine)
+    await engine.dispose()
+    assert _revision(path) is not None
+
+
+async def test_pre_alembic_database_is_caught_up_and_stamped(tmp_path) -> None:
+    path = tmp_path / "legacy.db"
+    con = sqlite3.connect(path)
+    con.executescript(V1_SCHEMA)
+    con.commit()
+    con.close()
+
+    engine = make_engine(path)
+    await init_db(engine)
+
+    assert _revision(path) == BASELINE_REVISION
+    # Every column a fresh install would have, on a file that had none of them.
+    assert _columns(path, "laps") == {c.name for c in Base.metadata.tables["laps"].columns}
+    assert _columns(path, "sessions") == {
+        c.name for c in Base.metadata.tables["sessions"].columns
+    }
+
+    # And the recorded lap is still there, readable through the ORM.
+    repo = Repository(make_session_factory(engine))
+    sessions = await repo.list_sessions()
+    laps = await repo.list_laps()
+    await engine.dispose()
+    assert [s["car_name"] for s in sessions] == ["Mazda Roadster"]
+    assert [lap["time_ms"] for lap in laps] == [91234]
+    # Columns the file never had come back as their declared defaults, not NULL.
+    assert laps[0]["counts_for_best"] is True
+    assert laps[0]["car_category"] == ""
+    assert laps[0]["off_track_count"] == -1
+
+
+async def test_legacy_catch_up_leaves_a_partly_upgraded_file_alone(tmp_path) -> None:
+    """A database from somewhere in the middle of the hand-rolled era: some of
+    the added columns present, some not. It must not be re-ALTERed for the
+    ones it has."""
+    path = tmp_path / "middle.db"
+    con = sqlite3.connect(path)
+    con.executescript(V1_SCHEMA)
+    con.executescript(
+        "ALTER TABLE sessions ADD COLUMN track_name VARCHAR NOT NULL DEFAULT '';"
+        "ALTER TABLE laps ADD COLUMN tod_ms INTEGER NOT NULL DEFAULT -1;"
+        "UPDATE sessions SET track_name = 'Suzuka';"
+    )
+    con.commit()
+    con.close()
+
+    engine = make_engine(path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    sessions = await repo.list_sessions()
+    await engine.dispose()
+
+    assert _revision(path) == BASELINE_REVISION
+    assert sessions[0]["track_name"] == "Suzuka"
+    assert _columns(path, "laps") == {c.name for c in Base.metadata.tables["laps"].columns}
+
+
+@pytest.mark.parametrize("table", ["laps", "sessions", "tracks", "layouts", "settings"])
+async def test_baseline_matches_the_orm_models(tmp_path, table) -> None:
+    """The baseline revision and the ORM must not drift: the next revision is
+    autogenerated by diffing them, and a mismatch here becomes a spurious
+    'drop this column' in whatever comes next."""
+    engine = make_engine(tmp_path / f"{table}.db")
+    await init_db(engine)
+    async with engine.connect() as conn:
+        columns = await conn.run_sync(lambda c: inspect(c).get_columns(table))
+    await engine.dispose()
+    assert {c["name"] for c in columns} == {
+        c.name for c in Base.metadata.tables[table].columns
+    }

--- a/backend/tests/test_tier1.py
+++ b/backend/tests/test_tier1.py
@@ -8,7 +8,12 @@ from app.main import create_app
 from app.models import AidsBits, SimulatorFlags
 from app.processing.cars import CarDatabase
 from app.processing.events import detect_events
-from app.processing.laps import SAMPLE_COLUMNS, CompletedLap, new_sample_store
+from app.processing.laps import (
+    OPTIONAL_COLUMNS,
+    SAMPLE_COLUMNS,
+    CompletedLap,
+    new_sample_store,
+)
 from app.service import TelemetryService
 from app.storage.db import init_db, make_engine, make_session_factory
 from app.storage.repository import Repository
@@ -189,8 +194,14 @@ async def test_lap_has_new_columns_and_metrics(client) -> None:
     detail = (await c.get(f"/api/laps/{lap['id']}")).json()
     assert detail["gearing"]["ratios"] == [3.2, 2.3, 1.8]
     assert any(e["type"] == "lockup" and "fl" in e["wheels"] for e in detail["events"])
+    # Every column the base packet format can fill. The optional ones (#15,
+    # #16, #18) need packet B/~ and are absent here on purpose — see
+    # test_channels.py.
     for col in SAMPLE_COLUMNS:
-        assert col in detail["samples"], col
+        if col in OPTIONAL_COLUMNS:
+            assert col not in detail["samples"], col
+        else:
+            assert col in detail["samples"], col
 
 
 async def test_compare_channels_param(client) -> None:

--- a/backend/tests/test_track_identify.py
+++ b/backend/tests/test_track_identify.py
@@ -128,6 +128,30 @@ def test_no_bundles_means_no_answer() -> None:
     assert tracks.match_bundles(_lap_samples(200.0), []) is None
 
 
+def test_a_fragment_of_a_lap_names_nothing() -> None:
+    """Coverage is a share of whatever samples it is handed, so a piece of a
+    lap can sit entirely on tarmac two layouts share and score 100 % on the
+    wrong one — the part that would have told them apart being the part that
+    is missing."""
+    prints = [tracks.fingerprint(_bundle("Ring", 200.0))]
+    whole = _lap_samples(200.0)
+    assert tracks.match_bundles(whole, prints) is not None
+
+    half = {k: v[: len(v) // 2] for k, v in whole.items()}
+    assert tracks.coverage(half, prints[0]) > 0.95  # it IS on the road...
+    assert tracks.match_bundles(half, prints) is None  # ...and still not enough
+
+
+def test_a_car_sitting_on_the_line_is_not_a_lap() -> None:
+    """Start and end in the same place, having gone nowhere: closure alone is
+    not evidence of anything."""
+    parked = _lap_samples(200.0, n=200)
+    parked["pos_x"] = [100.0] * 200
+    parked["pos_z"] = [0.0] * 200
+    parked["dist"] = [0.05 * i for i in range(200)]
+    assert not tracks.is_whole_lap(parked)
+
+
 def test_fingerprints_are_rebuilt_when_a_bundle_changes(tmp_path) -> None:
     _write(tmp_path, _bundle("Ring", 200.0))
     first = tracks.load_fingerprints(tmp_path)
@@ -160,18 +184,35 @@ async def client(tmp_path):
     await engine.dispose()
 
 
-async def drive(service: TelemetryService, radius: float, laps: int = 2) -> None:
-    points = _circle(radius, n=300)
-    for lap in range(1, laps + 1):
+DRIVE_SPEED_MPS = 60.0
+
+
+async def drive(
+    service: TelemetryService, radius: float, arcs: tuple[float, ...] = (1.0,)
+) -> None:
+    """Drive one lap per entry in `arcs` around a circle, a metre per tick.
+
+    The sample spacing is deliberately the distance the reported speed covers
+    in a tick: identification asks whether a lap closes, which compares the
+    integrated `dist` column against the driven positions, and a fixture where
+    those two disagree is testing nothing.
+
+    An arc below 1 leaves the lap short of where it started — a fragment, as
+    produced by capture starting mid-lap or an out-lap from the pits.
+    """
+    full = _circle(radius, n=round(2 * math.pi * radius / (DRIVE_SPEED_MPS / 60)))
+    laps = len(arcs)
+    for lap, arc in enumerate(arcs, start=1):
+        points = full[: max(2, round(len(full) * arc))]
         for tick, (x, z) in enumerate(points):
             await service._on_packet(
                 parse_packet(
                     build_packet(
-                        packet_id=lap * 1000 + tick,
+                        packet_id=lap * 100_000 + tick,
                         current_lap=lap,
                         last_lap_time_ms=60_000 if lap > 1 else -1,
                         position=(x, 0.0, z),
-                        speed_mps=40.0,
+                        speed_mps=DRIVE_SPEED_MPS,
                         throttle=200,
                         flags=ON_TRACK,
                     )
@@ -180,8 +221,8 @@ async def drive(service: TelemetryService, radius: float, laps: int = 2) -> None
     await service._on_packet(
         parse_packet(
             build_packet(
-                packet_id=99_999, current_lap=laps + 1, last_lap_time_ms=60_000,
-                speed_mps=40.0, flags=ON_TRACK,
+                packet_id=999_999, current_lap=laps + 1, last_lap_time_ms=60_000,
+                speed_mps=DRIVE_SPEED_MPS, flags=ON_TRACK,
             )
         )
     )
@@ -195,6 +236,20 @@ async def test_a_new_session_names_itself_from_the_bundle(client) -> None:
 
     assert service.track_name == "Ring"
     assert (await c.get("/api/sessions")).json()[0]["track_name"] == "Ring"
+
+
+async def test_a_fragment_does_not_name_a_session_but_the_next_lap_does(client) -> None:
+    """The first lap of a session is the one that gets to name it, and capture
+    often starts mid-lap. That lap must not be trusted — but nothing should be
+    lost either: identification retries on every lap until one sticks."""
+    c, service, data_dir = client
+    _write(data_dir, _bundle("Ring", 200.0))
+
+    await drive(service, radius=200.0, arcs=(0.55, 1.0))
+
+    assert service.track_name == "Ring"
+    laps = (await c.get("/api/laps")).json()
+    assert len(laps) == 2  # the fragment was recorded, just not trusted to name
 
 
 async def test_a_session_somewhere_unsurveyed_stays_unnamed(client) -> None:

--- a/backend/tests/test_track_identify.py
+++ b/backend/tests/test_track_identify.py
@@ -1,0 +1,256 @@
+"""Identifying a circuit from its survey bundle (#41).
+
+The gap this closes: surveying a track and NAMING it were two separate facts,
+so a driver who surveyed three circuits and never used "name track…" got no
+identification at all — and everything downstream of the circuit name (the
+outline under the race line, category bests, corner labels) stayed empty
+while the app plainly had the map.
+"""
+
+import json
+import math
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.main import create_app
+from app.models import SimulatorFlags
+from app.processing import track_bundle, tracks
+from app.processing.cars import CarDatabase
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+from app.telemetry.packet import build_packet, parse_packet
+
+ON_TRACK = int(SimulatorFlags.CAR_ON_TRACK)
+SOURCE = "abc123abc123"
+
+
+def _circle(radius: float, centre=(0.0, 0.0), n: int = 400):
+    cx, cz = centre
+    return [
+        (cx + radius * math.cos(2 * math.pi * i / n), cz + radius * math.sin(2 * math.pi * i / n))
+        for i in range(n)
+    ]
+
+
+def _bundle(track: str, radius: float, centre=(0.0, 0.0), coverage: float = 1.0):
+    """A circuit surveyed as a ring of border evidence either side of the road.
+
+    `coverage` < 1 leaves part of the lap unsurveyed, which is what a
+    half-finished survey looks like.
+    """
+    edges = []
+    points = _circle(radius, centre)
+    keep = int(len(points) * coverage)
+    for i, (x, z) in enumerate(points[:keep]):
+        hx, hz = -math.sin(2 * math.pi * i / len(points)), math.cos(2 * math.pi * i / len(points))
+        # The right border lies along the right-normal of travel, (hz, -hx).
+        for side, offset in (("L", -6.0), ("R", 6.0)):
+            edges.append({
+                "x": x + offset * hz, "z": z - offset * hx, "y": None,
+                "hx": hx, "hz": hz, "side": side, "kind": "auto",
+                "votes": {"auto": {SOURCE: [1, 1]}}, "run": 1, "tw": 1.6,
+            })
+    return {
+        "format": track_bundle.BUNDLE_FORMAT,
+        "version": track_bundle.BUNDLE_VERSION,
+        "meta": {
+            "track": track, "runs": 1, "source_runs": {SOURCE: 1},
+            "updated_at": "2026-08-01T00:00:00+00:00", "official": None,
+        },
+        "edges": edges,
+        "finish_crossings": [],
+        "corners": [],
+        "sections": [],
+    }
+
+
+def _lap_samples(radius: float, centre=(0.0, 0.0), n: int = 900):
+    xs, zs = [], []
+    for x, z in _circle(radius, centre, n):
+        xs.append(round(x, 2))
+        zs.append(round(z, 2))
+    return {
+        "t": [i / 60 for i in range(n)],
+        "dist": [i * 2.0 for i in range(n)],
+        "pos_x": xs,
+        "pos_z": zs,
+        "speed": [120.0] * n,
+    }
+
+
+def _write(directory, doc):
+    path = track_bundle.bundle_path(directory, doc["meta"]["track"])
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+# --- matching ------------------------------------------------------------------
+
+
+def test_a_lap_is_matched_to_the_circuit_it_was_driven_on() -> None:
+    prints = [
+        tracks.fingerprint(_bundle("Ring", 200.0)),
+        tracks.fingerprint(_bundle("Elsewhere", 200.0, centre=(5000.0, 5000.0))),
+    ]
+    hit = tracks.match_bundles(_lap_samples(200.0), prints)
+    assert hit is not None
+    assert hit[0] == "Ring"
+    assert hit[1] > 0.95
+
+
+def test_a_lap_driven_somewhere_else_matches_nothing() -> None:
+    prints = [tracks.fingerprint(_bundle("Ring", 200.0))]
+    assert tracks.match_bundles(_lap_samples(200.0, centre=(9000.0, 0.0)), prints) is None
+
+
+def test_a_half_surveyed_circuit_still_identifies_itself() -> None:
+    """A bundle only covers ground that has been driven; requiring full
+    coverage would mean a circuit cannot be recognised until it is finished."""
+    prints = [tracks.fingerprint(_bundle("Ring", 200.0, coverage=0.75))]
+    hit = tracks.match_bundles(_lap_samples(200.0), prints)
+    assert hit is not None and hit[0] == "Ring"
+
+
+def test_two_circuits_that_fit_equally_well_are_refused() -> None:
+    """Configurations of one venue share tarmac. Guessing between them puts a
+    wrong name on a session silently, which is worse than no name."""
+    prints = [
+        tracks.fingerprint(_bundle("Layout A", 200.0)),
+        tracks.fingerprint(_bundle("Layout B", 200.0)),  # same road
+    ]
+    assert tracks.match_bundles(_lap_samples(200.0), prints) is None
+
+
+def test_no_bundles_means_no_answer() -> None:
+    assert tracks.match_bundles(_lap_samples(200.0), []) is None
+
+
+def test_fingerprints_are_rebuilt_when_a_bundle_changes(tmp_path) -> None:
+    _write(tmp_path, _bundle("Ring", 200.0))
+    first = tracks.load_fingerprints(tmp_path)
+    assert [p.track for p in first] == ["Ring"]
+    assert tracks.load_fingerprints(tmp_path) is first  # cached
+
+    _write(tmp_path, _bundle("Other", 300.0, centre=(4000.0, 0.0)))
+    assert {p.track for p in tracks.load_fingerprints(tmp_path)} == {"Ring", "Other"}
+
+
+# --- through the pipeline ------------------------------------------------------
+
+
+@pytest.fixture
+async def client(tmp_path):
+    settings = Settings(source="udp", db_path=tmp_path / "data" / "test.db", ws_rate=1000)
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+    service.processor.min_lap_ticks = 1
+
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, service, settings.db_path.parent
+    await engine.dispose()
+
+
+async def drive(service: TelemetryService, radius: float, laps: int = 2) -> None:
+    points = _circle(radius, n=300)
+    for lap in range(1, laps + 1):
+        for tick, (x, z) in enumerate(points):
+            await service._on_packet(
+                parse_packet(
+                    build_packet(
+                        packet_id=lap * 1000 + tick,
+                        current_lap=lap,
+                        last_lap_time_ms=60_000 if lap > 1 else -1,
+                        position=(x, 0.0, z),
+                        speed_mps=40.0,
+                        throttle=200,
+                        flags=ON_TRACK,
+                    )
+                )
+            )
+    await service._on_packet(
+        parse_packet(
+            build_packet(
+                packet_id=99_999, current_lap=laps + 1, last_lap_time_ms=60_000,
+                speed_mps=40.0, flags=ON_TRACK,
+            )
+        )
+    )
+
+
+async def test_a_new_session_names_itself_from_the_bundle(client) -> None:
+    c, service, data_dir = client
+    _write(data_dir, _bundle("Ring", 200.0))
+
+    await drive(service, radius=200.0)
+
+    assert service.track_name == "Ring"
+    assert (await c.get("/api/sessions")).json()[0]["track_name"] == "Ring"
+
+
+async def test_a_session_somewhere_unsurveyed_stays_unnamed(client) -> None:
+    c, service, data_dir = client
+    _write(data_dir, _bundle("Ring", 200.0, centre=(9000.0, 9000.0)))
+
+    await drive(service, radius=200.0)
+
+    assert service.track_name == ""
+    assert (await c.get("/api/sessions")).json()[0]["track_name"] == ""
+
+
+async def test_backfill_names_sessions_recorded_before_the_survey(client) -> None:
+    """The case that made this necessary: laps were on disk long before the
+    circuit was ever surveyed, so nothing had a chance to identify them."""
+    c, service, data_dir = client
+    await drive(service, radius=200.0)
+    assert (await c.get("/api/sessions")).json()[0]["track_name"] == ""
+
+    _write(data_dir, _bundle("Ring", 200.0))
+    result = (await c.post("/api/tracks/identify")).json()
+
+    assert result == {"checked": 1, "identified": 1, "tracks": {"Ring": 1}}
+    assert (await c.get("/api/sessions")).json()[0]["track_name"] == "Ring"
+    # ...and the outline the whole thing exists to unlock now resolves.
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    outline = (await c.get(f"/api/track-outline?lap_id={lap_id}")).json()
+    assert outline["track"] == "Ring"
+    assert len(outline["road"]) > 0
+
+
+async def test_backfill_leaves_unrecognised_sessions_alone(client) -> None:
+    c, service, data_dir = client
+    await drive(service, radius=200.0)
+    _write(data_dir, _bundle("Ring", 200.0, centre=(9000.0, 9000.0)))
+
+    result = (await c.post("/api/tracks/identify")).json()
+    assert result["checked"] == 1 and result["identified"] == 0
+    assert (await c.get("/api/sessions")).json()[0]["track_name"] == ""
+
+
+async def test_backfill_refuses_when_nothing_has_been_surveyed(client) -> None:
+    c, service, _data_dir = client
+    await drive(service, radius=200.0)
+    assert (await c.post("/api/tracks/identify")).status_code == 409
+
+
+async def test_a_named_signature_still_wins(client) -> None:
+    """A circuit a human named outranks anything inferred from a bundle."""
+    c, service, data_dir = client
+    _write(data_dir, _bundle("Ring", 200.0))
+    await drive(service, radius=200.0)
+    lap_id = (await c.get("/api/laps")).json()[0]["id"]
+    await c.post("/api/tracks", json={"name": "My Own Name", "lap_id": lap_id})
+
+    service.track_name = ""
+    service.session_id = None
+    await drive(service, radius=200.0)
+    assert service.track_name == "My Own Name"

--- a/backend/tests/test_track_outline.py
+++ b/backend/tests/test_track_outline.py
@@ -1,0 +1,203 @@
+"""The surveyed road, compiled for the race-line map (#51)."""
+
+import json
+import math
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.config import Settings
+from app.main import create_app
+from app.processing import track_bundle, track_outline
+from app.processing.cars import CarDatabase
+from app.processing.laps import CompletedLap, SessionInfo, new_sample_store
+from app.service import TelemetryService
+from app.storage.db import init_db, make_engine, make_session_factory
+from app.storage.repository import Repository
+
+SOURCE = "abc123abc123"
+
+
+def _edge(x, z, hx, hz, side, kind="auto"):
+    return {
+        "x": x, "z": z, "y": None, "hx": hx, "hz": hz,
+        "side": side, "kind": kind, "votes": {kind: {SOURCE: [1, 1]}},
+        "run": 1, "tw": 1.6,
+    }
+
+
+def _straight(length=40, width=12.0, kind="auto"):
+    """A straight road running along +x, with both borders evidenced.
+
+    Sides follow the survey's convention: the right border sits along the
+    right-normal of the travel direction, which for a heading of (1, 0) is
+    (hz, -hx) = (0, -1) — so the right border is at negative z.
+    """
+    edges = []
+    for i in range(length):
+        edges.append(_edge(float(i), width / 2, 1.0, 0.0, "L", kind))
+        edges.append(_edge(float(i), -width / 2, 1.0, 0.0, "R", kind))
+    return edges
+
+
+def _document(edges, finish=(), track="Test Circuit"):
+    return {
+        "format": track_bundle.BUNDLE_FORMAT,
+        "version": track_bundle.BUNDLE_VERSION,
+        "meta": {
+            "track": track, "runs": 2, "source_runs": {SOURCE: 2},
+            "updated_at": "2026-08-01T00:00:00+00:00", "official": None,
+        },
+        "edges": edges,
+        "finish_crossings": list(finish),
+        "corners": [],
+        "sections": [],
+    }
+
+
+# --- pairing -----------------------------------------------------------------
+
+
+def test_facing_borders_fill_the_road() -> None:
+    quads = track_outline.road_quads(_straight())
+    assert len(quads) == 40
+    # Corners run left-back, left-forward, right-forward, right-back: the road
+    # width across the carriageway and a fixed extent along travel.
+    (lbx, lbz), (lfx, lfz), _rf, (rbx, rbz) = (
+        tuple(quads[0][i : i + 2]) for i in (0, 2, 4, 6)
+    )
+    assert math.hypot(rbx - lbx, rbz - lbz) == pytest.approx(12.0, abs=0.01)
+    assert math.hypot(lfx - lbx, lfz - lbz) == pytest.approx(
+        2 * track_outline.QUAD_HALF_LENGTH_M, abs=0.01
+    )
+
+
+def test_a_road_wider_than_any_road_is_not_paired() -> None:
+    """Two borders 60 m apart are the two legs of a hairpin, not one road."""
+    assert track_outline.road_quads(_straight(width=60.0)) == []
+
+
+def test_borders_recorded_travelling_opposite_ways_are_not_paired() -> None:
+    edges = [
+        _edge(0.0, 6.0, 1.0, 0.0, "L"),
+        _edge(0.0, -6.0, -1.0, 0.0, "R"),  # the other leg, driven back the way
+    ]
+    assert track_outline.road_quads(edges) == []
+
+
+def test_run_off_marks_still_count_as_road_edges() -> None:
+    """They bound the road and happen to have pavement beyond them; excluding
+    them drew no road at all through hand-surveyed corners."""
+    assert len(track_outline.road_quads(_straight(kind="runoff"))) == 40
+
+
+def test_walls_are_kept_apart_from_ordinary_borders() -> None:
+    edges = _straight(length=4) + [_edge(2.0, -9.0, 1.0, 0.0, "R", kind="wall")]
+    outline = track_outline.build(_document(edges))
+    assert len(outline["walls"]) == 1
+    assert len(outline["edges"]) == 8
+    # A wall is still a border, so it can still close a road span.
+    assert outline["road"]
+
+
+# --- finish line -------------------------------------------------------------
+
+
+def test_finish_line_lies_across_the_direction_of_travel() -> None:
+    crossings = [
+        {"x": 0.0, "z": -2.0, "hx": 1.0, "hz": 0.0, "lap": 1},
+        {"x": 0.0, "z": 2.0, "hx": 1.0, "hz": 0.0, "lap": 2},
+    ]
+    x1, z1, x2, z2 = track_outline.finish_line(crossings)
+    assert x1 == pytest.approx(0.0) and x2 == pytest.approx(0.0)
+    assert math.hypot(x2 - x1, z2 - z1) == pytest.approx(2 * track_outline.FINISH_HALF_M)
+
+
+def test_no_crossings_means_no_finish_line() -> None:
+    assert track_outline.finish_line([]) is None
+
+
+# --- loading, caching, and the endpoint --------------------------------------
+
+
+def test_unsurveyed_circuit_gets_an_empty_outline(tmp_path) -> None:
+    assert track_outline.for_track(tmp_path, "Never Driven") == track_outline.EMPTY
+    assert track_outline.for_track(tmp_path, "") == track_outline.EMPTY
+
+
+def test_outline_is_recompiled_when_the_bundle_changes(tmp_path) -> None:
+    path = track_bundle.bundle_path(tmp_path, "Test Circuit")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_document(_straight(length=4))), encoding="utf-8")
+    first = track_outline.for_track(tmp_path, "Test Circuit")
+    assert len(first["road"]) == 4
+    # Same call again is the cached object, not a fresh compile.
+    assert track_outline.for_track(tmp_path, "Test Circuit") is first
+
+    path.write_text(json.dumps(_document(_straight(length=9))), encoding="utf-8")
+    second = track_outline.for_track(tmp_path, "Test Circuit")
+    assert len(second["road"]) == 9
+
+
+@pytest.fixture
+async def client(tmp_path):
+    settings = Settings(source="udp", db_path=tmp_path / "data" / "test.db", ws_rate=1000)
+    engine = make_engine(settings.db_path)
+    await init_db(engine)
+    repo = Repository(make_session_factory(engine))
+    service = TelemetryService(settings, repo, CarDatabase())
+
+    app = create_app()
+    app.router.lifespan_context = None  # type: ignore[assignment]
+    app.state.service = service
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, service, settings.db_path.parent
+    await engine.dispose()
+
+
+async def test_endpoint_resolves_the_circuit_from_a_lap(client) -> None:
+    c, service, data_dir = client
+    path = track_bundle.bundle_path(data_dir, "Test Circuit")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            _document(
+                _straight(length=5),
+                finish=[{"x": 0.0, "z": 0.0, "hx": 1.0, "hz": 0.0, "lap": 1}],
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    samples = new_sample_store()
+    for i in range(10):
+        for column in ("t", "dist", "speed", "pos_x", "pos_z", "throttle", "brake",
+                       "coast", "tire_slip", "body_height", "fuel"):
+            samples[column].append(float(i))
+    lap = CompletedLap(
+        number=1, time_ms=90_000, finished_at="", car_id=1,
+        samples=samples, fuel_start=1.0, fuel_end=1.0,
+    )
+    session_id = await service.repo.create_session(
+        SessionInfo(car_id=1, started_at="now"), "Car"
+    )
+    lap_id = await service.repo.save_lap(session_id, lap)
+    await service.repo.set_session_track(session_id, "Test Circuit")
+
+    body = (await c.get(f"/api/track-outline?lap_id={lap_id}")).json()
+    assert body["track"] == "Test Circuit"
+    assert len(body["road"]) == 5
+    assert body["finish"] is not None
+    assert body["runs"] == 2
+
+
+async def test_endpoint_answers_empty_rather_than_404(client) -> None:
+    """A circuit nobody has surveyed is the common case, not an error — the
+    map has to be able to fall back to drawing the lap on its own."""
+    c, _service, _data_dir = client
+    r = await c.get("/api/track-outline?track=Somewhere%20Else")
+    assert r.status_code == 200
+    assert r.json()["road"] == []
+    assert (await c.get("/api/track-outline")).json()["slug"] is None

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -48,7 +48,24 @@ pytest
 ```
 
 The test suite exercises the packet decoder, lap detection, derived-channel math, event
-detection, and the REST API against fixture data — no PlayStation required.
+detection, schema migrations (including a first-release database being upgraded in
+place), and the REST API against fixture data — no PlayStation required.
+
+## Changing the schema
+
+Models live in `backend/app/storage/db.py`; every change to them needs an
+[Alembic](https://alembic.sqlalchemy.org/) revision, which `init_db` then applies on
+startup:
+
+```bash
+cd backend
+.venv/bin/alembic revision --autogenerate -m "add whatever"
+```
+
+`alembic.ini` points at `../data/gt7.db` — pass `-x db=…` or edit it to autogenerate
+against a different database. Review what comes out before committing (SQLite cannot
+alter a column in place, so batch mode rewrites the table), and keep the history to a
+single head.
 
 ## Project layout
 
@@ -58,6 +75,7 @@ backend/
     telemetry/    # UDP listener, Salsa20 decrypt, packet decode, simulator
     processing/   # lap detection, derived channels, events, tracks, cars
     storage/      # SQLAlchemy async engine + repository
+    migrations/   # Alembic revisions (run to head on startup)
     api/          # REST routes, WebSocket, admin endpoints
     service.py    # wires capture → processing → storage → broadcast
   tests/

--- a/docs/guide/analysis-view.md
+++ b/docs/guide/analysis-view.md
@@ -48,13 +48,20 @@ The **Channels (n)** button opens a grouped picker with ~20 channels:
 
 | Group | Channels |
 | --- | --- |
-| Driving | Speed, Throttle, Brake, Coasting, Gear, Yaw rate |
+| Driving | Speed, Throttle, Brake, Coasting, Gear, Yaw rate, **Steering**, **Throttle/Brake applied**, **TCS cut**, **ABS release** |
 | Engine | RPM, Boost |
 | Tires & wheels | Tire spd/car spd, slip front/rear avg, slip per wheel, tire temp front/rear avg, **tire temp F−R balance** |
-| Chassis | Ride height, susp travel front/rear avg |
+| Chassis | Ride height, susp travel front/rear avg, **lateral / longitudinal / vertical g** |
 
 Your selection persists in the browser and is added to the URL when it differs from the
 default nine-panel stack. Laps recorded before a channel existed simply skip that line.
+
+!!! note "Aid intervention, measured rather than inferred"
+    **Throttle applied** / **Brake applied** are the pedal *after* the aids acted on it.
+    Plotted against the raw pedal the two lines separate exactly where TCS or ABS
+    intervened; **TCS cut** and **ABS release** are that separation on its own. These
+    need the `~` packet format or wider — see
+    [Configuration](../getting-started/configuration.md).
 
 ## Race line map
 
@@ -63,6 +70,35 @@ throttle, red = braking, blue = coasting — with ▲ speed peaks and ▼ valley
 Other selected laps overlay as colored lines. The map has no direct mouse interaction:
 it follows the chart cursor, placing one dot per lap at the hovered distance so you can
 see the spatial gap between lines, and it auto-crops when you zoom a section.
+
+**Under the line: the surveyed road.** If the session's circuit has been named *and*
+[surveyed](tracks-view.md), the map draws the track itself beneath every lap — road surface,
+both borders, hand-marked walls in dark red, and the start/finish line. A racing line
+only means something against the road it was driven on: whether the apex was clipped,
+how much kerb was used, whether there was tarmac left on the exit. Circuits with no
+bundle simply draw as before. The geometry is compiled server-side
+(`/api/track-outline`) — a bundle holds up to 50,000 border records and the browser
+never sees them.
+
+## Traction circle (g-g)
+
+Every moment of the lap plotted as lateral g against longitudinal g, coloured by input
+zone: braking at the bottom, power at the top, corners out to the sides, and the
+combined phases — trail-braking in, picking up throttle while still turning — filling
+the diagonals. How much of the ring gets used is the reading; an empty middle-left and
+middle-right is a car that never brakes and turns at the same time. Other selected laps
+appear as faint dots in their own colours, and the four numbers underneath are the peak
+g reached in each direction.
+
+The panel appears whenever the recording has the accelerometer (packet B or wider).
+
+!!! warning "GT7 documents no unit for these channels"
+    So the app checks them rather than trusting them: the server fits each axis against
+    physics the same lap recorded — lateral against `v × ω` from the driven path,
+    longitudinal against `dv/dt` — which recovers both the unit and the sign. The
+    footnote under the diagram reports the fit. When a lap gave too little steady
+    cornering or braking to check, it says **scale unverified** and assumes m/s²: the
+    shapes still compare between laps, the absolute numbers may be off by a constant.
 
 ## Corner Detail widget
 
@@ -90,5 +126,9 @@ laps, focus chips let you switch the focus lap.
   for each setting −5…+5 vs the reference lap's, projected fuel/lap, laps remaining,
   time remaining, and lap-time cost.
 - **Tuning info (reference lap)** — max speed, min ride height, input percentages, tire
-  spin, fuel used, aid usage (TCS/ASM %), engine health (max water/oil temp, min oil
-  pressure), and the detected-event summary.
+  spin, fuel used, car category, aid usage (TCS/ASM %), engine health (max water/oil
+  temp, min oil pressure), and the detected-event summary. When the circuit is named and
+  the car's class is known, it also shows the **class benchmark** — the fastest full lap
+  ever recorded at this circuit in the same category, the gap to the reference lap, and a
+  link to open it. Scoped by class on purpose: a Gr.3 time and an N100 time around the
+  same corners are not the same achievement.

--- a/docs/guide/analysis-view.md
+++ b/docs/guide/analysis-view.md
@@ -71,10 +71,11 @@ Other selected laps overlay as colored lines. It follows the chart cursor, placi
 dot per lap at the hovered distance so you can see the spatial gap between lines, and it
 auto-crops when you zoom a section.
 
-Both axes share one scale, so a metre across is a metre down and a corner's shape on
-screen is its shape on the track. (Letting each axis fill the box independently stretches
-the map by whatever the circuit's aspect ratio happens to be — 8 % at Lago Maggiore
-Centre, nearly 3× at Deep Forest.)
+A metre across is a metre down, so a corner's shape on screen is its shape on the track.
+The axis ranges follow the plotting area's pixel aspect to keep it that way in any
+window; letting each axis fill the box independently stretches the map by whatever the
+circuit's aspect ratio happens to be — 8 % at Lago Maggiore Centre, nearly 3× at Deep
+Forest.
 
 ### Corners
 

--- a/docs/guide/analysis-view.md
+++ b/docs/guide/analysis-view.md
@@ -67,9 +67,35 @@ default nine-panel stack. Laps recorded before a channel existed simply skip tha
 
 A top-down plot of the reference lap's driven line, colored by input zone — green =
 throttle, red = braking, blue = coasting — with ▲ speed peaks and ▼ valleys marked.
-Other selected laps overlay as colored lines. The map has no direct mouse interaction:
-it follows the chart cursor, placing one dot per lap at the hovered distance so you can
-see the spatial gap between lines, and it auto-crops when you zoom a section.
+Other selected laps overlay as colored lines. It follows the chart cursor, placing one
+dot per lap at the hovered distance so you can see the spatial gap between lines, and it
+auto-crops when you zoom a section.
+
+Both axes share one scale, so a metre across is a metre down and a corner's shape on
+screen is its shape on the track. (Letting each axis fill the box independently stretches
+the map by whatever the circuit's aspect ratio happens to be — 8 % at Lago Maggiore
+Centre, nearly 3× at Deep Forest.)
+
+### Corners
+
+The corner strip under the map is the fast way around a lap: **click a number** — or the
+numbered circle on the map itself — and everything zooms to that corner, charts included,
+with the braking zone into it and the exit out of it for context. `‹` `›` step through
+them and wrap; **lap** goes back to the whole circuit. The selected corner is named
+beside the strip (`T5 · left`).
+
+The corners come from the reference lap's curvature, or from the circuit's
+[authored corners](tracks-view.md#labelling-corners) when it has them — in which case the
+numbering is the same in every session, not just within this one.
+
+### Full screen
+
+**⤢** (top right of the map) opens the same map as large as the window will allow, which
+is the difference between a squiggle and a track on anything longer than a kart circuit.
+The maximized view adds **scroll to zoom** and **drag to pan** — off in the rail, where a
+wheel that sometimes scrolls the page and sometimes zooms a chart is worse than one that
+always scrolls — plus the selected corner's minimum speed and total angle. Escape or
+**Close** returns.
 
 **Under the line: the surveyed road.** If the session's circuit has been named *and*
 [surveyed](tracks-view.md), the map draws the track itself beneath every lap — road surface,

--- a/docs/guide/sessions-view.md
+++ b/docs/guide/sessions-view.md
@@ -19,6 +19,15 @@ sparkline** (chronological lap times with the best lap dotted in accent), and th
 Click a row (or the chevron) to expand its lap table; **Analyze** opens the session in
 Analysis with *latest vs best* selected.
 
+## Category filter
+
+When GT7 broadcasts the car's class (packet C — "Gr.3", "Gr.4", "N300"…), it appears as
+a chip on each row and a filter strip above the list: *show me only the Gr.3 runs*. Only
+classes actually present are offered, so the strip disappears entirely on a history
+recorded before packet C, and **All** is the only way back to sessions that have no
+class at all. A session whose own class is blank — its very first packet was a narrower
+format — takes the class its laps recorded.
+
 ## Lap table
 
 Per lap: time (best in accent), Δ to session best, fuel used, full-throttle %,

--- a/docs/guide/tracks-view.md
+++ b/docs/guide/tracks-view.md
@@ -7,14 +7,29 @@ nothing on any screen showed them together:
 
 | you have | which means | where it lives |
 |---|---|---|
-| a **named track** | sessions here identify themselves automatically | the `tracks` table |
-| a **survey bundle** | its borders, elevation and finish line are mapped | `data/track-bundles/` |
+| a **named track** | a five-number signature sessions can match against | the `tracks` table |
+| a **survey bundle** | its borders, elevation and finish line are mapped — *and* sessions driven on it identify themselves | `data/track-bundles/` |
 | an **official layout match** | its real length and turn count are known | `backend/data/tracks.json` |
 
-Having one is not having the others. A bundle full of border evidence does
-nothing for auto-identification; a named track you have never surveyed has no
-map. The Tracks tab lists every circuit this installation knows anything
+Having one is not having the others: a named track you have never surveyed has
+no map. The Tracks tab lists every circuit this installation knows anything
 about, merged across all three, with the gaps called out.
+
+## Identifying sessions
+
+A surveyed circuit recognises itself. When a new session's first lap has no
+matching signature, the lap is compared against the survey bundles — *did this
+lap drive on this tarmac?* — and a confident match names the session. That is
+what makes the track badge, the surveyed road under the
+[race line](analysis-view.md#race-line-map), category bests and corner labels
+appear without anyone naming anything. See
+[Track identification](../internals/track-identification.md#matching-against-a-survey-bundle).
+
+Sessions recorded **before** a circuit was surveyed never got that chance.
+**Identify sessions** re-runs the match over every unlabelled session in your
+history and names the ones that were driven on a circuit you have since
+mapped. Sessions with no confident match are left alone — an unlabelled
+session is honest, a mislabelled one is not.
 
 ## Reading a row
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -54,17 +54,41 @@ SQLite via SQLAlchemy 2.x **async** engine (`sqlite+aiosqlite`). Because the sto
 layer only sees a SQLAlchemy URL, SQLite can be swapped for Postgres
 (`postgresql+asyncpg://…`) by changing `GT7_DB_PATH` — no code changes.
 
-Four tables:
+Five tables:
 
 | Table | Contents |
 | --- | --- |
-| `sessions` | one row per driving session: start time, car ID/name, note, track name |
+| `sessions` | one row per driving session: start time, car ID/name/category, note, track name |
 | `laps` | one row per lap: timing, per-lap metrics, detected events (JSON), gearing (JSON), and the **full 60 Hz sample series** (JSON) |
 | `tracks` | named track signatures for auto-identification (length + bounding box) |
+| `layouts` | saved overlay/dashboard grid configs (JSON) |
 | `settings` | runtime overrides set from the Admin view (console IP, source, log level, webhook URL) |
 
-Schema evolution is handled with an idempotent additive-column migration list — on
-startup, missing columns are added with `ALTER TABLE`, so old databases upgrade in place.
+### Schema evolution
+
+Migrations are **Alembic** revisions under `backend/app/migrations/`, run to head on
+every startup by `init_db`. The app builds its Alembic config in Python and passes the
+already-open connection through `AsyncConnection.run_sync`, so nothing opens a second
+writer against the SQLite file; `backend/alembic.ini` exists only for the CLI
+(`alembic revision --autogenerate`).
+
+Before Alembic, schema changes were a hand-rolled list of `ALTER TABLE ADD COLUMN`
+statements applied at startup — which could only ever *add* columns, and grew by one
+entry per feature. That list survives, frozen, for exactly one job: a database predating
+migrations is brought up to the baseline revision by it and then **stamped**, so an
+existing install and a fresh one converge on the same schema and everything after that
+is an ordinary revision. Every recorded lap survives the transition; see
+`backend/tests/test_migrations.py`, which asserts it against a first-release database.
+
+To add a column: change the ORM model, then
+
+```bash
+cd backend && .venv/bin/alembic revision --autogenerate -m "add whatever"
+```
+
+review the generated file (SQLite cannot alter a column in place — `render_as_batch` is
+on, which rewrites the table instead) and commit it. Keep one head: two make
+`upgrade head` ambiguous, and a test guards against it.
 
 **No downsampling on write**: every 60 Hz tick of a lap is stored. Downsampling happens
 at *read* time — the analysis endpoints resample onto a uniform distance grid (default
@@ -90,3 +114,10 @@ front lockups under braking, rear wheelspin on slow launches, a kerb strike, and
 TCS/ASM/rev-limiter activity. Lap detection, event detection, charts, and the overlay
 all get realistic data with no console — it's how the project is developed, demoed, and
 screenshotted.
+
+The simulated car is **internally consistent**, which matters more than it sounds: the
+broadcast yaw rate is the actual turn rate of the line being drawn, the accelerometer is
+`v × ω` and the real speed delta, and the filtered pedals differ from the raw ones
+exactly while an aid is intervening. Features that check one channel against another —
+the g-g diagram's calibration, the ABS/TCS intervention traces — can only be exercised
+without a console if the synthetic data would pass the same check real data does.

--- a/docs/internals/derived-channels.md
+++ b/docs/internals/derived-channels.md
@@ -30,6 +30,53 @@ One value per column per tick (~60/s):
 | `aids` | bitmask: TCS=1, ASM=2, handbrake=4, rev limiter=8 | mask |
 | `surface` | per-wheel surface codes, 4 bits each, FL in the lowest nibble (0 = no data, 1 = tarmac, 2 = kerb, 3 = dirt, 4 = grass, 5 = sand, 6 = snow, 7 = other) — packet C only | mask |
 
+### Optional columns
+
+These need an extended packet format, and a lap that did not carry one from start to
+finish **does not have the column at all** rather than a column of zeros. A zero-filled
+steering trace reads as "the driver never turned"; an absent panel says nothing false.
+The rule is enforced once, at lap completion (`prune_optional` in
+`app/processing/laps.py`), so it also covers a recording whose packet format changed
+mid-lap.
+
+| Column | Needs | Formula | Unit |
+| --- | --- | --- | --- |
+| `steer` | packet B | `wheel_rotation` as broadcast | rad |
+| `acc_lat` | packet B | `sway`, raw | see below |
+| `acc_long` | packet B | `surge`, raw | see below |
+| `acc_vert` | packet B | `heave`, raw | see below |
+| `throttle_f` | packet ~ | `throttle_filtered ÷ 2.55` | % |
+| `brake_f` | packet ~ | `brake_filtered ÷ 2.55` | % |
+
+**Filtered pedals** are the pedal position *after* the aids acted on it. The gap to the
+raw `throttle` / `brake` column is the intervention itself — TCS trimming throttle, ABS
+bleeding brake pressure — measured rather than inferred from the aids bitmask, which
+only says whether an aid was active at all.
+
+### Accelerometer units are calibrated, not assumed
+
+GT7 documents neither a unit nor a sign convention for `sway`/`heave`/`surge`, and the
+simulator source cannot prove what a real console sends. The channels are therefore
+stored raw, and `analysis.accel_calibration()` fits each axis against physics the same
+lap already recorded:
+
+| Axis | Reference | Recovers |
+| --- | --- | --- |
+| lateral | `v × ω`, with `ω` the **signed** yaw rate taken from the driven path (the stored `yaw_rate` column is absolute, so it cannot settle the sign) | unit and sign |
+| longitudinal | `dv/dt` from the speed trace | unit and sign |
+| vertical | — | nothing; no independent reference exists |
+
+Each fit is a least-squares slope forced through the origin (zero acceleration must mean
+zero reading), graded by R² **about zero** rather than a mean-centred correlation — a
+long constant-rate braking zone makes both series near-constant, where Pearson *r*
+collapses into numerical noise. A fit needs ≥ 150 qualifying samples and R² ≥ 0.75; below
+that the axis reports `fitted: false`, falls back to assuming m/s², and the g-g panel
+says the scale is unverified.
+
+The result is delivered as `g_per_unit` — multiply the raw channel by it to get g, sign
+included — on the `accel` key of `/api/analysis/compare`, fitted on the reference lap and
+applied to every lap in the comparison so they share one axis.
+
 **Wheel slip** is a slip-ratio proxy: wheel surface speed divided by car speed. `< 1`
 under braking means the wheel is locking; `> 1` under power means it's spinning. Below
 1 m/s car speed the ratio is meaningless, so all four are pinned to `1.0`.
@@ -71,6 +118,9 @@ These are computed in the browser from the stored columns, never persisted:
 | Tire temp front / rear avg | mean of the two front / rear corners |
 | **Tire temp F−R balance** | `mean(tt_fl, tt_fr) − mean(tt_rl, tt_rr)` °C — positive = fronts running hotter (push/understeer working the fronts) |
 | Susp travel front / rear avg | mean of the two front / rear corners |
+| **TCS cut** | `max(0, throttle − throttle_f)` % — how much throttle traction control took away |
+| **ABS release** | `max(0, brake − brake_f)` % — how much brake pressure ABS gave back |
+| Lateral / longitudinal / vertical g | `acc_* ÷ 9.80665` as a trace (assumes m/s²; the g-g panel uses the fitted scale instead) |
 
 Laps recorded before per-corner channels existed simply skip these lines rather than
 erroring.
@@ -92,7 +142,7 @@ speed_i = top_speed × (ratio_top ÷ ratio_i)
 If you browse the code or `TODO.md` you'll see channels grouped into tiers. That's a
 **roadmap grouping**, not a runtime concept: Tier 1 = surface data already in the packet
 (per-corner slip/temps/suspension, aids, engine health, gearing — all implemented),
-Tier 2 = derived analytics like sector splits and g-g diagrams (largely future work),
-Tier 3+ = larger features (overlay, webhooks, strategy — implemented). There is no
-lateral-G, brake-temp, or slip-angle channel — GT7 doesn't send them and they aren't
-synthesized.
+Tier 2 = derived analytics like sector splits (sectors still future work; the g-g
+diagram is implemented from the broadcast accelerometer rather than derived from speed
+deltas), Tier 3+ = larger features (overlay, webhooks, strategy — implemented). There is
+no brake-temp or slip-angle channel — GT7 doesn't send them and they aren't synthesized.

--- a/docs/internals/track-identification.md
+++ b/docs/internals/track-identification.md
@@ -61,6 +61,11 @@ is a strictly better fingerprint than a bounding box — it is the road, not a r
 around it — and matching asks the only question that matters: **did this lap drive on
 this surveyed tarmac?**
 
+- The lap has to be a **whole lap** — one that ends where it started. Coverage is a share
+  of whatever samples it is given, so a fragment can sit entirely on tarmac two layouts
+  share and score 100 % on the wrong one, the part that would have told them apart being
+  the part that is missing. This matters most on the first lap of a session, which is the
+  one that gets to name it and often the one that capture started in the middle of.
 - Border records go into a 20 m occupancy grid, coarse enough to span a carriageway so
   the answer doesn't depend on which line through the corner was taken.
 - Up to 600 evenly spread positions from the lap are tested against the 3×3
@@ -76,11 +81,19 @@ two are close the evidence genuinely doesn't distinguish them, and the session i
 unnamed rather than given a wrong name silently.
 
 !!! note "Calibration"
-    Measured over 321 real recorded sessions scored against three bundles, the result
-    is sharply bimodal: 13 sessions at 100 %, 5 more at 65–85 % (all on the circuit with
-    the thinnest survey — 406 border records), then **nothing at all** until 33 %, below
-    which sit the 302 sessions driven at circuits with no bundle. The 60 % cut sits in
-    the middle of that empty band.
+    **Coverage.** Measured over 321 real recorded sessions scored against three bundles,
+    the result is sharply bimodal: 13 sessions at 100 %, 5 more at 65–85 % (all on the
+    circuit with the thinnest survey — 406 border records), then **nothing at all** until
+    33 %, below which sit the 302 sessions driven at circuits with no bundle. The 60 %
+    cut sits in the middle of that empty band.
+
+    **Closure.** A lap counts as whole when it ends within 60 m of where it started, or
+    5 % of its own length, whichever is more forgiving. Over 1,635 recorded laps, 1,583
+    of the 1,618 full ones close within 10 m (median 1 m) and not one of the 17 partial
+    laps closes within 50 m — so a flat threshold separates them. The relative term is
+    for the tail of genuine laps that end 100–200 m out because dropped packets cost them
+    their last second: 120 m means nothing on a 4 km lap and everything on a 500 m one.
+    Together the two keep 99.6 % of full laps and turn away 15 of the 17 partials.
 
 Fingerprints are cached against the bundle files' identity, so a re-survey, an import or
 a rename rebuilds them without anyone having to remember to.
@@ -89,10 +102,12 @@ a rename rebuilds them without anyone having to remember to.
 
 New sessions identify themselves as they are recorded, but a history recorded before a
 circuit was surveyed has already missed its chance. **Tracks → Identify sessions**
-(`POST /api/tracks/identify`) re-runs the bundle match over every unlabelled session —
-using each one's *shortest* usable lap, since a lap is a sample blob of a few hundred
-kilobytes and this is the difference between reading a gigabyte and reading a fraction
-of it. Sessions with no confident match are left alone.
+(`POST /api/tracks/identify`) re-runs the bundle match over every unlabelled session,
+using each one's shortest **full** lap. Full, because a pit out-lap can cover only shared
+tarmac and prove nothing; shortest for a duller reason — a lap is a sample blob of a few
+hundred kilobytes, and this is the difference between reading a gigabyte and reading a
+fraction of it. Being full costs nothing on top: a lap that covers the route covers it
+however quickly it was driven. Sessions with no confident match are left alone.
 
 ## Managing tracks
 

--- a/docs/internals/track-identification.md
+++ b/docs/internals/track-identification.md
@@ -1,8 +1,12 @@
 # Track identification
 
 GT7 telemetry doesn't include the track name — but its world coordinates are fixed per
-circuit. The datalogger exploits that: name a circuit once, and every future session on
-it is tagged automatically from lap geometry.
+circuit. The datalogger exploits that in two ways, tried in order:
+
+1. **A stored signature**, written when you name a circuit by hand.
+2. **A [survey bundle](../guide/tracks-view.md)** — the surveyed road itself.
+
+A name a person typed outranks anything inferred, so the signature goes first.
 
 ## The signature
 
@@ -43,11 +47,60 @@ track badge appears in the UI immediately.
   If you drive both directions regularly, include the direction in the name you give
   the first one you record.
 
+## Matching against a survey bundle
+
+The signature has a bootstrapping hole, and it is not a small one: a signature only
+exists once somebody has *named* a circuit. Survey a track, and the app has a
+metre-accurate map of it while still being unable to recognise the next session driven
+there — so the track badge, the outline under the race line, category bests and corner
+labels all stay empty on a circuit it has mapped in detail. Having surveyed a track and
+having named it were two separate facts, and nothing joined them.
+
+So when no signature matches, the lap is compared against the survey bundles. A bundle
+is a strictly better fingerprint than a bounding box — it is the road, not a rectangle
+around it — and matching asks the only question that matters: **did this lap drive on
+this surveyed tarmac?**
+
+- Border records go into a 20 m occupancy grid, coarse enough to span a carriageway so
+  the answer doesn't depend on which line through the corner was taken.
+- Up to 600 evenly spread positions from the lap are tested against the 3×3
+  neighbourhood of their own cell.
+- The circuit scoring highest wins if it covers **≥ 60 %** of the lap **and** beats the
+  runner-up by **≥ 25 percentage points**.
+
+Both thresholds matter. The coverage floor is well below the 100 % a fully surveyed
+circuit scores, because a bundle only covers ground that has actually been driven — a
+half-finished survey should still recognise its own circuit. The margin exists because
+two configurations of one venue share tarmac, so the loser is never near zero; when the
+two are close the evidence genuinely doesn't distinguish them, and the session is left
+unnamed rather than given a wrong name silently.
+
+!!! note "Calibration"
+    Measured over 321 real recorded sessions scored against three bundles, the result
+    is sharply bimodal: 13 sessions at 100 %, 5 more at 65–85 % (all on the circuit with
+    the thinnest survey — 406 border records), then **nothing at all** until 33 %, below
+    which sit the 302 sessions driven at circuits with no bundle. The 60 % cut sits in
+    the middle of that empty band.
+
+Fingerprints are cached against the bundle files' identity, so a re-survey, an import or
+a rename rebuilds them without anyone having to remember to.
+
+## Naming sessions that were recorded first
+
+New sessions identify themselves as they are recorded, but a history recorded before a
+circuit was surveyed has already missed its chance. **Tracks → Identify sessions**
+(`POST /api/tracks/identify`) re-runs the bundle match over every unlabelled session —
+using each one's *shortest* usable lap, since a lap is a sample blob of a few hundred
+kilobytes and this is the difference between reading a gigabyte and reading a fraction
+of it. Sessions with no confident match are left alone.
+
 ## Managing tracks
 
 - `POST /api/tracks {name, lap_id}` — what the *name track…* dialog calls; stores the
   signature and back-fills the current session's track name.
 - `GET /api/tracks` / `DELETE /api/tracks/{id}` — list and remove signatures.
+- `POST /api/tracks/identify` — name every unlabelled session that was driven on a
+  surveyed circuit.
 
 Deleting a track signature doesn't touch any session data — it only stops future
-auto-matching.
+auto-matching by signature. A surveyed circuit keeps identifying itself from its bundle.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -14,14 +14,15 @@ script can too. All REST routes live under `/api`; responses are JSON.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| GET | `/api/sessions` | all sessions, newest first, with lap count and best lap |
+| GET | `/api/sessions` | all sessions, newest first, with lap count and best lap. `?category=Gr.3` filters by car class; blank returns everything, which is also the only way to reach recordings made before packet C. A session whose own category is empty (its first packet was a narrower format) inherits its laps' category |
 | DELETE | `/api/sessions/{id}` | delete a session and its laps |
 | GET | `/api/sessions/{id}/laps` | lap summaries for one session |
 | GET | `/api/laps` | all lap summaries, newest first |
+| GET | `/api/laps/best` | `track`, `category` → the fastest **full** lap ever recorded at that circuit in that class, or `null`. Partial pit out-laps are excluded, for the same reason they never own a session best |
 | GET | `/api/laps/{id}?samples=true` | full lap detail: metrics, events, gearing, and (optionally) the 60 Hz samples |
 | DELETE | `/api/laps/{id}` | delete a lap |
 | GET | `/api/laps/{id}/export` | JSON export envelope (see [Lap file format](lap-file-format.md)) |
-| GET | `/api/laps/{id}/export.csv` | MoTeC-compatible CSV (one row per tick, 27 channels with units) |
+| GET | `/api/laps/{id}/export.csv` | MoTeC-compatible CSV (one row per tick, up to 34 channels with units — the optional channels appear only when the recording carried them) |
 | POST | `/api/laps/import` | import an exported lap file |
 
 ## Tracks
@@ -31,6 +32,7 @@ script can too. All REST routes live under `/api`; responses are JSON.
 | GET | `/api/tracks` | stored track signatures |
 | POST | `/api/tracks` | `{name, lap_id}` — name a circuit from a lap's geometry |
 | DELETE | `/api/tracks/{id}` | remove a signature (session data untouched) |
+| POST | `/api/tracks/identify` | name every unlabelled session that was driven on a [surveyed circuit](../internals/track-identification.md#matching-against-a-survey-bundle) → `{checked, identified, tracks}`. New sessions do this for themselves; this is for history recorded before the bundles existed. Sessions with no confident match are left alone. 409 when nothing has been surveyed |
 
 ## Overlay / dashboard layouts
 
@@ -49,7 +51,7 @@ builder; the server only checks the version and a 64 KB size cap.
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| GET | `/api/analysis/compare` | `laps` (CSV ids), `ref` (id), `step` (m, default 5, 0.5–50), `channels` (optional CSV) → per-lap distance-resampled series, speed peaks/valleys, events, and delta-vs-reference. The reference lap also carries `corners`: the circuit's [authored corners](../guide/tracks-view.md#labelling-corners) when it has them (`authored: true`, and a `name` when given), otherwise detected from that lap's curvature |
+| GET | `/api/analysis/compare` | `laps` (CSV ids), `ref` (id), `step` (m, default 5, 0.5–50), `channels` (optional CSV) → per-lap distance-resampled series, speed peaks/valleys, events, and delta-vs-reference. The reference lap also carries `corners`: the circuit's [authored corners](../guide/tracks-view.md#labelling-corners) when it has them (`authored: true`, and a `name` when given), otherwise detected from that lap's curvature. Top-level `accel` is the broadcast accelerometer's [unit + sign calibration](../internals/derived-channels.md#accelerometer-units-are-calibrated-not-assumed), fitted on the reference lap and applied to all of them; each lap with the channels also gets `gg`, its peak g in each direction taken from the raw ticks |
 | GET | `/api/analysis/deviation` | `session_id`, `count` (2–20, default 5) → median speed + standard deviation by distance across the best N laps |
 | GET | `/api/analysis/fuel` | `lap_id` → relative fuel-map table for settings −5…+5 |
 
@@ -94,6 +96,7 @@ import path for [track bundles](track-bundle-format.md). See the
 | --- | --- | --- |
 | GET | `/api/track-catalog` | official GT7 track/layout metadata (bundled `data/tracks.json`: 41 tracks, 85 layouts, lengths, corner counts, reverse configs) |
 | GET | `/api/track-overview` | one row per circuit, merged across the DB's named tracks, the survey bundles and the official catalog: `named` (auto-identification will work), bundle stats (points, runs, sources, elevation %, finish crossings, corners), session count, the confirmed `official` match and — only when there is none — a `suggestion` with its confidence and reasoning. Also lists the survey logs and this installation's source id |
+| GET | `/api/track-outline` | `lap_id` (resolves the circuit from the lap's session) or `track` → the surveyed road compiled for drawing: `road` (quads `[x1,z1,…,x4,z4]`), `edges` and `walls` (segments `[x1,z1,x2,z2]`), and `finish`. Answers with an **empty** outline rather than 404 when the circuit has no bundle — never having been surveyed is the common case, not an error. Compiled off the event loop and cached per bundle revision: a bundle is up to 50,000 records and the browser must not download it |
 | GET | `/api/track-bundles` | every circuit's bundle, with the same stats |
 | GET | `/api/track-bundles/{slug}` | one bundle document — the export unit, and what import consumes |
 | POST | `/api/track-bundles/import` | merge a bundle document from elsewhere. `?track=` overrides the document's own label, which is how a near-miss name lands on the right circuit. Every field is validated and rebuilt before anything is merged; versions 1–4 are accepted and upgraded. Your own authored corners and confirmed layout match are never overwritten (`corners_kept` says when incoming ones were dropped). 400 on any malformed document; 413 over 64 MB, enforced while reading rather than after buffering |

--- a/frontend/src/components/analysis/GGDiagram.tsx
+++ b/frontend/src/components/analysis/GGDiagram.tsx
@@ -1,0 +1,269 @@
+// G-G diagram (traction circle) from the broadcast accelerometer (#16).
+//
+// Every point is one moment of the lap plotted as lateral g against
+// longitudinal g: braking sits at the bottom, power at the top, corners out
+// to the sides, and the combined phases — trail-braking into a corner,
+// picking up throttle while still turning — fill the diagonals. How much of
+// the ring gets used is the whole story; an empty middle-left/middle-right is
+// a car that never brakes and turns at the same time.
+//
+// The axes are calibrated, not assumed: GT7 documents neither the unit nor
+// the sign of sway/surge, so the server fits them against physics the lap
+// already recorded (see analysis.accel_calibration) and hands over a
+// multiplier to g. When that fit is too weak the panel says so rather than
+// drawing a confident-looking circle on an unproven scale.
+
+import type * as echarts from "echarts";
+import type { EChartsOption, SeriesOption } from "echarts";
+import { useEffect, useMemo, useRef } from "react";
+import type { MapLap } from "@/components/analysis/RaceLineMap";
+import { CHART_COLORS, EChart } from "@/components/EChart";
+import type { AccelCalibration } from "@/lib/types";
+
+const ZONE_COLORS = [CHART_COLORS.brake, CHART_COLORS.coast, CHART_COLORS.throttle];
+const RING_STEP_G = 0.5;
+const RING_POINTS = 72;
+const MIN_AXIS_G = 1.5;
+
+function zoneOf(throttle: number, brake: number): number {
+  if (brake >= 1) return 0;
+  if (throttle >= 1) return 2;
+  return 1;
+}
+
+function ring(radius: number): [number, number][] {
+  return Array.from({ length: RING_POINTS + 1 }, (_, i) => {
+    const a = (i / RING_POINTS) * 2 * Math.PI;
+    return [radius * Math.cos(a), radius * Math.sin(a)] as [number, number];
+  });
+}
+
+export interface GGLap extends MapLap {
+  lat: number[]; // g, positive = right-hander as the map draws it
+  long: number[]; // g, positive = accelerating
+}
+
+// Convert a lap's raw accelerometer series into g using the fitted scale.
+// Returns null for laps recorded before packet B, which simply don't appear.
+export function ggLap(lap: MapLap, accel: AccelCalibration): GGLap | null {
+  const s = lap.entry.series;
+  const latRaw = s.acc_lat;
+  const longRaw = s.acc_long;
+  if (!latRaw?.length || !longRaw?.length) return null;
+  const kLat = accel.lateral?.g_per_unit ?? 0;
+  const kLong = accel.longitudinal?.g_per_unit ?? 0;
+  if (!kLat || !kLong) return null;
+  const n = Math.min(latRaw.length, longRaw.length);
+  return {
+    ...lap,
+    lat: Array.from({ length: n }, (_, i) => latRaw[i] * kLat),
+    long: Array.from({ length: n }, (_, i) => longRaw[i] * kLong),
+  };
+}
+
+export function GGDiagram({
+  laps,
+  accel,
+  cursorDist,
+  step,
+}: {
+  laps: GGLap[];
+  accel: AccelCalibration;
+  cursorDist: number | null;
+  step: number;
+}) {
+  const chartRef = useRef<echarts.ECharts | null>(null);
+  const ref = laps.find((lap) => lap.isRef) ?? laps[0];
+
+  const option = useMemo<EChartsOption>(() => {
+    // Both axes share one range so a constant-g ring renders as a circle
+    // rather than an ellipse — the shape IS the reading here.
+    let peak = MIN_AXIS_G;
+    for (const lap of laps) {
+      for (const v of lap.lat) peak = Math.max(peak, Math.abs(v));
+      for (const v of lap.long) peak = Math.max(peak, Math.abs(v));
+    }
+    const limit = Math.ceil(peak / RING_STEP_G) * RING_STEP_G;
+    const rings: number[] = [];
+    for (let r = RING_STEP_G; r <= limit + 1e-9; r += RING_STEP_G) rings.push(r);
+
+    const series: SeriesOption[] = [
+      {
+        id: "rings",
+        type: "custom",
+        data: rings,
+        renderItem: (params, apiCustom) => ({
+          type: "polyline",
+          shape: {
+            points: ring(rings[params.dataIndex as number]).map((p) => apiCustom.coord(p)),
+          },
+          style: { stroke: CHART_COLORS.axis, fill: "none", lineWidth: 1, opacity: 0.7 },
+        }),
+        silent: true,
+        z: 1,
+      },
+      {
+        id: "axes",
+        type: "custom",
+        data: [0, 1],
+        renderItem: (params, apiCustom) => {
+          const horizontal = params.dataIndex === 0;
+          const a = apiCustom.coord(horizontal ? [-limit, 0] : [0, -limit]);
+          const b = apiCustom.coord(horizontal ? [limit, 0] : [0, limit]);
+          return {
+            type: "line",
+            shape: { x1: a[0], y1: a[1], x2: b[0], y2: b[1] },
+            style: { stroke: CHART_COLORS.axis, lineWidth: 1, opacity: 0.9 },
+          };
+        },
+        silent: true,
+        z: 1,
+      },
+    ];
+
+    // Comparison laps first, beneath the reference: faint dots in their own
+    // chart colour, enough to show a smaller or lopsided envelope.
+    for (const lap of laps) {
+      if (lap.isRef) continue;
+      series.push({
+        id: `gg-${lap.id}`,
+        type: "scatter",
+        data: lap.lat.map((v, i) => [v, lap.long[i]]),
+        symbolSize: 3,
+        itemStyle: { color: lap.color, opacity: 0.35 },
+        large: true,
+        largeThreshold: 1000,
+        silent: true,
+        z: 2,
+      });
+    }
+
+    if (ref) {
+      const s = ref.entry.series;
+      series.push({
+        id: `gg-ref`,
+        type: "scatter",
+        data: ref.lat.map((v, i) => ({
+          value: [v, ref.long[i]],
+          itemStyle: {
+            color: ZONE_COLORS[zoneOf(s.throttle?.[i] ?? 0, s.brake?.[i] ?? 0)],
+            opacity: 0.75,
+          },
+        })),
+        symbolSize: 4,
+        silent: true,
+        z: 3,
+      });
+    }
+
+    for (const lap of laps) {
+      series.push({
+        id: `gg-cursor-${lap.id}`,
+        type: "scatter",
+        data: [] as number[][],
+        symbolSize: lap.isRef ? 11 : 8,
+        itemStyle: lap.isRef
+          ? { color: "#fff", borderColor: CHART_COLORS.series[0], borderWidth: 3 }
+          : { color: lap.color, borderColor: "#fff", borderWidth: 1.5 },
+        silent: true,
+        z: 10,
+      });
+    }
+
+    const axis = {
+      type: "value" as const,
+      min: -limit,
+      max: limit,
+      splitLine: { show: false },
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { show: false },
+    };
+    return {
+      animation: false,
+      grid: { left: 10, right: 10, top: 10, bottom: 10 },
+      xAxis: axis,
+      yAxis: axis,
+      tooltip: { show: false },
+      series,
+    };
+  }, [laps, ref]);
+
+  // Cursor dots merge in by series id, exactly like the race-line map.
+  useEffect(() => {
+    const updates: SeriesOption[] = laps.map((lap) => {
+      let data: number[][] = [];
+      if (cursorDist != null && step > 0 && lap.lat.length > 0) {
+        const i = Math.min(lap.lat.length - 1, Math.max(0, Math.round(cursorDist / step)));
+        if (Number.isFinite(i)) data = [[lap.lat[i], lap.long[i]]];
+      }
+      return { id: `gg-cursor-${lap.id}`, data } as SeriesOption;
+    });
+    chartRef.current?.setOption({ series: updates }, { notMerge: false, lazyUpdate: true });
+  }, [laps, cursorDist, step]);
+
+  const peaks = ref?.entry.gg;
+  const lat = accel.lateral;
+  const long = accel.longitudinal;
+  const proven = !!lat?.fitted && !!long?.fitted;
+
+  return (
+    <div>
+      <div className="relative">
+        <EChart
+          option={option}
+          className="aspect-square w-full"
+          onInit={(chart) => {
+            chartRef.current = chart;
+          }}
+        />
+        <span className="pointer-events-none absolute left-1/2 top-2 -translate-x-1/2 text-[10px] text-ink-dim">
+          accelerating
+        </span>
+        <span className="pointer-events-none absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] text-ink-dim">
+          braking
+        </span>
+        <span className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-[10px] text-ink-dim">
+          left
+        </span>
+        <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-ink-dim">
+          right
+        </span>
+      </div>
+      {peaks && (
+        <div className="grid grid-cols-4 gap-1 px-3 pb-1 text-center font-tabular text-[11px]">
+          <Peak label="brake" value={peaks.braking} />
+          <Peak label="left" value={peaks.lat_left} />
+          <Peak label="right" value={peaks.lat_right} />
+          <Peak label="accel" value={peaks.accel} />
+        </div>
+      )}
+      <div className="px-3 pb-3 pt-1 text-[10px] leading-relaxed text-ink-dim">
+        {proven ? (
+          <>
+            Scale checked against the lap's own physics: lateral vs v·ω
+            (R²&nbsp;{lat!.r2.toFixed(2)}), longitudinal vs dv/dt (R²&nbsp;
+            {long!.r2.toFixed(2)}). GT7 broadcasts these as{" "}
+            <span className="text-ink">{accel.unit}</span>.
+          </>
+        ) : (
+          <>
+            <span className="text-warn">Scale unverified</span> — this lap gave
+            too little steady cornering or braking to check the broadcast
+            channels against v·ω and dv/dt, so g is assumed to be m/s². Shapes
+            are still comparable between laps; the numbers may not be.
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Peak({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <div className="text-ink">{value.toFixed(2)}g</div>
+      <div className="text-ink-dim">{label}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -6,11 +6,13 @@
 //
 // Three things make it usable rather than merely present:
 //
-// * **True geometry.** Both axes are given the same span, so a corner's shape
-//   on screen is its shape on the track. Letting each axis scale to its own
-//   data stretches the map by whatever the circuit's aspect ratio happens to
-//   be — 8 % at Lago Maggiore Centre, nearly 3x at Deep Forest — which is a
-//   strange thing for a map to do to a racing line.
+// * **True geometry.** The axis spans follow the plotting area's pixel aspect,
+//   so a metre across is a metre down and a corner's shape on screen is its
+//   shape on the track. Letting each axis scale to its own data stretches the
+//   map by whatever the circuit's aspect ratio happens to be — 8 % at Lago
+//   Maggiore Centre, nearly 3x at Deep Forest — which is a strange thing for a
+//   map to do to a racing line. (Equal spans are not enough on their own: they
+//   are only true on a square plot, and the maximized view is widescreen.)
 // * **Corner navigation.** The corners are already known (detected, or
 //   authored in the track bundle), so they are the natural unit to look at
 //   one at a time. Picking one drives the SHARED zoom, so the charts follow
@@ -55,6 +57,9 @@ const MAX_NUMBERED_CORNERS_LARGE = 90;
 // the braking zone into it and the exit out of it — rather than cropped to
 // the arc itself.
 const CORNER_PAD_M = 40;
+
+// Chart margin, subtracted when measuring the plotting area's pixel aspect.
+const GRID_PAD = 8;
 
 function zoneOf(throttle: number, brake: number): number {
   if (brake >= 1) return 0;
@@ -140,6 +145,29 @@ function MapBody({
   maximized = false,
 }: MapProps & { onMaximize?: () => void; maximized?: boolean }) {
   const chartRef = useRef<echarts.ECharts | null>(null);
+  // Equal axis spans only keep the geometry honest if the PLOTTING AREA is
+  // square, which the rail's aspect-square box is and the maximized dialog —
+  // a widescreen rectangle — very much is not. So the spans follow the box:
+  // the axis with more pixels gets proportionally more metres, and a metre
+  // stays a metre either way. Measured rather than assumed, because the same
+  // component renders in both.
+  const boxRef = useRef<HTMLDivElement>(null);
+  const [aspect, setAspect] = useState(1);
+  useEffect(() => {
+    const el = boxRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      const { width, height } = el.getBoundingClientRect();
+      const plotW = width - 2 * GRID_PAD;
+      const plotH = height - 2 * GRID_PAD;
+      if (plotW <= 0 || plotH <= 0) return;
+      // Quantized: a resize drag fires this continuously, and every distinct
+      // value rebuilds the whole option.
+      setAspect((was) => (Math.abs(plotW / plotH - was) > 0.005 ? plotW / plotH : was));
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
   const ref = laps.find((lap) => lap.isRef);
   const hasOutline = (outline?.road.length ?? 0) > 0 || (outline?.edges.length ?? 0) > 0;
   const corners = useMemo(() => ref?.entry.corners ?? [], [ref]);
@@ -255,24 +283,43 @@ function MapBody({
           if (s.pos_x[i] != null && s.pos_z[i] != null) see(s.pos_x[i], s.pos_z[i]);
         }
       }
-      for (const quad of outline?.road ?? []) see(quad[0], quad[1]);
-      for (const seg of outline?.edges ?? []) see(seg[0], seg[1]);
+      // EVERY vertex of every layer. Sampling one corner of each quad and one
+      // end of each segment leaves whatever lies past it outside the explicit
+      // axis limits, and the things most likely to be out there are the ones
+      // worth seeing: a wall beyond the ordinary border, or a finish line
+      // reaching 12 m either side of the road.
+      for (const quad of outline?.road ?? []) {
+        for (let i = 0; i + 1 < quad.length; i += 2) see(quad[i], quad[i + 1]);
+      }
+      for (const segments of [outline?.edges ?? [], outline?.walls ?? []]) {
+        for (const seg of segments) {
+          see(seg[0], seg[1]);
+          see(seg[2], seg[3]);
+        }
+      }
+      if (outline?.finish) {
+        see(outline.finish[0], outline.finish[1]);
+        see(outline.finish[2], outline.finish[3]);
+      }
     }
 
-    // One span for both axes: a metre across must be a metre down, or the map
-    // lies about every corner's shape. The container is square, so the window
-    // is too — the shorter axis grows around its own centre.
+    // A metre across must be a metre down, or the map lies about every
+    // corner's shape. Equal spans would do that only on a square plot; the
+    // spans instead follow the plotting area's pixel aspect, so the wider
+    // dimension simply shows more track.
     let axis: { xMin: number; xMax: number; zMin: number; zMax: number } | null = null;
     if (isFinite(minX) && isFinite(maxX) && isFinite(minZ) && isFinite(maxZ)) {
       const pad = Math.max(Math.max(maxX - minX, maxZ - minZ) * 0.06, 8);
       const span = Math.max(maxX - minX, maxZ - minZ) + pad * 2;
+      const spanX = span * Math.max(1, aspect);
+      const spanZ = span * Math.max(1, 1 / aspect);
       const cx = (minX + maxX) / 2;
       const cz = (minZ + maxZ) / 2;
       axis = {
-        xMin: cx - span / 2,
-        xMax: cx + span / 2,
-        zMin: cz - span / 2,
-        zMax: cz + span / 2,
+        xMin: cx - spanX / 2,
+        xMax: cx + spanX / 2,
+        zMin: cz - spanZ / 2,
+        zMax: cz + spanZ / 2,
       };
     }
 
@@ -518,7 +565,7 @@ function MapBody({
       tooltip: { show: false },
       series,
     };
-  }, [laps, zoomRange, outline, corners, current, maximized, ref]);
+  }, [laps, zoomRange, outline, corners, current, maximized, ref, aspect]);
 
   // Cursor updates merge into the existing chart by series id — no rebuild.
   useEffect(() => {
@@ -541,7 +588,7 @@ function MapBody({
 
   return (
     <div className={maximized ? "flex h-full flex-col" : undefined}>
-      <div className={maximized ? "relative min-h-0 flex-1" : "relative"}>
+      <div ref={boxRef} className={maximized ? "relative min-h-0 flex-1" : "relative"}>
         <EChart
           option={option}
           className={maximized ? "h-full w-full" : "aspect-square w-full"}

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -8,7 +8,12 @@ import type * as echarts from "echarts";
 import type { EChartsOption, SeriesOption } from "echarts";
 import { useEffect, useMemo, useRef } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
-import { type CompareLapEntry, kerbWheelCount, looseWheelCount } from "@/lib/types";
+import {
+  type CompareLapEntry,
+  kerbWheelCount,
+  looseWheelCount,
+  type TrackOutline,
+} from "@/lib/types";
 
 const ZONE_COLORS = [CHART_COLORS.brake, CHART_COLORS.coast, CHART_COLORS.throttle];
 
@@ -16,6 +21,13 @@ const ZONE_COLORS = [CHART_COLORS.brake, CHART_COLORS.coast, CHART_COLORS.thrott
 // kerb strikes in yellow, wheels on grass/gravel/dirt in orange.
 const KERB_COLOR = "#eab308";
 const LOOSE_COLOR = "#f97316";
+
+// The surveyed road beneath everything (#51). Deliberately quiet: it is the
+// backdrop the lap is read against, not a thing to read on its own — a fill
+// bright enough to compete with the input-zone dots would bury them.
+const ROAD_FILL = "#252b34";
+const BORDER_COLOR = "#4b5563";
+const WALL_COLOR = "#7f1d1d";
 
 // Numbered circles are readable up to about this many corners in view;
 // beyond that (or fully zoomed out on a long track) they collapse to dots.
@@ -40,17 +52,88 @@ export function RaceLineMap({
   cursorDist,
   step,
   zoomRange,
+  outline,
 }: {
   laps: MapLap[];
   cursorDist: number | null;
   step: number;
   zoomRange?: [number, number] | null;
+  // The circuit's surveyed road, when it has been surveyed. Null/empty draws
+  // exactly what this map drew before it existed.
+  outline?: TrackOutline | null;
 }) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   const ref = laps.find((lap) => lap.isRef);
+  const hasOutline = (outline?.road.length ?? 0) > 0 || (outline?.edges.length ?? 0) > 0;
 
   const option = useMemo<EChartsOption>(() => {
     const series: SeriesOption[] = [];
+
+    // Surveyed road first, under every lap line: fill, then borders, then the
+    // start/finish line. Segment endpoints are pre-computed server-side, so
+    // renderItem only has to project them.
+    if (outline) {
+      if (outline.road.length > 0) {
+        series.push({
+          id: "outline-road",
+          type: "custom",
+          data: outline.road,
+          renderItem: (_params, apiCustom) => ({
+            type: "polygon",
+            shape: {
+              points: [0, 1, 2, 3].map((i) =>
+                apiCustom.coord([
+                  Number(apiCustom.value(i * 2)),
+                  Number(apiCustom.value(i * 2 + 1)),
+                ]),
+              ),
+            },
+            style: { fill: ROAD_FILL },
+          }),
+          progressive: 0,
+          silent: true,
+          z: 0.5,
+        });
+      }
+      for (const [id, data, color, width] of [
+        ["outline-edges", outline.edges, BORDER_COLOR, 1.4],
+        ["outline-walls", outline.walls, WALL_COLOR, 2],
+      ] as const) {
+        if (data.length === 0) continue;
+        series.push({
+          id,
+          type: "custom",
+          data: data as unknown as number[][],
+          renderItem: (_params, apiCustom) => {
+            const p1 = apiCustom.coord([Number(apiCustom.value(0)), Number(apiCustom.value(1))]);
+            const p2 = apiCustom.coord([Number(apiCustom.value(2)), Number(apiCustom.value(3))]);
+            return {
+              type: "line",
+              shape: { x1: p1[0], y1: p1[1], x2: p2[0], y2: p2[1] },
+              style: { stroke: color, lineWidth: width, opacity: 0.85 },
+            };
+          },
+          progressive: 0,
+          silent: true,
+          z: 0.8,
+        });
+      }
+      if (outline.finish) {
+        const [fx1, fz1, fx2, fz2] = outline.finish;
+        series.push({
+          id: "outline-finish",
+          type: "line",
+          data: [
+            [fx1, fz1],
+            [fx2, fz2],
+          ],
+          showSymbol: false,
+          lineStyle: { color: "#e5e7eb", width: 2.5, opacity: 0.8 },
+          silent: true,
+          z: 0.9,
+        });
+      }
+    }
 
     let xMin: number | undefined;
     let xMax: number | undefined;
@@ -279,8 +362,9 @@ export function RaceLineMap({
       tooltip: { show: false },
       series,
     };
-    // Deliberately depends only on laps/zoomRange: cursor updates merge separately below.
-  }, [laps, zoomRange]);
+    // Deliberately depends only on laps/zoomRange/outline: cursor updates
+    // merge separately below.
+  }, [laps, zoomRange, outline]);
 
   // Cursor updates merge into the existing chart by series id — no rebuild.
   useEffect(() => {
@@ -302,25 +386,30 @@ export function RaceLineMap({
   const hasSurface = !!ref?.entry.series.surface?.some((v) => v > 0);
 
   return (
-    <div className="relative">
-      <EChart
-        option={option}
-        className="aspect-square w-full"
-        onInit={(chart) => {
-          chartRef.current = chart;
-        }}
-      />
-      {others.length > 0 && (
-        <div className="absolute right-2 top-2 space-y-0.5 text-[10px]">
-          {others.map((lap) => (
-            <div key={lap.id} className="flex items-center justify-end gap-1.5 text-ink-dim">
-              {lap.label}
-              <i className="inline-block h-0.5 w-4" style={{ backgroundColor: lap.color }} />
-            </div>
-          ))}
-        </div>
-      )}
-      <div className="absolute bottom-2 left-2 flex gap-3 text-[10px] text-ink-dim">
+    <div>
+      <div className="relative">
+        <EChart
+          option={option}
+          className="aspect-square w-full"
+          onInit={(chart) => {
+            chartRef.current = chart;
+          }}
+        />
+        {others.length > 0 && (
+          <div className="absolute right-2 top-2 space-y-0.5 text-[10px]">
+            {others.map((lap) => (
+              <div key={lap.id} className="flex items-center justify-end gap-1.5 text-ink-dim">
+                {lap.label}
+                <i className="inline-block h-0.5 w-4" style={{ backgroundColor: lap.color }} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {/* Below the map, not floating over it: the key grew past what fits on
+          one overlaid row once the surveyed road joined it, and legend text
+          wrapping across the track is worse than a couple of rows of space. */}
+      <div className="flex flex-wrap gap-x-3 gap-y-1 px-3 pb-2 text-[10px] text-ink-dim [&>span]:whitespace-nowrap">
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-throttle" />throttle</span>
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-brake" />brake</span>
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-coast" />coast</span>
@@ -350,6 +439,24 @@ export function RaceLineMap({
               1
             </i>
             corner
+          </span>
+        )}
+        {hasOutline && (
+          <span title={`Surveyed over ${outline!.runs} run${outline!.runs === 1 ? "" : "s"}`}>
+            <i
+              className="mr-1 inline-block h-2 w-2 rounded-sm"
+              style={{ backgroundColor: ROAD_FILL, outline: `1px solid ${BORDER_COLOR}` }}
+            />
+            surveyed road
+          </span>
+        )}
+        {(outline?.walls.length ?? 0) > 0 && (
+          <span>
+            <i
+              className="mr-1 inline-block h-2 w-2 rounded-sm"
+              style={{ backgroundColor: WALL_COLOR }}
+            />
+            wall
           </span>
         )}
       </div>

--- a/frontend/src/components/analysis/RaceLineMap.tsx
+++ b/frontend/src/components/analysis/RaceLineMap.tsx
@@ -3,13 +3,30 @@
 // every other selected lap is overlaid as a solid line in its chart color —
 // like GT7's own Data Logger, but with a synced cursor dot per lap showing
 // the spatial gap at the hovered distance.
+//
+// Three things make it usable rather than merely present:
+//
+// * **True geometry.** Both axes are given the same span, so a corner's shape
+//   on screen is its shape on the track. Letting each axis scale to its own
+//   data stretches the map by whatever the circuit's aspect ratio happens to
+//   be — 8 % at Lago Maggiore Centre, nearly 3x at Deep Forest — which is a
+//   strange thing for a map to do to a racing line.
+// * **Corner navigation.** The corners are already known (detected, or
+//   authored in the track bundle), so they are the natural unit to look at
+//   one at a time. Picking one drives the SHARED zoom, so the charts follow
+//   the map into the corner rather than the two disagreeing.
+// * **A maximized view.** A 4.5 km circuit in a 360 px rail is a squiggle;
+//   the same map at full screen is a track.
 
 import type * as echarts from "echarts";
 import type { EChartsOption, SeriesOption } from "echarts";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CHART_COLORS, EChart } from "@/components/EChart";
+import { LargeDialog } from "@/components/ui/Dialog";
+import { Tip } from "@/components/ui/Tooltip";
 import {
   type CompareLapEntry,
+  type Corner,
   kerbWheelCount,
   looseWheelCount,
   type TrackOutline,
@@ -29,14 +46,42 @@ const ROAD_FILL = "#252b34";
 const BORDER_COLOR = "#4b5563";
 const WALL_COLOR = "#7f1d1d";
 
-// Numbered circles are readable up to about this many corners in view;
-// beyond that (or fully zoomed out on a long track) they collapse to dots.
+// Numbered circles are readable up to about this many corners in view; beyond
+// that they collapse to dots. The maximized view has the room for far more.
 const MAX_NUMBERED_CORNERS = 30;
+const MAX_NUMBERED_CORNERS_LARGE = 90;
+
+// Track either side of a corner's own extent, so it arrives in context —
+// the braking zone into it and the exit out of it — rather than cropped to
+// the arc itself.
+const CORNER_PAD_M = 40;
 
 function zoneOf(throttle: number, brake: number): number {
   if (brake >= 1) return 0;
   if (throttle >= 1) return 2;
   return 1;
+}
+
+/** The distance window a corner is shown in. Also the identity used to tell
+ *  whether the current zoom IS this corner, so it must be deterministic. */
+export function cornerRange(c: Corner): [number, number] {
+  return [
+    Math.max(0, c.entry_dist - CORNER_PAD_M),
+    Math.max(c.exit_dist, c.entry_dist) + CORNER_PAD_M,
+  ];
+}
+
+/** Which corner the current zoom is showing, if it is showing one. Derived
+ *  rather than remembered: the charts can change the zoom too (drag, sector
+ *  buttons, reset), and a remembered selection would go stale behind them. */
+function selectedCorner(corners: Corner[], zoom: [number, number] | null): Corner | null {
+  if (!zoom) return null;
+  return (
+    corners.find((c) => {
+      const [lo, hi] = cornerRange(c);
+      return Math.abs(lo - zoom[0]) < 1 && Math.abs(hi - zoom[1]) < 1;
+    }) ?? null
+  );
 }
 
 export interface MapLap {
@@ -47,13 +92,7 @@ export interface MapLap {
   isRef: boolean;
 }
 
-export function RaceLineMap({
-  laps,
-  cursorDist,
-  step,
-  zoomRange,
-  outline,
-}: {
+interface MapProps {
   laps: MapLap[];
   cursorDist: number | null;
   step: number;
@@ -61,10 +100,62 @@ export function RaceLineMap({
   // The circuit's surveyed road, when it has been surveyed. Null/empty draws
   // exactly what this map drew before it existed.
   outline?: TrackOutline | null;
-}) {
+  // Lets the map drive the zoom every panel shares, so picking a corner here
+  // takes the charts there too.
+  onZoomChange?: (range: [number, number] | null) => void;
+}
+
+export function RaceLineMap(props: MapProps) {
+  const [maximized, setMaximized] = useState(false);
+  return (
+    <>
+      {/* While the dialog is up the inline chart is behind an opaque overlay,
+          so it is swapped for a placeholder of the same size: two live
+          instances would both re-render the outline's thousands of segments,
+          and only one of them would be visible. */}
+      {maximized ? (
+        <div className="aspect-square w-full" />
+      ) : (
+        <MapBody {...props} onMaximize={() => setMaximized(true)} />
+      )}
+      <LargeDialog
+        open={maximized}
+        title="Race line"
+        onClose={() => setMaximized(false)}
+      >
+        <MapBody {...props} maximized />
+      </LargeDialog>
+    </>
+  );
+}
+
+function MapBody({
+  laps,
+  cursorDist,
+  step,
+  zoomRange,
+  outline,
+  onZoomChange,
+  onMaximize,
+  maximized = false,
+}: MapProps & { onMaximize?: () => void; maximized?: boolean }) {
   const chartRef = useRef<echarts.ECharts | null>(null);
   const ref = laps.find((lap) => lap.isRef);
   const hasOutline = (outline?.road.length ?? 0) > 0 || (outline?.edges.length ?? 0) > 0;
+  const corners = useMemo(() => ref?.entry.corners ?? [], [ref]);
+  const current = selectedCorner(corners, zoomRange ?? null);
+
+  const zoomToCorner = useCallback(
+    (c: Corner | null) => onZoomChange?.(c ? cornerRange(c) : null),
+    [onZoomChange],
+  );
+
+  // Bound once on the chart, so it reads the corner list through a ref rather
+  // than capturing whichever one existed at mount.
+  const cornersRef = useRef(corners);
+  cornersRef.current = corners;
+  const zoomRef = useRef(zoomToCorner);
+  zoomRef.current = zoomToCorner;
 
   const option = useMemo<EChartsOption>(() => {
     const series: SeriesOption[] = [];
@@ -135,42 +226,54 @@ export function RaceLineMap({
       }
     }
 
-    let xMin: number | undefined;
-    let xMax: number | undefined;
-    let zMin: number | undefined;
-    let zMax: number | undefined;
+    // The window to show: the zoomed section of the reference lap, or
+    // everything there is. Collected from every drawn layer so the surveyed
+    // road cannot fall outside the frame.
+    let minX = Infinity;
+    let maxX = -Infinity;
+    let minZ = Infinity;
+    let maxZ = -Infinity;
+    const see = (x: number, z: number) => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    };
 
     if (zoomRange && ref) {
       const s = ref.entry.series;
-      let minX = Infinity;
-      let maxX = -Infinity;
-      let minZ = Infinity;
-      let maxZ = -Infinity;
-      let count = 0;
-
       for (let i = 0; i < s.dist.length; i++) {
         const d = s.dist[i];
-        if (d >= zoomRange[0] && d <= zoomRange[1]) {
-          const x = s.pos_x[i];
-          const z = s.pos_z[i];
-          if (x != null && z != null) {
-            if (x < minX) minX = x;
-            if (x > maxX) maxX = x;
-            if (z < minZ) minZ = z;
-            if (z > maxZ) maxZ = z;
-            count++;
-          }
+        if (d >= zoomRange[0] && d <= zoomRange[1] && s.pos_x[i] != null && s.pos_z[i] != null) {
+          see(s.pos_x[i], s.pos_z[i]);
         }
       }
-
-      if (count > 0 && isFinite(minX) && isFinite(maxX) && isFinite(minZ) && isFinite(maxZ)) {
-        const padX = Math.max((maxX - minX) * 0.15, 8);
-        const padZ = Math.max((maxZ - minZ) * 0.15, 8);
-        xMin = minX - padX;
-        xMax = maxX + padX;
-        zMin = minZ - padZ;
-        zMax = maxZ + padZ;
+    } else {
+      for (const lap of laps) {
+        const s = lap.entry.series;
+        for (let i = 0; i < s.dist.length; i++) {
+          if (s.pos_x[i] != null && s.pos_z[i] != null) see(s.pos_x[i], s.pos_z[i]);
+        }
       }
+      for (const quad of outline?.road ?? []) see(quad[0], quad[1]);
+      for (const seg of outline?.edges ?? []) see(seg[0], seg[1]);
+    }
+
+    // One span for both axes: a metre across must be a metre down, or the map
+    // lies about every corner's shape. The container is square, so the window
+    // is too — the shorter axis grows around its own centre.
+    let axis: { xMin: number; xMax: number; zMin: number; zMax: number } | null = null;
+    if (isFinite(minX) && isFinite(maxX) && isFinite(minZ) && isFinite(maxZ)) {
+      const pad = Math.max(Math.max(maxX - minX, maxZ - minZ) * 0.06, 8);
+      const span = Math.max(maxX - minX, maxZ - minZ) + pad * 2;
+      const cx = (minX + maxX) / 2;
+      const cz = (minZ + maxZ) / 2;
+      axis = {
+        xMin: cx - span / 2,
+        xMax: cx + span / 2,
+        zMin: cz - span / 2,
+        zMax: cz + span / 2,
+      };
     }
 
     // Comparison laps first (under the reference), as solid colored lines.
@@ -210,11 +313,52 @@ export function RaceLineMap({
 
     if (ref) {
       const s = ref.entry.series;
+      // Zoomed in there is room for the line to be a line rather than a dotted
+      // trail, and the input zones read better for it.
+      const dot = zoomRange ? (maximized ? 7 : 5) : maximized ? 4.5 : 3.5;
+
+      // The reference lap as a CONTINUOUS line, one series per input zone
+      // with the other zones nulled out. Samples arrive on a 5 m grid, which
+      // reads as a solid line across a whole circuit and as scattered dots
+      // the moment you zoom into a corner — which is exactly where the line
+      // matters most. Each run is extended one sample backwards so
+      // consecutive zones meet instead of leaving a gap at every transition.
+      const inZoomAt = (i: number) =>
+        !zoomRange || (s.dist[i] >= zoomRange[0] && s.dist[i] <= zoomRange[1]);
+      const zoneAt = (i: number) => zoneOf(s.throttle[i], s.brake[i]);
+      if (zoomRange) {
+        series.push({
+          id: "ref-line-dim",
+          type: "line",
+          data: s.dist.map((_, i) => [s.pos_x[i], s.pos_z[i]]),
+          showSymbol: false,
+          lineStyle: { color: CHART_COLORS.label, width: 1.2, opacity: 0.18 },
+          silent: true,
+          z: 1.8,
+        });
+      }
+      for (let zone = 0; zone < 3; zone++) {
+        series.push({
+          id: `ref-zone-${zone}`,
+          type: "line",
+          data: s.dist.map((_, i) =>
+            inZoomAt(i) && (zoneAt(i) === zone || (i > 0 && zoneAt(i - 1) === zone))
+              ? [s.pos_x[i], s.pos_z[i]]
+              : [null, null],
+          ),
+          showSymbol: false,
+          connectNulls: false,
+          lineStyle: { color: ZONE_COLORS[zone], width: zoomRange ? 3 : 2, opacity: 0.95 },
+          silent: true,
+          z: 2.8,
+        });
+      }
+
       const points = s.dist.map((d, i) => {
         const inZoom = zoomRange ? d >= zoomRange[0] && d <= zoomRange[1] : true;
         return {
           value: [s.pos_x[i], s.pos_z[i]],
-          symbolSize: inZoom ? 4 : 2,
+          symbolSize: inZoom ? dot : dot * 0.55,
           itemStyle: {
             color: ZONE_COLORS[zoneOf(s.throttle[i], s.brake[i])],
             opacity: inZoom ? 1 : 0.15,
@@ -246,7 +390,7 @@ export function RaceLineMap({
             id: "surface-kerb",
             type: "scatter",
             data: kerbPts,
-            symbolSize: 8,
+            symbolSize: dot * 2.3,
             itemStyle: { color: KERB_COLOR },
             silent: true,
             z: 2.5,
@@ -255,7 +399,7 @@ export function RaceLineMap({
             id: "surface-loose",
             type: "scatter",
             data: loosePts,
-            symbolSize: 9,
+            symbolSize: dot * 2.6,
             itemStyle: { color: LOOSE_COLOR },
             silent: true,
             z: 2.6,
@@ -264,45 +408,42 @@ export function RaceLineMap({
       }
 
       const pv = ref.entry.peaks_valleys;
-      const peaks = pv.peaks.filter(
-        (p) => !zoomRange || (p.dist >= zoomRange[0] && p.dist <= zoomRange[1]),
-      );
-      const valleys = pv.valleys.filter(
-        (p) => !zoomRange || (p.dist >= zoomRange[0] && p.dist <= zoomRange[1]),
-      );
+      const pvInZoom = (d: number) => !zoomRange || (d >= zoomRange[0] && d <= zoomRange[1]);
 
       series.push(
-        { type: "scatter", data: points, symbolSize: 3.5, silent: true, z: 3 },
+        { type: "scatter", data: points, symbolSize: dot, silent: true, z: 3 },
         {
           type: "scatter",
-          data: peaks.map((p) => [p.x, p.z]),
+          data: pv.peaks.filter((p) => pvInZoom(p.dist)).map((p) => [p.x, p.z]),
           symbol: "triangle",
-          symbolSize: 9,
+          symbolSize: maximized ? 12 : 9,
           itemStyle: { color: "#facc15" },
           silent: true,
           z: 5,
         },
         {
           type: "scatter",
-          data: valleys.map((p) => [p.x, p.z]),
+          data: pv.valleys.filter((p) => pvInZoom(p.dist)).map((p) => [p.x, p.z]),
           symbol: "triangle",
           symbolRotate: 180,
-          symbolSize: 9,
+          symbolSize: maximized ? 12 : 9,
           itemStyle: { color: "#c084fc" },
           silent: true,
           z: 5,
         },
       );
 
-      // Auto-numbered corners (detected on the reference lap). Numbered
-      // circles while the view shows a readable amount; plain dots otherwise.
-      const corners = ref.entry.corners ?? [];
+      // Corners (detected on the reference lap, or authored for the circuit).
+      // Numbered circles while the view shows a readable amount; plain dots
+      // otherwise. Clickable: they are the fastest way into a corner.
       const cornersInView = corners.filter(
         (c) => !zoomRange || (c.apex_dist >= zoomRange[0] && c.apex_dist <= zoomRange[1]),
       );
       const numbered =
-        cornersInView.length > 0 && cornersInView.length <= MAX_NUMBERED_CORNERS;
+        cornersInView.length > 0 &&
+        cornersInView.length <= (maximized ? MAX_NUMBERED_CORNERS_LARGE : MAX_NUMBERED_CORNERS);
       if (cornersInView.length > 0) {
+        const size = maximized ? 20 : 15;
         series.push({
           id: "corners",
           type: "scatter",
@@ -310,19 +451,23 @@ export function RaceLineMap({
             value: [c.apex_x, c.apex_z],
             name: String(c.n),
           })),
-          symbolSize: numbered ? 15 : 5,
+          symbolSize: numbered ? size : 5,
           itemStyle: numbered
-            ? { color: "#14171c", borderColor: CHART_COLORS.label, borderWidth: 1 }
+            ? {
+                color: "#14171c",
+                borderColor: current ? CHART_COLORS.series[0] : CHART_COLORS.label,
+                borderWidth: current ? 2 : 1,
+              }
             : { color: CHART_COLORS.label, opacity: 0.85 },
           label: {
             show: numbered,
             position: "inside",
             formatter: "{b}",
             color: "#e5e7eb",
-            fontSize: 9,
+            fontSize: maximized ? 11 : 9,
             fontWeight: "bold",
           },
-          silent: true,
+          cursor: "pointer",
           z: 4, // above the race line dots, below peak/valley markers & cursors
         });
       }
@@ -334,7 +479,7 @@ export function RaceLineMap({
         id: `cursor-${lap.id}`,
         type: "scatter",
         data: [] as number[][],
-        symbolSize: lap.isRef ? 12 : 9,
+        symbolSize: (lap.isRef ? 12 : 9) * (maximized ? 1.3 : 1),
         itemStyle: lap.isRef
           ? { color: "#fff", borderColor: CHART_COLORS.series[0], borderWidth: 3 }
           : { color: lap.color, borderColor: "#fff", borderWidth: 1.5 },
@@ -349,22 +494,31 @@ export function RaceLineMap({
       xAxis: {
         type: "value",
         show: false,
-        scale: true,
-        ...(xMin != null ? { min: xMin, max: xMax } : {}),
+        ...(axis ? { min: axis.xMin, max: axis.xMax } : { scale: true }),
       },
       yAxis: {
         type: "value",
         show: false,
-        scale: true,
         inverse: true,
-        ...(zMin != null ? { min: zMin, max: zMax } : {}),
+        ...(axis ? { min: axis.zMin, max: axis.zMax } : { scale: true }),
       },
+      // Free pan and wheel-zoom, but only where it cannot fight the page:
+      // in the rail the map sits inside a scrolling column, and a wheel that
+      // sometimes scrolls and sometimes zooms is worse than one that always
+      // scrolls. The window resets whenever the option is rebuilt (a new
+      // selection, a new corner), which is the moment it should.
+      ...(maximized
+        ? {
+            dataZoom: [
+              { type: "inside", xAxisIndex: 0, filterMode: "none" },
+              { type: "inside", yAxisIndex: 0, filterMode: "none" },
+            ],
+          }
+        : {}),
       tooltip: { show: false },
       series,
     };
-    // Deliberately depends only on laps/zoomRange/outline: cursor updates
-    // merge separately below.
-  }, [laps, zoomRange, outline]);
+  }, [laps, zoomRange, outline, corners, current, maximized, ref]);
 
   // Cursor updates merge into the existing chart by series id — no rebuild.
   useEffect(() => {
@@ -386,30 +540,52 @@ export function RaceLineMap({
   const hasSurface = !!ref?.entry.series.surface?.some((v) => v > 0);
 
   return (
-    <div>
-      <div className="relative">
+    <div className={maximized ? "flex h-full flex-col" : undefined}>
+      <div className={maximized ? "relative min-h-0 flex-1" : "relative"}>
         <EChart
           option={option}
-          className="aspect-square w-full"
+          className={maximized ? "h-full w-full" : "aspect-square w-full"}
           onInit={(chart) => {
             chartRef.current = chart;
+            chart.on("click", (e) => {
+              if (e.seriesId !== "corners") return;
+              const corner = cornersRef.current.find((c) => String(c.n) === e.name);
+              if (corner) zoomRef.current(corner);
+            });
           }}
         />
-        {others.length > 0 && (
-          <div className="absolute right-2 top-2 space-y-0.5 text-[10px]">
-            {others.map((lap) => (
-              <div key={lap.id} className="flex items-center justify-end gap-1.5 text-ink-dim">
-                {lap.label}
-                <i className="inline-block h-0.5 w-4" style={{ backgroundColor: lap.color }} />
-              </div>
-            ))}
-          </div>
+        {onMaximize && (
+          <Tip content="Open the map full screen">
+            <button
+              onClick={onMaximize}
+              aria-label="Maximize the race line map"
+              className="absolute right-2 top-2 rounded border border-edge bg-panel/80 px-1.5 py-0.5 text-xs text-ink-dim backdrop-blur transition-colors hover:border-edge-bright hover:text-ink"
+            >
+              ⤢
+            </button>
+          </Tip>
         )}
       </div>
+
+      {onZoomChange && corners.length > 0 && (
+        <CornerBar
+          corners={corners}
+          current={current}
+          onPick={zoomToCorner}
+          maximized={maximized}
+        />
+      )}
+
       {/* Below the map, not floating over it: the key grew past what fits on
           one overlaid row once the surveyed road joined it, and legend text
           wrapping across the track is worse than a couple of rows of space. */}
       <div className="flex flex-wrap gap-x-3 gap-y-1 px-3 pb-2 text-[10px] text-ink-dim [&>span]:whitespace-nowrap">
+        {others.map((lap) => (
+          <span key={lap.id} className="flex items-center gap-1.5">
+            <i className="inline-block h-0.5 w-4" style={{ backgroundColor: lap.color }} />
+            {lap.label}
+          </span>
+        ))}
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-throttle" />throttle</span>
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-brake" />brake</span>
         <span><i className="mr-1 inline-block h-2 w-2 rounded-full bg-coast" />coast</span>
@@ -433,12 +609,12 @@ export function RaceLineMap({
             </span>
           </>
         )}
-        {(ref?.entry.corners?.length ?? 0) > 0 && (
+        {corners.length > 0 && (
           <span>
             <i className="mr-1 inline-block h-2.5 w-2.5 rounded-full border border-ink-dim text-center align-middle text-[7px] leading-[9px]">
               1
             </i>
-            corner
+            corner — click to zoom
           </span>
         )}
         {hasOutline && (
@@ -459,7 +635,81 @@ export function RaceLineMap({
             wall
           </span>
         )}
+        {maximized && <span className="ml-auto">scroll to zoom · drag to pan</span>}
       </div>
+    </div>
+  );
+}
+
+/** Corner picker. Every corner as a chip, the selected one called out with
+ *  what it is — because "corner 7" alone is not something anyone remembers,
+ *  and the direction plus minimum speed is how you recognise it. */
+function CornerBar({
+  corners,
+  current,
+  onPick,
+  maximized,
+}: {
+  corners: Corner[];
+  current: Corner | null;
+  onPick: (c: Corner | null) => void;
+  maximized: boolean;
+}) {
+  const index = current ? corners.indexOf(current) : -1;
+  const step = (by: number) => {
+    if (corners.length === 0) return;
+    // Wraps, because the last corner's exit is the first one's approach.
+    const next = index < 0 ? (by > 0 ? 0 : corners.length - 1) : (index + by + corners.length) % corners.length;
+    onPick(corners[next]);
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 border-t border-edge px-3 py-1.5 text-[11px]">
+      <button
+        onClick={() => step(-1)}
+        aria-label="Previous corner"
+        className="shrink-0 rounded border border-edge px-1.5 text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+      >
+        ‹
+      </button>
+      <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto">
+        <button
+          onClick={() => onPick(null)}
+          className={`shrink-0 rounded px-1.5 font-tabular transition-colors ${
+            current ? "text-ink-dim hover:text-ink" : "bg-accent/15 text-accent"
+          }`}
+        >
+          lap
+        </button>
+        {corners.map((c) => (
+          <button
+            key={c.n}
+            onClick={() => onPick(c)}
+            title={c.name || `Corner ${c.n}`}
+            className={`shrink-0 rounded px-1.5 font-tabular transition-colors ${
+              current?.n === c.n
+                ? "bg-accent/15 text-accent"
+                : "text-ink-dim hover:bg-panel-2 hover:text-ink"
+            }`}
+          >
+            {c.n}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={() => step(1)}
+        aria-label="Next corner"
+        className="shrink-0 rounded border border-edge px-1.5 text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+      >
+        ›
+      </button>
+      {current && (
+        <span className="shrink-0 truncate pl-1 text-ink-dim">
+          {current.name || `T${current.n}`}
+          {current.direction && ` · ${current.direction === "L" ? "left" : "right"}`}
+          {maximized && ` · ${current.min_speed.toFixed(0)} km/h · ${current.angle_deg.toFixed(0)}°`}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -69,9 +69,14 @@ function eventBandsFor(panelKey: string, events: LapEvent[]): MarkAreaData {
 
 const TOP_PAD = 20;
 const PANEL_GAP = 26;
-// Stable identity — an inline literal would re-trigger the chart's setOption
-// effect on every render (hover re-renders at cursor rate).
-const REPLACE_SERIES = ["series"];
+// Every component whose COUNT follows the panel list. A plain merge keeps
+// whatever the previous option had beyond the end of the new arrays, so
+// picking fewer channels left the dropped panels' titles painted over the ones
+// that remained — a ghost "Yaw rate (rad/s)" sitting on top of a real label,
+// with orphaned grids and axes behind it. Stable identity: an inline literal
+// would re-trigger the chart's setOption effect on every render (hover
+// re-renders at cursor rate).
+const REPLACE_PANEL_PARTS = ["series", "title", "grid", "xAxis", "yAxis"];
 
 export function StackedCharts({
   data,
@@ -511,7 +516,7 @@ export function StackedCharts({
           option={option}
           className="w-full"
           notMerge={false}
-          replaceMerge={REPLACE_SERIES}
+          replaceMerge={REPLACE_PANEL_PARTS}
           onInit={(chart) => {
             chartRef.current = chart;
             chart.getDom().style.height = `${panels.length * 110 + TOP_PAD + PANEL_GAP}px`;

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -30,6 +30,45 @@ function Dialog({
   );
 }
 
+/** A dialog sized for looking at something rather than answering a question:
+ *  as much of the viewport as it can take, with the content free to fill it. */
+export function LargeDialog({
+  open,
+  title,
+  onClose,
+  children,
+}: {
+  open: boolean;
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-40 bg-black/75" />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-40 flex h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border border-edge bg-panel shadow-xl shadow-black/50"
+        >
+          <div className="flex shrink-0 items-center gap-2 border-b border-edge px-3 py-2">
+            <DialogPrimitive.Title className="text-[10px] font-semibold uppercase tracking-widest text-ink-dim">
+              {title}
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close
+              className="ml-auto rounded border border-edge px-2 py-0.5 text-xs text-ink-dim transition-colors hover:border-edge-bright hover:text-ink"
+              aria-label="Close"
+            >
+              Close ⎋
+            </DialogPrimitive.Close>
+          </div>
+          <div className="min-h-0 flex-1">{children}</div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
 export function ConfirmDialog({
   open,
   title,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   AdminStats,
   AuthoredCorner,
   AuthoredSection,
+  CategoryBest,
   CompareResult,
   ConnectionStatus,
   DeviationResult,
@@ -19,6 +20,7 @@ import type {
   Track,
   TrackBundleInfo,
   TrackCatalog,
+  TrackOutline,
   TrackOverview,
   VoiceCallout,
 } from "./types";
@@ -95,7 +97,18 @@ async function send<T>(url: string, method: string, body?: unknown): Promise<T> 
 
 export const api = {
   status: () => get<ConnectionStatus>("/api/status"),
-  sessions: () => get<SessionSummary[]>("/api/sessions"),
+  // `category` is the packet-C car class ("Gr.3", "N300"…); blank = every
+  // session, which is also the only way to reach pre-packet-C recordings.
+  sessions: (category = "") =>
+    get<SessionSummary[]>(
+      `/api/sessions${category ? `?category=${encodeURIComponent(category)}` : ""}`,
+    ),
+  // Fastest full lap at a circuit in a car category (#19); null when nothing
+  // has been recorded there in that class yet.
+  categoryBest: (track: string, category: string) =>
+    get<CategoryBest | null>(
+      `/api/laps/best?track=${encodeURIComponent(track)}&category=${encodeURIComponent(category)}`,
+    ),
   sessionLaps: (id: number) => get<LapSummary[]>(`/api/sessions/${id}/laps`),
   laps: () => get<LapSummary[]>("/api/laps"),
   lapDetail: (id: number, withSamples = true) =>
@@ -149,10 +162,22 @@ export const api = {
       ),
   },
 
+  // The surveyed road under a lap, compiled server-side (#51). Always
+  // resolves — a circuit with no bundle answers with an empty outline.
+  trackOutline: (lapId: number) => get<TrackOutline>(`/api/track-outline?lap_id=${lapId}`),
+
   tracks: () => get<Track[]>("/api/tracks"),
   trackCatalog: () => get<TrackCatalog>("/api/track-catalog"),
   trackBundles: () => get<TrackBundleInfo[]>("/api/track-bundles"),
   trackOverview: () => get<TrackOverview>("/api/track-overview"),
+  // Name every unlabelled session that was driven on a surveyed circuit (#41).
+  // New sessions do this for themselves as they are recorded; this is for the
+  // history that predates the bundles.
+  identifySessions: () =>
+    send<{ checked: number; identified: number; tracks: Record<string, number> }>(
+      "/api/tracks/identify",
+      "POST",
+    ),
   createTrack: (name: string, lapId: number) =>
     send<{ id: number; name: string }>("/api/tracks", "POST", { name, lap_id: lapId }),
   deleteTrack: (id: number) => send<{ status: string }>(`/api/tracks/${id}`, "DELETE"),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,9 +162,10 @@ export const api = {
       ),
   },
 
-  // The surveyed road under a lap, compiled server-side (#51). Always
+  // The surveyed road for a circuit, compiled server-side (#51). Always
   // resolves — a circuit with no bundle answers with an empty outline.
-  trackOutline: (lapId: number) => get<TrackOutline>(`/api/track-outline?lap_id=${lapId}`),
+  trackOutline: (track: string) =>
+    get<TrackOutline>(`/api/track-outline?track=${encodeURIComponent(track)}`),
 
   tracks: () => get<Track[]>("/api/tracks"),
   trackCatalog: () => get<TrackCatalog>("/api/track-catalog"),

--- a/frontend/src/lib/channels.ts
+++ b/frontend/src/lib/channels.ts
@@ -12,6 +12,12 @@ import type { Samples } from "@/lib/types";
 
 export type ChannelGroup = "Driving" | "Tires & wheels" | "Chassis" | "Engine";
 
+// Broadcast accelerometer channels carry no documented unit; the compare
+// endpoint fits them against physics and returns a multiplier to g. This is
+// the fallback the stacked charts use before that fit lands (and when it is
+// too weak to trust): assume m/s², which is what the fit usually confirms.
+const G = 9.80665;
+
 export interface ChannelDef {
   key: string;
   title: string;
@@ -41,6 +47,60 @@ export const CHANNELS: ChannelDef[] = [
   { key: "rpm", title: "RPM", group: "Engine", height: 1 },
   { key: "boost", title: "Boost (bar)", group: "Engine", height: 0.7 },
   { key: "yaw_rate", title: "Yaw rate (rad/s)", group: "Driving", height: 0.8 },
+  // Steering, at last (#15): understeer is more lock with no more rotation,
+  // and that only shows next to the yaw-rate trace above.
+  { key: "steer", title: "Steering (rad)", group: "Driving", height: 0.8 },
+
+  // --- Driver aids, measured rather than inferred (#18) ---
+  // The pedal AFTER the aids acted on it. Plotted against the raw pedal these
+  // two lines separate exactly where ABS/TCS intervened; the derived channels
+  // below are that separation on its own.
+  { key: "throttle_f", title: "Throttle applied %", group: "Driving", height: 0.8 },
+  { key: "brake_f", title: "Brake applied %", group: "Driving", height: 0.8 },
+  {
+    key: "tcs_cut",
+    title: "TCS cut (% throttle)",
+    group: "Driving",
+    height: 0.7,
+    columns: ["throttle", "throttle_f"],
+    derive: (s, i) => Math.max(0, (s.throttle?.[i] ?? 0) - (s.throttle_f?.[i] ?? 0)),
+  },
+  {
+    key: "abs_release",
+    title: "ABS release (% brake)",
+    group: "Driving",
+    height: 0.7,
+    columns: ["brake", "brake_f"],
+    derive: (s, i) => Math.max(0, (s.brake?.[i] ?? 0) - (s.brake_f?.[i] ?? 0)),
+  },
+
+  // --- Accelerometer (#16). The g-g panel calibrates these properly; as
+  // traces they assume m/s², which is what the fit reports on every capture
+  // seen so far. Vertical has no independent reference to check it against.
+  {
+    key: "acc_lat",
+    title: "Lateral g",
+    group: "Chassis",
+    height: 0.9,
+    derive: (s, i) => (s.acc_lat?.[i] ?? 0) / G,
+    columns: ["acc_lat"],
+  },
+  {
+    key: "acc_long",
+    title: "Longitudinal g",
+    group: "Chassis",
+    height: 0.9,
+    derive: (s, i) => (s.acc_long?.[i] ?? 0) / G,
+    columns: ["acc_long"],
+  },
+  {
+    key: "acc_vert",
+    title: "Vertical g",
+    group: "Chassis",
+    height: 0.7,
+    derive: (s, i) => (s.acc_vert?.[i] ?? 0) / G,
+    columns: ["acc_vert"],
+  },
 
   // --- Tires & wheels ---
   { key: "tire_slip", title: "Tire spd / car spd", group: "Tires & wheels", height: 0.8 },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface LapSummary {
   finished_at?: string;
   car_id?: number;
   car_name?: string;
+  car_category?: string; // packet C: "Gr.3", "Gr.4", "N300"…; "" when unknown
   fuel_consumed: number;
   full_throttle_pct: number;
   full_brake_pct: number;
@@ -356,6 +357,22 @@ export interface Track {
   created_at: string;
 }
 
+// Fastest full lap at one circuit in one car category — the reference a lap
+// is worth being compared against, since a Gr.3 time and an N100 time around
+// the same corners are not the same achievement (#19).
+export interface CategoryBest {
+  lap_id: number;
+  session_id: number;
+  number: number;
+  time_ms: number;
+  car_id: number;
+  car_name: string;
+  car_category: string;
+  track_name: string;
+  clean_lap: boolean | null;
+  finished_at: string;
+}
+
 // Official GT7 track/layout metadata (bundled data/tracks.json — only the
 // fields the UI reads; the endpoint returns more).
 export interface TrackCatalog {
@@ -397,18 +414,66 @@ export interface Corner {
   authored?: boolean;
 }
 
+// One accelerometer axis, checked against physics the recording already
+// carries (lateral vs v·ω from the driven path, longitudinal vs dv/dt).
+// `slope` is broadcast units per m/s²; `g_per_unit` is what the UI multiplies
+// the raw channel by to get g — signed, so a channel that counts the other way
+// comes out upright. Mirrors backend analysis.accel_calibration (#16).
+export interface AccelAxis {
+  slope: number;
+  r2: number; // share of the channel the scaled reference explains (about zero)
+  samples: number;
+  fitted: boolean; // false = too weak to trust; g_per_unit assumes m/s²
+  g_per_unit: number;
+}
+
+export interface AccelCalibration {
+  available: boolean; // false on recordings without packet-B accelerometer
+  lateral?: AccelAxis;
+  longitudinal?: AccelAxis;
+  unit?: string; // "m/s^2" | "g" | "unverified" | "1 unit = … m/s^2"
+}
+
+// Corners of the traction circle a lap actually reached, in g.
+export interface GGExtremes {
+  lat_right: number;
+  lat_left: number;
+  accel: number;
+  braking: number;
+}
+
 export interface CompareLapEntry {
   series: Samples & { dist: number[] };
   peaks_valleys: { peaks: PeakValley[]; valleys: PeakValley[] };
   events?: LapEvent[];
   delta?: { dist: number[]; delta_ms: number[] };
   corners?: Corner[]; // reference lap only
+  gg?: GGExtremes; // peaks from the raw ticks, not the resampled series
 }
 
 export interface CompareResult {
   ref: number;
   step: number;
+  accel: AccelCalibration;
   laps: Record<string, CompareLapEntry>;
+}
+
+// The surveyed road under a lap, compiled server-side from the circuit's
+// track bundle (#51). Empty when the circuit has never been surveyed.
+export interface TrackOutline {
+  track: string;
+  slug: string | null;
+  // Road surface as quads [x1,z1,x2,z2,x3,z3,x4,z4], one per paired metre of
+  // left/right border — order-free, so no centerline has to be reconstructed.
+  road: number[][];
+  // Border evidence as short segments [x, z, hx, hz] along travel direction,
+  // split by what the votes settled on.
+  edges: number[][];
+  walls: number[][];
+  // Start/finish line as [x1, z1, x2, z2]; null until a survey located it.
+  finish: number[] | null;
+  runs: number;
+  updated_at: string;
 }
 
 export interface DeviationResult {

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -193,23 +193,25 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
     api.deviation(sessionId).then(setDeviation).catch(() => setDeviation(null));
   }, [sessionId, lapEpoch]);
 
-  // The surveyed road under the race line (#51). Keyed on the reference lap
-  // because that is what resolves the circuit; a track that was never
-  // surveyed answers with an empty outline and the map draws as it always did.
+  // The surveyed road under the race line (#51). Keyed on the SESSION'S
+  // circuit rather than the reference lap: the lap only ever resolved to its
+  // session's circuit anyway, so this is the same answer without refetching
+  // every time the reference lap changes — and it means the outline is cleared
+  // exactly when the circuit changes, never leaving one track's road drawn
+  // under another track's lap while the replacement is in flight.
   const [outline, setOutline] = useState<TrackOutline | null>(null);
+  const outlineTrack = sessions?.find((s) => s.id === sessionId)?.track_name ?? "";
   useEffect(() => {
-    if (refLap == null) {
-      setOutline(null);
-      return;
-    }
+    setOutline(null);
+    if (!outlineTrack) return;
     let live = true;
-    api.trackOutline(refLap)
+    api.trackOutline(outlineTrack)
       .then((o) => live && setOutline(o))
       .catch(() => live && setOutline(null));
     return () => {
       live = false;
     };
-  }, [refLap]);
+  }, [outlineTrack]);
 
   // Synchronized zoom state across all charts (minDist, maxDist in meters)
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
@@ -256,10 +258,12 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
   const bestTrack = session?.track_name ?? "";
   const bestCategory = session?.car_category ?? "";
   useEffect(() => {
-    if (!bestTrack || !bestCategory) {
-      setCategoryBest(null);
-      return;
-    }
+    // Cleared before the request, not after it: otherwise switching sessions
+    // shows the previous circuit's benchmark against the new reference lap's
+    // time until the replacement lands, and the "open" link goes to a lap from
+    // somewhere else entirely.
+    setCategoryBest(null);
+    if (!bestTrack || !bestCategory) return;
     let live = true;
     api.categoryBest(bestTrack, bestCategory)
       .then((b) => live && setCategoryBest(b))
@@ -535,6 +539,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
               <CategoryBestRow
                 best={categoryBest}
                 refTimeMs={refSummary.time_ms}
+                refIsFullLap={refSummary.counts_for_best !== false}
                 onOpen={() =>
                   openInAnalysis({
                     session: categoryBest.session_id,
@@ -557,13 +562,19 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
 function CategoryBestRow({
   best,
   refTimeMs,
+  refIsFullLap,
   onOpen,
 }: {
   best: CategoryBest;
   refTimeMs: number;
+  /** Partial laps (pit out-laps) are excluded from the benchmark itself, so
+   *  their GT7-reported time — short precisely because it is not a lap — must
+   *  not be measured against it, let alone allowed to beat it. */
+  refIsFullLap: boolean;
   onOpen: () => void;
 }) {
   const gap = refTimeMs - best.time_ms;
+  const isBest = refIsFullLap && gap <= 0;
   return (
     <div className="border-t border-edge px-3 py-2 text-xs">
       <div className="mb-1 flex items-baseline gap-2">
@@ -575,13 +586,17 @@ function CategoryBestRow({
       <div className="flex items-baseline gap-2 text-ink-dim">
         <span className="truncate">{best.car_name}</span>
         <span className="ml-auto shrink-0 font-tabular">
-          {gap <= 0 ? (
+          {!refIsFullLap ? (
+            <span title="This reference lap is a partial lap, so its time is not a lap time">
+              partial lap — no comparison
+            </span>
+          ) : isBest ? (
             <span className="text-throttle">this lap is the best</span>
           ) : (
             <span className="text-brake">+{(gap / 1000).toFixed(3)}</span>
           )}
         </span>
-        {gap > 0 && (
+        {!isBest && (
           <button className="shrink-0 text-ink-dim hover:text-accent" onClick={onOpen}>
             open
           </button>

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -9,6 +9,7 @@ import { CornerDetail, type CornerLap } from "@/components/analysis/CornerDetail
 import { DeviationChart } from "@/components/analysis/DeviationChart";
 import { FuelMapPanel } from "@/components/analysis/FuelMapPanel";
 import { GearingPanel } from "@/components/analysis/GearingPanel";
+import { GGDiagram, ggLap, type GGLap } from "@/components/analysis/GGDiagram";
 import { RaceLineMap, type MapLap } from "@/components/analysis/RaceLineMap";
 import { StackedCharts } from "@/components/analysis/StackedCharts";
 import { Select } from "@/components/ui/Select";
@@ -23,8 +24,19 @@ import {
 } from "@/lib/channels";
 import { lapColor, lapColorMap } from "@/lib/colors";
 import { formatLapTime, formatSpeed } from "@/lib/format";
-import { reflectAnalysisSelection, type AnalysisRequest } from "@/lib/router";
-import type { CompareResult, DeviationResult, LapSummary, SessionSummary } from "@/lib/types";
+import {
+  openInAnalysis,
+  reflectAnalysisSelection,
+  type AnalysisRequest,
+} from "@/lib/router";
+import type {
+  CategoryBest,
+  CompareResult,
+  DeviationResult,
+  LapSummary,
+  SessionSummary,
+  TrackOutline,
+} from "@/lib/types";
 import { useAnalysisSelection } from "@/store/analysis";
 import { useSettings } from "@/store/settings";
 import { useTelemetry } from "@/store/telemetry";
@@ -41,6 +53,10 @@ const CORNER_COLUMNS = [
 // The race-line map shades where wheels touched kerb/grass/gravel whenever
 // the lap carries the per-tick surface column (packet C recordings).
 const MAP_COLUMNS = ["surface"];
+
+// The g-g diagram is always shown when the recording has an accelerometer, so
+// its columns ride along regardless of the chart picker (#16).
+const GG_COLUMNS = ["acc_lat", "acc_long"];
 
 export function AnalysisView({ request }: { request: AnalysisRequest }) {
   const units = useSettings((s) => s.units);
@@ -147,7 +163,14 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
   // The request always carries the per-corner columns for the Corner Detail
   // widget on top of whatever the picked panels need.
   const requestColumns = useMemo(
-    () => [...new Set([...columnsForChannels(channelKeys), ...CORNER_COLUMNS, ...MAP_COLUMNS])],
+    () => [
+      ...new Set([
+        ...columnsForChannels(channelKeys),
+        ...CORNER_COLUMNS,
+        ...MAP_COLUMNS,
+        ...GG_COLUMNS,
+      ]),
+    ],
     [channelKeys],
   );
   useEffect(() => {
@@ -169,6 +192,24 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
     if (sessionId == null) return;
     api.deviation(sessionId).then(setDeviation).catch(() => setDeviation(null));
   }, [sessionId, lapEpoch]);
+
+  // The surveyed road under the race line (#51). Keyed on the reference lap
+  // because that is what resolves the circuit; a track that was never
+  // surveyed answers with an empty outline and the map draws as it always did.
+  const [outline, setOutline] = useState<TrackOutline | null>(null);
+  useEffect(() => {
+    if (refLap == null) {
+      setOutline(null);
+      return;
+    }
+    let live = true;
+    api.trackOutline(refLap)
+      .then((o) => live && setOutline(o))
+      .catch(() => live && setOutline(null));
+    return () => {
+      live = false;
+    };
+  }, [refLap]);
 
   // Synchronized zoom state across all charts (minDist, maxDist in meters)
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
@@ -204,6 +245,29 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
 
   const refEntry = compare?.laps[String(refLap)];
   const refSummary = laps.find((l) => l.id === refLap);
+  const session = sessions?.find((s) => s.id === sessionId) ?? null;
+
+  // Category best at this circuit (#19): a lap is worth judging against the
+  // fastest one ever set here IN THE SAME CLASS — a Gr.3 time and an N100
+  // time around the same corners are not the same achievement. Needs both a
+  // named circuit and a category, so it stays absent on unnamed tracks and on
+  // recordings made before packet C.
+  const [categoryBest, setCategoryBest] = useState<CategoryBest | null>(null);
+  const bestTrack = session?.track_name ?? "";
+  const bestCategory = session?.car_category ?? "";
+  useEffect(() => {
+    if (!bestTrack || !bestCategory) {
+      setCategoryBest(null);
+      return;
+    }
+    let live = true;
+    api.categoryBest(bestTrack, bestCategory)
+      .then((b) => live && setCategoryBest(b))
+      .catch(() => live && setCategoryBest(null));
+    return () => {
+      live = false;
+    };
+  }, [bestTrack, bestCategory, lapEpoch]);
 
   // One color assignment for everything that shows the compared laps together
   // (chips, chart series, map, corner detail): id-keyed, but two selected laps
@@ -230,6 +294,15 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
       isRef: id === String(refLap),
     }));
   }, [compare, lapLabels, refLap, lapColors]);
+
+  // Same laps again, converted to g for the traction circle. Empty whenever
+  // the recording predates the accelerometer (packet A) — the panel then
+  // never mounts rather than drawing an empty ring.
+  const ggLaps = useMemo<GGLap[]>(() => {
+    const accel = compare?.accel;
+    if (!accel?.available) return [];
+    return mapLaps.map((lap) => ggLap(lap, accel)).filter((l): l is GGLap => l != null);
+  }, [mapLaps, compare]);
 
   // Same laps, shaped for the Corner Detail widget (cursor-synced with the
   // charts and the map dot).
@@ -382,6 +455,17 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
               cursorDist={cursorDist}
               step={compare!.step}
               zoomRange={zoomRange}
+              outline={outline}
+            />
+          </SidePanel>
+        )}
+        {ggLaps.length > 0 && (
+          <SidePanel title="Traction circle — g-g">
+            <GGDiagram
+              laps={ggLaps}
+              accel={compare!.accel}
+              cursorDist={cursorDist}
+              step={compare!.step}
             />
           </SidePanel>
         )}
@@ -421,6 +505,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
               <Info k="Tire spin" v={`${refSummary.tire_spin_pct.toFixed(1)}%`} />
               <Info k="Fuel used" v={`${refSummary.fuel_consumed.toFixed(2)} L`} />
               <Info k="Car" v={refSummary.car_name ?? "–"} />
+              {bestCategory && <Info k="Category" v={bestCategory} />}
               {refSummary.tcs_active_pct != null && (
                 <Info k="TCS active" v={`${refSummary.tcs_active_pct.toFixed(1)}%`} />
               )}
@@ -445,7 +530,60 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
                 />
               )}
             </div>
+            {categoryBest && (
+              <CategoryBestRow
+                best={categoryBest}
+                refTimeMs={refSummary.time_ms}
+                onOpen={() =>
+                  openInAnalysis({
+                    session: categoryBest.session_id,
+                    laps: [categoryBest.lap_id],
+                    ref: categoryBest.lap_id,
+                  })
+                }
+              />
+            )}
           </SidePanel>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// The class benchmark for this circuit, and how far off the reference lap is.
+// Silent about which session it came from beyond the car — the point is the
+// target, and clicking through is how you go and look at it.
+function CategoryBestRow({
+  best,
+  refTimeMs,
+  onOpen,
+}: {
+  best: CategoryBest;
+  refTimeMs: number;
+  onOpen: () => void;
+}) {
+  const gap = refTimeMs - best.time_ms;
+  return (
+    <div className="border-t border-edge px-3 py-2 text-xs">
+      <div className="mb-1 flex items-baseline gap-2">
+        <span className="text-ink-dim">
+          {best.car_category} best at {best.track_name}
+        </span>
+        <span className="ml-auto font-tabular text-accent">{formatLapTime(best.time_ms)}</span>
+      </div>
+      <div className="flex items-baseline gap-2 text-ink-dim">
+        <span className="truncate">{best.car_name}</span>
+        <span className="ml-auto shrink-0 font-tabular">
+          {gap <= 0 ? (
+            <span className="text-throttle">this lap is the best</span>
+          ) : (
+            <span className="text-brake">+{(gap / 1000).toFixed(3)}</span>
+          )}
+        </span>
+        {gap > 0 && (
+          <button className="shrink-0 text-ink-dim hover:text-accent" onClick={onOpen}>
+            open
+          </button>
         )}
       </div>
     </div>

--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -456,6 +456,7 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
               step={compare!.step}
               zoomRange={zoomRange}
               outline={outline}
+              onZoomChange={setZoomRange}
             />
           </SidePanel>
         )}

--- a/frontend/src/views/TracksView.tsx
+++ b/frontend/src/views/TracksView.tsx
@@ -90,6 +90,29 @@ export function TracksView() {
     }
   };
 
+  // Not routed through `run`: the interesting part of the result is WHICH
+  // circuits were recognised and how many sessions each of them claimed, and
+  // "no match at all" is a perfectly good outcome rather than a failure.
+  const onIdentify = async () => {
+    setBusy(true);
+    try {
+      const r = await api.identifySessions();
+      const breakdown = Object.entries(r.tracks)
+        .map(([track, n]) => `${n}× ${track}`)
+        .join(", ");
+      if (r.identified === 0) {
+        toast(`No surveyed circuit matched any of the ${r.checked} unlabelled sessions`);
+      } else {
+        toastSuccess(`Named ${r.identified} of ${r.checked} sessions — ${breakdown}`);
+      }
+      refresh();
+    } catch (e) {
+      toastError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const onImportFile = async (file: File) => {
     const target = importTarget.current;
     importTarget.current = undefined;
@@ -129,6 +152,9 @@ export function TracksView() {
   const rows = data?.tracks ?? [];
   const orphans = (data?.logs ?? []).filter((l) => l.orphaned);
   const knownNames = rows.map((r) => r.name);
+  // Identification needs something to match against; with no bundle at all
+  // the button would only ever be able to say "nothing to compare with".
+  const bundleCount = rows.filter((r) => r.bundle != null).length;
 
   return (
     <div className="mx-auto max-w-6xl space-y-3 p-3">
@@ -138,6 +164,15 @@ export function TracksView() {
           named tracks, survey bundles and the official catalog, in one place
         </span>
         <div className="ml-auto flex items-center gap-2">
+          <Tip content="Match every unlabelled session against the surveyed circuits and name the ones that were driven on them. New sessions do this by themselves.">
+            <button
+              className="btn"
+              disabled={busy || bundleCount === 0}
+              onClick={onIdentify}
+            >
+              Identify sessions
+            </button>
+          </Tip>
           <button
             className="btn"
             disabled={busy}
@@ -211,13 +246,20 @@ export function TracksView() {
             <div key={row.slug} className="rounded-xl bg-panel p-3">
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-sm font-semibold">{row.name}</span>
+                {/* Either source identifies a session, so the chip reflects
+                    whether identification WORKS here — not whether one
+                    particular mechanism is present. Saying "no auto-ID" on a
+                    surveyed circuit would send someone off to name a track
+                    that already recognises itself. */}
                 <Flag
-                  ok={row.named}
+                  ok={row.named || b != null}
                   label="auto-ID"
                   title={
                     row.named
-                      ? "This circuit has a geometry signature, so future sessions identify it on their own"
-                      : "No geometry signature — sessions here will NOT be identified. Name it from a lap in Sessions."
+                      ? "This circuit has a geometry signature, so sessions here identify themselves"
+                      : b != null
+                        ? "Sessions here identify themselves by matching the surveyed road — no signature needed"
+                        : "Neither a geometry signature nor a survey — sessions here will NOT be identified. Name it from a lap in Sessions, or survey it."
                   }
                 />
                 <Flag


### PR DESCRIPTION
Closes #14, #15, #16, #18, #51. Advances #19 and #41.

Six issues held together by one thread: the app was already receiving or storing everything here and throwing it away.

---

## The surveyed road under the race line (#51)

A racing line only means something against the road it was driven on — whether the apex was clipped, how much kerb was used, whether there was tarmac left on the exit. The map drew the lap floating in empty space.

The outline is compiled **server-side** (`GET /api/track-outline`) and cached per bundle revision: a bundle is up to 50,000 border records, and the Analysis page must not download a circuit's whole survey history to draw a map. Circuits with no bundle answer with an **empty outline, not a 404** — never having been surveyed is the common case, not an error — so the map degrades to exactly what it drew before.

Verified against a real Lago Maggiore Centre bundle (4,634 cells): borders, walls and the finish line land on the driven line.

> Note: the *road fill* is sparse on real bundles (16 quads from 5,564 cells). That is #44, untouched here — the border ticks are what make the outline read.

## The map itself is now worth looking at

Follow-up on the above: having put the road under the race line, the map was still a 360-pixel thumbnail that only the charts could drive.

- **⤢ opens it full screen**, where it also gets scroll-to-zoom and drag-to-pan. Those stay out of the rail deliberately — the map sits in a scrolling column there, and a wheel that sometimes scrolls the page and sometimes zooms a chart is worse than one that always scrolls.
- **A corner strip** under the map takes you to any corner in one click, as does clicking the numbered circle on the map. It drives the *shared* zoom, so the charts follow the map into the corner rather than the two disagreeing, and the window includes the braking zone in and the exit out — a corner cropped to its own arc is not a corner anyone recognises. Which corner is selected is *derived* from the zoom rather than remembered, so it stays correct when the charts change the zoom instead.
- **The reference lap is a continuous zone-coloured line**, not a dotted trail. Samples land every 5 m, which reads as a solid line across a whole circuit and as scattered dots exactly where you have zoomed in to look closely. One line series per input zone with the others nulled out keeps it continuous *and* still coloured by what the driver was doing.
- **It is no longer stretched.** Both axes share one scale, so a corner's shape on screen is its shape on the track. Letting each axis fill the box independently distorted it by the circuit's aspect ratio — 8 % at Lago Maggiore Centre, nearly 3x at Deep Forest.

## A surveyed circuit now recognises itself (#41)

**This is the one worth reviewing carefully.** Auto-identification only ever matched against signatures written by naming a track by hand. Survey three circuits, never use *name track…*, and the app has a metre-accurate map of each while still failing to recognise the next session driven there — so the track badge, the outline above, category bests and corner labels all stay empty on a circuit it has mapped in detail. Having surveyed a track and having named it were two separate facts, and nothing joined them. On the author's own database this meant **all 415 sessions were unnamed** despite three surveyed circuits.

A lap with no matching signature is now compared against the bundles, which are a strictly better fingerprint than a bounding box — they are the road, not a rectangle around it. Matching asks the only question that matters: *did this lap drive on this surveyed tarmac?*

It needs a coverage floor **and** a clear margin over the runner-up. Two configurations of one venue share tarmac, so the loser is never near zero; when they are close the evidence genuinely does not distinguish them, and the session is **left unnamed rather than given a wrong name silently**.

Thresholds were calibrated against 321 real recorded sessions rather than guessed. The scores are sharply bimodal:

| best coverage | sessions |
|---|---|
| 100 % | 13 |
| 65–85 % | 5 (all on the thinnest survey — 406 border records) |
| *nothing at all* | 34–64 % |
| ≤ 33 % | 302 (circuits with no bundle) |

The 60 % cut sits in the middle of that empty band. A signature someone typed still wins outright.

**Tracks → Identify sessions** backfills history recorded before its circuit was surveyed, reading each session's *shortest* usable lap rather than a gigabyte of telemetry (2.6 s for 321 sessions). The "auto-ID" chip now reflects whether identification *works*, not whether one particular mechanism is present.

## Alembic migrations (#14)

The hand-rolled `ALTER TABLE ADD COLUMN` list could only ever *add*, was SQLite-only, and grew by one entry per feature — and nearly everything on the roadmap adds columns. Adopted while the schema is still small.

**Existing databases upgrade in place and lose nothing.** The old list is frozen and kept for exactly one job: a pre-Alembic database is carried to the baseline shape by it and then *stamped*, so an install from the first release and a fresh one converge on the same schema. Verified against a real 950 MB database (a mid-era schema, no `car_category`): 398 sessions and 1,563 laps intact, schema identical to a fresh install, and an autogenerate drift check confirms baseline == ORM.

## Traction circle from the broadcast accelerometer (#16)

The issue said to validate the axes, sign conventions and units against a real capture before building UI — **so the app validates them**, per lap, against physics the same lap already recorded: lateral against `v × ω` (with the signed yaw rate from the driven path, since the stored yaw column is absolute), longitudinal against `dv/dt`. A least-squares slope through the origin recovers unit *and* sign at once, so the diagram comes out upright whichever way the console counts. When a lap gives too little steady cornering or braking to check, the panel says **scale unverified** rather than drawing a confident-looking circle on an unproven scale.

Building it surfaced a real bug: positions are stored rounded to a centimetre, which is **larger than the heading change one 60 Hz tick covers**, so a tick-differenced yaw rate was a staircase of quantisation noise rather than a curve. The heading window is now distance-based, matching what corner detection already does.

## Steering (#15), ABS/TCS intervention (#18), car category (#19)

- `steer` from `wheel_rotation`, decoded since packet-B support landed and dropped on the floor ever since. Next to the yaw-rate trace it is what makes understeer legible.
- Filtered pedals give **TCS cut** and **ABS release** — the intervention measured, not inferred from the aids bitmask, which only ever said *whether* an aid was active.
- Category: server-side filter, a laps-fallback for sessions whose first packet was a narrower format (they used to sit outside their own filter), and the class benchmark at a circuit.

Optional columns are **absent rather than zero-filled** when a recording lacks them. A flat zero steering trace reads as "the driver never turned"; a missing panel says nothing false.

---

## Also in here

- **Fixes a pre-existing chart bug** these channels exposed: dropping a channel left its panel title painted over the ones that remained, because only `series` was in `replaceMerge`.
- **Makes the simulator internally consistent** — it advances along the circuit at the speed it reports, turns at the rate its own line demands, and its accelerometer is that motion rather than a decorative sine. Without this the calibration and intervention traces could never be exercised without a console, because the synthetic data would fail the same check real data has to pass. This changes recorded sim positions (arc-length parameterisation fixes the car covering ground faster than its reported speed).

## Testing

373 backend tests (52 new), ruff and mypy clean, frontend `tsc` + eslint clean. Beyond unit coverage, every claim above was checked against the author's real 950 MB database and real survey bundles on a scratch copy — the migration, the identification thresholds, the backfill, and the outline rendering.

## Reviewer notes

- One commit: the six issues touch overlapping files (`types.ts`, `api.ts`, `AnalysisView.tsx`, `routes.py`, `repository.py`, `api/tracks.py`), so a per-issue split would produce commits that do not build.
- `alembic>=1.13` is a new **runtime** dependency, not a dev one — `init_db` runs migrations at startup.
- `POST /api/tracks/identify` writes `track_name` across many sessions. It is admin-gated and user-triggered on purpose; it was **not** run against the author's live database.
- Not addressed here: #44 (sparse road fill), and 94 of 415 sessions having zero laps from menu-restart churn — filed separately.
