### PR TITLE
Road fill pairs to the border curve, Live rail on tablets, bounded frame loop, split bundles (#44, #29, #32, #33)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { StatusBar } from "@/components/StatusBar";
 import { Toasts } from "@/components/ui/Toasts";
 import { TooltipProvider } from "@/components/ui/Tooltip";
@@ -6,16 +6,20 @@ import { isDashLocation, parseDashParams } from "@/lib/dash";
 import { isEngineerLocation } from "@/lib/engineerRoute";
 import { isOverlayLocation, parseOverlayRoute } from "@/lib/overlay";
 import { parseAnalysisParams, parseHash, type Route } from "@/lib/router";
-import { AdminView } from "@/views/AdminView";
-import { AnalysisView } from "@/views/AnalysisView";
-import { DashView } from "@/views/DashView";
-import { EngineerView } from "@/views/EngineerView";
-import { LiveView } from "@/views/LiveView";
-import { OverlayView } from "@/views/OverlayView";
-import { SessionsView } from "@/views/SessionsView";
-import { SurveyView } from "@/views/SurveyView";
-import { TracksView } from "@/views/TracksView";
 import { useTelemetry } from "@/store/telemetry";
+
+// Every view is its own chunk (#33): an OBS overlay source or a phone on
+// /dash downloads only that view's code — in particular not ECharts, which
+// only the Analysis/Survey/Tracks maps use.
+const AdminView = lazy(() => import("@/views/AdminView").then((m) => ({ default: m.AdminView })));
+const AnalysisView = lazy(() => import("@/views/AnalysisView").then((m) => ({ default: m.AnalysisView })));
+const DashView = lazy(() => import("@/views/DashView").then((m) => ({ default: m.DashView })));
+const EngineerView = lazy(() => import("@/views/EngineerView").then((m) => ({ default: m.EngineerView })));
+const LiveView = lazy(() => import("@/views/LiveView").then((m) => ({ default: m.LiveView })));
+const OverlayView = lazy(() => import("@/views/OverlayView").then((m) => ({ default: m.OverlayView })));
+const SessionsView = lazy(() => import("@/views/SessionsView").then((m) => ({ default: m.SessionsView })));
+const SurveyView = lazy(() => import("@/views/SurveyView").then((m) => ({ default: m.SurveyView })));
+const TracksView = lazy(() => import("@/views/TracksView").then((m) => ({ default: m.TracksView })));
 
 function useRoute(): Route {
   const [route, setRoute] = useState<Route>(() => parseHash(window.location.hash));
@@ -41,14 +45,28 @@ export default function App() {
     [analysisParams],
   );
 
+  // Chrome-less deep links render nothing while their chunk loads — a
+  // spinner would flash inside an OBS capture.
   if (isOverlayLocation(window.location)) {
-    return <OverlayView route={parseOverlayRoute(window.location)} />;
+    return (
+      <Suspense fallback={null}>
+        <OverlayView route={parseOverlayRoute(window.location)} />
+      </Suspense>
+    );
   }
   if (isDashLocation(window.location)) {
-    return <DashView params={parseDashParams(window.location)} />;
+    return (
+      <Suspense fallback={null}>
+        <DashView params={parseDashParams(window.location)} />
+      </Suspense>
+    );
   }
   if (isEngineerLocation(window.location)) {
-    return <EngineerView />;
+    return (
+      <Suspense fallback={null}>
+        <EngineerView />
+      </Suspense>
+    );
   }
 
   return (
@@ -56,12 +74,16 @@ export default function App() {
       <div className="flex h-full flex-col">
         <StatusBar view={route.view} />
         <main className="min-h-0 flex-1 overflow-y-auto">
-          {route.view === "live" && <LiveView />}
-          {route.view === "analysis" && <AnalysisView request={analysisRequest} />}
-          {route.view === "sessions" && <SessionsView />}
-          {route.view === "survey" && <SurveyView />}
-          {route.view === "tracks" && <TracksView />}
-          {route.view === "admin" && <AdminView />}
+          <Suspense
+            fallback={<div className="p-6 text-sm text-ink-dim">Loading…</div>}
+          >
+            {route.view === "live" && <LiveView />}
+            {route.view === "analysis" && <AnalysisView request={analysisRequest} />}
+            {route.view === "sessions" && <SessionsView />}
+            {route.view === "survey" && <SurveyView />}
+            {route.view === "tracks" && <TracksView />}
+            {route.view === "admin" && <AdminView />}
+          </Suspense>
         </main>
         <Toasts />
       </div>

--- a/frontend/src/components/EChart.tsx
+++ b/frontend/src/components/EChart.tsx
@@ -1,8 +1,44 @@
 // Thin ECharts wrapper: theme defaults, resize handling, optional group connect.
+//
+// ECharts is imported modularly (#33): only the chart and component types the
+// app actually renders are registered, instead of the ~1.1 MB whole-library
+// import. Adding a new series or option feature to any chart may need its
+// module registered here — a missing one fails loudly at render with an
+// "is not loaded" error. Type-only imports still come from "echarts"; they
+// are erased at build time and cost nothing.
 
-import * as echarts from "echarts";
+import type * as echartsTypes from "echarts";
+import { CustomChart, EffectScatterChart, LineChart, ScatterChart } from "echarts/charts";
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  MarkAreaComponent,
+  MarkLineComponent,
+  TitleComponent,
+  ToolboxComponent,
+  TooltipComponent,
+} from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
 import { useEffect, useRef } from "react";
 import { SERIES_COLORS } from "@/lib/colors";
+
+echarts.use([
+  LineChart,
+  ScatterChart,
+  CustomChart,
+  EffectScatterChart, // survey map's gap beacons
+  GridComponent,
+  TitleComponent, // StackedCharts per-panel titles
+  TooltipComponent,
+  DataZoomComponent,
+  ToolboxComponent, // StackedCharts zoom controls
+  LegendComponent,
+  MarkLineComponent,
+  MarkAreaComponent, // delta zero-line + event bands
+  CanvasRenderer,
+]);
 
 export const CHART_COLORS = {
   axis: "#3a414c",
@@ -14,11 +50,11 @@ export const CHART_COLORS = {
   coast: "#3b82f6",
 };
 
-export function baseGrid(): echarts.GridComponentOption {
+export function baseGrid(): echartsTypes.GridComponentOption {
   return { left: 52, right: 16, top: 28, bottom: 24, containLabel: false };
 }
 
-export function baseAxis(name?: string): echarts.XAXisComponentOption {
+export function baseAxis(name?: string): echartsTypes.XAXisComponentOption {
   return {
     type: "value",
     name,
@@ -29,10 +65,10 @@ export function baseAxis(name?: string): echarts.XAXisComponentOption {
 }
 
 interface Props {
-  option: echarts.EChartsOption;
+  option: echartsTypes.EChartsOption;
   group?: string;
   className?: string;
-  onInit?: (chart: echarts.ECharts) => void;
+  onInit?: (chart: echartsTypes.ECharts) => void;
   notMerge?: boolean;
   // In merge mode, replace these components wholesale (matched by id) so
   // entries dropped from the option are removed instead of lingering.
@@ -41,7 +77,7 @@ interface Props {
 
 export function EChart({ option, group, className, onInit, notMerge, replaceMerge }: Props) {
   const el = useRef<HTMLDivElement>(null);
-  const chartRef = useRef<echarts.ECharts | null>(null);
+  const chartRef = useRef<echartsTypes.ECharts | null>(null);
 
   useEffect(() => {
     if (!el.current) return;

--- a/frontend/src/components/LayoutBuilder.tsx
+++ b/frontend/src/components/LayoutBuilder.tsx
@@ -109,7 +109,22 @@ export function LayoutBuilder({ flash }: { flash: (text: string) => void }) {
   const importFile = useRef<HTMLInputElement>(null);
 
   const { layout } = draft;
-  const { frame, laps } = useLiveFrame(layout.demo);
+
+  // The builder mounts inside Admin, usually below the fold — its frame loop
+  // must not run while it is scrolled out of sight (#32).
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(([entry]) =>
+      setVisible(entry.isIntersecting),
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const { frame, laps } = useLiveFrame(layout.demo, visible);
 
   useEffect(() => {
     localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
@@ -338,7 +353,7 @@ export function LayoutBuilder({ flash }: { flash: (text: string) => void }) {
     : "fill";
 
   return (
-    <div className="space-y-3 p-4">
+    <div ref={rootRef} className="space-y-3 p-4">
       {legacyPresets && (
         <div className="flex flex-wrap items-center gap-2 rounded-lg border border-warn/40 bg-warn/10 px-3 py-2 text-xs">
           <span>

--- a/frontend/src/components/analysis/DeviationChart.tsx
+++ b/frontend/src/components/analysis/DeviationChart.tsx
@@ -59,6 +59,7 @@ export function DeviationChart({
           name: "Median speed",
           type: "line",
           data: data.dist.map((d, i) => [d, median[i]]),
+          sampling: "lttb", // per-metre samples; draw to canvas width (#33)
           showSymbol: false,
           lineStyle: { width: 1.4 },
           color: CHART_COLORS.series[0],
@@ -68,6 +69,7 @@ export function DeviationChart({
           type: "line",
           yAxisIndex: 1,
           data: data.dist.map((d, i) => [d, dev[i]]),
+          sampling: "lttb",
           showSymbol: false,
           lineStyle: { width: 1 },
           areaStyle: { opacity: 0.25 },

--- a/frontend/src/components/analysis/StackedCharts.tsx
+++ b/frontend/src/components/analysis/StackedCharts.tsx
@@ -288,6 +288,11 @@ export function StackedCharts({
           xAxisIndex: gi,
           yAxisIndex: gi,
           data: dist.map((d, i) => [d, values[i]]),
+          // Perceptual downsampling to the canvas width (#33): many laps ×
+          // many panels can put ~184k points in one chart; drawing them all
+          // buys nothing visually and stalls a Pi. Zooming re-samples, so
+          // detail comes back where the viewport looks.
+          sampling: "lttb",
           showSymbol: false,
           step: panel.step ? "end" : undefined,
           lineStyle: { width: 1.4 },

--- a/frontend/src/lib/surveyGeometry.ts
+++ b/frontend/src/lib/surveyGeometry.ts
@@ -1,22 +1,34 @@
 // Geometry for the survey map's forming track: the run's accumulated border
-// edge points pair up left↔right wherever they face each other across the
-// road, filling in the confirmed surface span by span. Matching is purely
-// local — no lap ordering or centerline needed — so partial coverage just
-// fills in as laps add evidence.
+// edge points pair up left↔right wherever both borders are surveyed across
+// the road from each other, filling in the confirmed surface span by span.
+// Matching is purely local — no lap ordering or centerline needed — so
+// partial coverage just fills in as laps add evidence.
 
 import type { SurveyEdge } from "@/lib/types";
 
 // Matched pairs must look like a road cross-section: the line from the left
-// point to the right point should run along the car's right-normal, between
-// plausible road widths, with both contacts driven in the same direction.
+// point across should run along its right-normal, between plausible widths.
+// The across gate is sign-free (|dot|) and matches track_compile's: border
+// evidence is recorded from both directions of travel, so headings carry no
+// usable sign.
 const ROAD_WIDTH_MIN_M = 3;
 const ROAD_WIDTH_MAX_M = 40;
-const ACROSS_MIN_DOT = 0.85; // L→R direction vs right-normal: cos ~32°
-const HEADING_MIN_DOT = 0.7; // both points from the same direction of travel
+const ACROSS_MIN_DOT = 0.7; // L→across direction vs right-normal: cos ~45°
 const QUAD_HALF_LENGTH_M = 2.5; // along-track extent of one filled span
-// Spatial hash cell for the right-side candidates: one cell spans the whole
-// search radius, so scanning the 3×3 neighborhood covers every match. Keeps
-// the pairing near-linear as edge points accumulate into the thousands.
+// Left points pair against the right border CURVE, not against individual
+// right points: L and R evidence come from different laps, so on real
+// bundles the two sides' points almost never sit directly opposite each
+// other — point-to-point pairing filled 1-4% of a well-surveyed circuit
+// (#44). The curve is approximated by linking each right point to its
+// nearest same-side neighbours; a left point then pairs with the nearest
+// point ON those segments, which exists wherever the right border is
+// surveyed at all on that stretch. Same idea as the server-side compiler
+// (backend/app/processing/track_compile.py), which fixed the same defect
+// for bundle maps.
+const SEG_LINK_M = 6; // max neighbour spacing that still reads as one border
+// Spatial hash cell spanning the whole search radius, so scanning the 3×3
+// neighborhood covers every match. Keeps the pairing near-linear as edge
+// points accumulate into the thousands.
 const CELL_M = ROAD_WIDTH_MAX_M;
 
 // The trail is a time sequence, not a continuous path: pit returns, resets
@@ -295,7 +307,7 @@ export function borderCoverage(
 }
 
 // Quads [x1,z1, x2,z2, x3,z3, x4,z4] spanning left→right wherever a left
-// border point has a right border point directly across from it.
+// border point has the right border curve across from it (see SEG_LINK_M).
 //
 // Every kind contributes, "runoff" included. It used to be excluded, on the
 // reading that it bounded the run-off rather than the road — but that is not
@@ -305,49 +317,115 @@ export function borderCoverage(
 // to have pavement beyond them. Excluding them drew no road at all through
 // exactly the corners someone had taken the trouble to survey.
 export function roadQuads(edges: SurveyEdge[]): number[][] {
-  const usable = edges;
-  const rights = new Map<string, SurveyEdge[]>();
-  for (const e of usable) {
-    if (e.side !== "R") continue;
-    const key = `${Math.floor(e.x / CELL_M)}:${Math.floor(e.z / CELL_M)}`;
-    const bucket = rights.get(key);
-    if (bucket) bucket.push(e);
-    else rights.set(key, [e]);
+  const rights = edges.filter((e) => e.side === "R");
+
+  // The right border as a segment soup: each right point linked to its
+  // nearest neighbour on either side of it (split by its own heading, sign
+  // irrelevant). No global ordering needed — nearest-point-on-curve queries
+  // work on unordered segments — and capping at two links per point keeps
+  // kerb-chatter clusters from exploding into O(n²) segments.
+  const linkCells = new Map<string, number[]>();
+  rights.forEach((r, i) => {
+    const key = `${Math.floor(r.x / SEG_LINK_M)}:${Math.floor(r.z / SEG_LINK_M)}`;
+    const bucket = linkCells.get(key);
+    if (bucket) bucket.push(i);
+    else linkCells.set(key, [i]);
+  });
+  // Segments as [ax, az, bx, bz]; isolated right points stay in as
+  // zero-length segments so sparse evidence still pairs like it used to.
+  const segments: number[][] = [];
+  const linked = new Set<string>();
+  rights.forEach((r, i) => {
+    let fwd = -1;
+    let fwdDist = SEG_LINK_M;
+    let back = -1;
+    let backDist = SEG_LINK_M;
+    const cx = Math.floor(r.x / SEG_LINK_M);
+    const cz = Math.floor(r.z / SEG_LINK_M);
+    for (let gx = cx - 1; gx <= cx + 1; gx++) {
+      for (let gz = cz - 1; gz <= cz + 1; gz++) {
+        for (const j of linkCells.get(`${gx}:${gz}`) ?? []) {
+          if (j === i) continue;
+          const q = rights[j];
+          const d = Math.hypot(q.x - r.x, q.z - r.z);
+          if ((q.x - r.x) * r.hx + (q.z - r.z) * r.hz >= 0) {
+            if (d < fwdDist) {
+              fwd = j;
+              fwdDist = d;
+            }
+          } else if (d < backDist) {
+            back = j;
+            backDist = d;
+          }
+        }
+      }
+    }
+    let isolated = true;
+    for (const j of [fwd, back]) {
+      if (j < 0) continue;
+      isolated = false;
+      const key = i < j ? `${i}:${j}` : `${j}:${i}`;
+      if (linked.has(key)) continue;
+      linked.add(key);
+      segments.push([r.x, r.z, rights[j].x, rights[j].z]);
+    }
+    if (isolated) segments.push([r.x, r.z, r.x, r.z]);
+  });
+
+  // Segments bucketed by midpoint; segments are ≤ SEG_LINK_M long and the
+  // query radius is ROAD_WIDTH_MAX_M = CELL_M, so the 3×3 scan sees them all.
+  const segCells = new Map<string, number[][]>();
+  for (const s of segments) {
+    const key = `${Math.floor((s[0] + s[2]) / 2 / CELL_M)}:${Math.floor((s[1] + s[3]) / 2 / CELL_M)}`;
+    const bucket = segCells.get(key);
+    if (bucket) bucket.push(s);
+    else segCells.set(key, [s]);
   }
+
   const quads: number[][] = [];
-  for (const l of usable) {
+  for (const l of edges) {
     if (l.side !== "L") continue;
     const rnx = l.hz; // right-normal of the left point's heading
     const rnz = -l.hx;
-    let best: SurveyEdge | null = null;
+    // Nearest point on the right border curve, gated to a plausible
+    // cross-section: within road widths and near-perpendicular to travel.
+    let bestX = 0;
+    let bestZ = 0;
     let bestDist = ROAD_WIDTH_MAX_M;
+    let found = false;
     const cx = Math.floor(l.x / CELL_M);
     const cz = Math.floor(l.z / CELL_M);
     for (let gx = cx - 1; gx <= cx + 1; gx++) {
       for (let gz = cz - 1; gz <= cz + 1; gz++) {
-        for (const r of rights.get(`${gx}:${gz}`) ?? []) {
-          const dx = r.x - l.x;
-          const dz = r.z - l.z;
-          const dist = Math.hypot(dx, dz);
+        for (const [ax2, az2, bx2, bz2] of segCells.get(`${gx}:${gz}`) ?? []) {
+          const dx = bx2 - ax2;
+          const dz = bz2 - az2;
+          const seg2 = dx * dx + dz * dz;
+          const t =
+            seg2 < 1e-12
+              ? 0
+              : Math.max(0, Math.min(1, ((l.x - ax2) * dx + (l.z - az2) * dz) / seg2));
+          const px = ax2 + dx * t;
+          const pz = az2 + dz * t;
+          const dist = Math.hypot(px - l.x, pz - l.z);
           if (dist < ROAD_WIDTH_MIN_M || dist >= bestDist) continue;
-          if ((dx * rnx + dz * rnz) / dist < ACROSS_MIN_DOT) continue;
-          if (l.hx * r.hx + l.hz * r.hz < HEADING_MIN_DOT) continue;
-          best = r;
+          if (Math.abs(((px - l.x) * rnx + (pz - l.z) * rnz) / dist) < ACROSS_MIN_DOT)
+            continue;
+          bestX = px;
+          bestZ = pz;
           bestDist = dist;
+          found = true;
         }
       }
     }
-    if (!best) continue;
-    let ax = l.hx + best.hx;
-    let az = l.hz + best.hz;
-    const alen = Math.hypot(ax, az) || 1;
-    ax = (ax / alen) * QUAD_HALF_LENGTH_M;
-    az = (az / alen) * QUAD_HALF_LENGTH_M;
+    if (!found) continue;
+    const ax = l.hx * QUAD_HALF_LENGTH_M;
+    const az = l.hz * QUAD_HALF_LENGTH_M;
     quads.push([
       l.x - ax, l.z - az,
       l.x + ax, l.z + az,
-      best.x + ax, best.z + az,
-      best.x - ax, best.z - az,
+      bestX + ax, bestZ + az,
+      bestX - ax, bestZ - az,
     ]);
   }
   return quads;

--- a/frontend/src/lib/useLiveFrame.ts
+++ b/frontend/src/lib/useLiveFrame.ts
@@ -9,21 +9,37 @@ import { liveFrameRef, useTelemetry } from "@/store/telemetry";
 
 export const STALE_AFTER_MS = 3000;
 
+// React commits are decoupled from the animation clock (#32): the rAF loop
+// keeps sampling every frame, but state updates — each one a re-render of
+// the whole consuming view — are capped at this rate. 15 Hz halves the live
+// re-render rate (telemetry arrives at ~30 Hz) and cuts demo mode's from 60,
+// which is what keeps a Pi or a tablet responsive; readouts and bars are
+// indistinguishable at this cadence.
+const UI_UPDATE_HZ = 15;
+
 export interface LiveSample {
   frame: LiveFrame | null;
   laps: LapSummary[];
   placeholder: boolean; // true while showing demo data
 }
 
-export function useLiveFrame(demo: boolean): LiveSample {
+// `enabled: false` stops the loop entirely (the last frame stays on screen)
+// — for consumers that can scroll out of view, like the builder canvas.
+export function useLiveFrame(demo: boolean, enabled = true): LiveSample {
   const [frame, setFrame] = useState<LiveFrame | null>(null);
   const [placeholder, setPlaceholder] = useState(false);
   const recentLaps = useTelemetry((s) => s.recentLaps);
   const raf = useRef(0);
 
   useEffect(() => {
+    if (!enabled) return;
+    const minGapMs = 1000 / UI_UPDATE_HZ;
+    let lastCommit = -Infinity;
     const tick = () => {
+      raf.current = requestAnimationFrame(tick);
       const now = performance.now();
+      if (now - lastCommit < minGapMs) return;
+      lastCommit = now;
       const live =
         liveFrameRef.current && now - liveFrameRef.at < STALE_AFTER_MS
           ? liveFrameRef.current
@@ -38,11 +54,10 @@ export function useLiveFrame(demo: boolean): LiveSample {
         setFrame(liveFrameRef.current);
         setPlaceholder(false);
       }
-      raf.current = requestAnimationFrame(tick);
     };
     raf.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf.current);
-  }, [demo]);
+  }, [demo, enabled]);
 
   return { frame, laps: placeholder ? DEMO_LAPS : recentLaps, placeholder };
 }

--- a/frontend/src/views/LiveView.tsx
+++ b/frontend/src/views/LiveView.tsx
@@ -1,7 +1,7 @@
-// Live/Race view: large readouts driven by a rAF loop reading liveFrameRef,
-// so 30 Hz telemetry never causes React re-renders.
+// Live/Race view: large readouts driven by useLiveFrame's bounded sampling
+// of liveFrameRef, so 30 Hz telemetry re-renders at the capped UI rate (#32)
+// instead of once per animation frame.
 
-import { useEffect, useRef, useState } from "react";
 import {
   formatDelta,
   formatDuration,
@@ -22,21 +22,12 @@ import {
   type LapSummary,
   type LiveFrame,
 } from "@/lib/types";
+import { useLiveFrame } from "@/lib/useLiveFrame";
 import { useSettings } from "@/store/settings";
-import { liveFrameRef, useTelemetry } from "@/store/telemetry";
+import { useTelemetry } from "@/store/telemetry";
 
 export function LiveView() {
-  const [frame, setFrame] = useState<LiveFrame | null>(null);
-  const raf = useRef(0);
-
-  useEffect(() => {
-    const tick = () => {
-      setFrame(liveFrameRef.current);
-      raf.current = requestAnimationFrame(tick);
-    };
-    raf.current = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf.current);
-  }, []);
+  const { frame } = useLiveFrame(false);
 
   if (!frame) {
     return (
@@ -69,7 +60,7 @@ function Dashboard({ frame }: { frame: LiveFrame }) {
   const finished = frame.total_laps > 0 && frame.current_lap > frame.total_laps;
 
   return (
-    <div className="grid h-full grid-cols-1 gap-3 p-3 lg:grid-cols-[1fr_320px]">
+    <div className="grid min-h-full grid-cols-1 gap-3 p-3 lg:h-full lg:grid-cols-[1fr_320px]">
       <div className="flex flex-col gap-3">
         {/* RPM bar */}
         <div className="rounded-xl bg-panel p-3">
@@ -216,12 +207,16 @@ function Dashboard({ frame }: { frame: LiveFrame }) {
         </div>
       </div>
 
-      {/* Strategy + recent laps */}
-      <div className="hidden max-h-full flex-col gap-3 overflow-hidden lg:flex">
+      {/* Strategy + recent laps. Below lg this stacks under the main panels
+          instead of disappearing (#29): a tablet is the obvious second-screen
+          device, and this rail holds the fuel strategy plus the only in-app
+          route from Live into Analysis. The height constraints are lg-only —
+          stacked, the panels size to their content and the page scrolls. */}
+      <div className="flex flex-col gap-3 lg:max-h-full lg:overflow-hidden">
         <StrategyPanel frame={frame} laps={recentLaps} />
-        <Panel className="flex min-h-0 flex-1 flex-col overflow-hidden p-4">
+        <Panel className="flex flex-col overflow-hidden p-4 lg:min-h-0 lg:flex-1">
           <Label>Recent laps</Label>
-        <div className="mt-2 flex-1 space-y-1 overflow-y-auto font-tabular text-sm">
+        <div className="mt-2 max-h-72 space-y-1 overflow-y-auto font-tabular text-sm lg:max-h-none lg:flex-1">
           {recentLaps.length === 0 && (
             <div className="text-ink-dim">Completed laps appear here.</div>
           )}

--- a/frontend/src/views/SurveyView.tsx
+++ b/frontend/src/views/SurveyView.tsx
@@ -502,8 +502,8 @@ export function SurveyView() {
         z: 1,
       },
       {
-        // Confirmed road: filled wherever a left border point has a right
-        // border point directly across from it.
+        // Confirmed road: filled wherever a left border point has the right
+        // border surveyed across from it.
         id: "road-fill",
         type: "custom",
         data: quads,
@@ -1032,7 +1032,7 @@ export function SurveyView() {
               />
               wall
             </span>
-            <span title="Filled where a left border point has a right border point directly across">
+            <span title="Filled where the left border has the right border surveyed across from it">
               <i
                 className="mr-1 inline-block h-2.5 w-4 align-middle"
                 style={{ backgroundColor: ROAD_FILL }}


### PR DESCRIPTION
Fixes the four open bugs from the 2026-08 review batch (#30 and #31 were already closed).

## #44 — road fill paired only 1–4% of border points
`roadQuads()` now pairs each left border point against the right border **curve** — nearest point on segments built by linking each right point to its nearest same-side neighbours — instead of requiring a right *point* directly across. Same point-to-curve idea the server-side compiler (`track_compile.py`) already proved out. The across gate is sign-free and relaxed to the compiler's 0.7, and the old same-direction heading gate is dropped (border evidence carries no usable heading sign across runs).

Measured against the real bundles from the issue (harness first reproduced the old code's exact 28/9/20 to validate itself):

| circuit | old | new |
|---|---|---|
| Lago Maggiore East End | 28 (1.7%) | 1,656 (100%) |
| Deep Forest Raceway | 9 (0.5%) | 1,990 (99.5%) |
| Lago Maggiore Centre | 20 (0.7%) | 3,010 (99.3%) |
| Dragon Trail Gardens (partial survey) | 44 (13.1%) | 47 (14.0%) — honestly partial |

Widths sit tight around the measured road (East End p5–p95: 12.6–14.4 m; 1 quad over 20 m out of 6,703 across all four bundles), and the fill percentages agree with the server-compiled `road %` on the Tracks page. Both consumers (Survey live map, CornerEditor) pick the fix up. No bundle-format or export changes — this is drawing only.

## #29 — Live view lost its right rail below 1024px
The strategy + recent-laps rail stacks under the main panels below `lg` instead of being `hidden`; height/overflow constraints are now `lg:`-only and the lap list is capped at `max-h-72` with its own scroll. Verified at the 768 px tablet preset.

## #32 — 60 Hz frame loop vs React state
- `useLiveFrame` still samples on rAF but commits to React state at a bounded 15 Hz.
- `LiveView` uses `useLiveFrame` instead of its own unthrottled per-frame `setState`.
- `LayoutBuilder` pauses its loop via IntersectionObserver while scrolled off-screen in Admin (resumes live when scrolled into view).

## #33 — bundle size
- Modular ECharts (`echarts/core` + only the used charts/components/renderer): echarts chunk **1,119 kB → 641 kB**. New chart features need their module registered in `EChart.tsx` — a missing one fails loudly (caught and fixed `TitleComponent` this way during browser testing).
- `React.lazy` per SPA view: entry **496 kB → 202 kB**, echarts `modulepreload` gone; `/overlay`, `/dash`, `/engineer` ship without ECharts or analysis code (~220 kB of JS instead of ~1.6 MB). Chrome-less routes get a `null` Suspense fallback so nothing flashes in an OBS capture.
- `sampling: "lttb"` on the stacked-chart and deviation line series (the ~184k-point worst case).

## Verification
`tsc -b`, eslint, and production build clean. Exercised in the browser against the sim source: Live (desktop + tablet), Analysis (panels, titles, tooltip, zoom), Survey, Tracks/corner editor (full road ribbon on East End), `/dash`, `#overlay`, Admin/builder. Chunk graph of the built output confirms only chart views reference the echarts chunk.

Closes #29. Closes #32. Closes #33. Closes #44.