### PR TITLE
Put the circuit in the Analysis session picker (#58)

### DIFF
--- a/frontend/src/views/AnalysisView.tsx
+++ b/frontend/src/views/AnalysisView.tsx
@@ -563,7 +563,14 @@ export function AnalysisView({ request }: { request: AnalysisRequest }) {
             }}
             options={sessions.map((s) => ({
               value: String(s.id),
-              label: `#${s.id} · ${s.car_name} · ${s.lap_count} laps`,
+              // The circuit goes first: it is what you are looking for when
+              // picking a session to analyse, and since #58 most sessions
+              // have one. Omitted rather than shown blank when they do not,
+              // so an unidentified session reads as unidentified instead of
+              // as a formatting glitch.
+              label: `#${s.id}${s.track_name ? ` · ${s.track_name}` : ""} · ${
+                s.car_name
+              } · ${s.lap_count} laps`,
             }))}
             className="px-2 py-1.5 text-sm"
           />


### PR DESCRIPTION
## What changed

`frontend/src/views/AnalysisView.tsx` — the session picker label now includes
the circuit name when the session has one.

```
- label: `#${s.id} · ${s.car_name} · ${s.lap_count} laps`
+ label: `#${s.id}${s.track_name ? ` · ${s.track_name}` : ""} · ${s.car_name} · ${s.lap_count} laps`
```

## What it fixes

Reported as auto-identification not working: session #129 was driven at Trial
Mountain and the picker showed `#129 · 296 GT3 '23 · 6 laps`.

Identification had worked — the session has `Trial Mountain Circuit` in the
database, set from a shipped signature. There is no Trial Mountain bundle on
that install and the only user-created track row is `Sim Ring`, so nothing else
could have named it. The picker just never displayed the circuit.

The label predates #58, when almost no session had a name and the field would
have been empty most of the time. Now most sessions are identified, and the
Analysis view is where sessions get picked for comparison.

Before and after, same sessions:

```
#130 · 296 GT3 '23 · 0 laps
#129 · 296 GT3 '23 · 6 laps
#128 · 296 GT3 '23 · 1 laps
#127 · 296 GT3 '23 · 4 laps
```
```
#130 · 296 GT3 '23 · 0 laps
#129 · Trial Mountain Circuit · 296 GT3 '23 · 6 laps
#128 · Trial Mountain Circuit · 296 GT3 '23 · 1 laps
#127 · Sardegna - Road Track - A · 296 GT3 '23 · 4 laps
```

The name is omitted rather than blank when a session has none, so #130 reads as
unidentified rather than as a formatting gap.

`tsc -b --noEmit` and eslint pass.